### PR TITLE
Update for basic Python3 compatibility

### DIFF
--- a/bin/gftools
+++ b/bin/gftools
@@ -72,7 +72,7 @@ if __name__ == '__main__':
                                    stderr=sys.stderr)
         sys.exit(p.wait())
     elif "--list-subcommands" in sys.argv:
-        print ' '.join(subcommands.keys())
+        print(' '.join(list(subcommands.keys())))
     else:
         # shows help if no args
         args = parser.parse_args()


### PR DESCRIPTION
This one-line change allows the basic `gftools` menu to work with
python3.

See: #68