### PR TITLE
Remove napostrophe.sc from all encodings

### DIFF
--- a/encodings/GF Glyph Sets/GF-latin-expert_unique-glyphs.nam
+++ b/encodings/GF Glyph Sets/GF-latin-expert_unique-glyphs.nam
@@ -129,7 +129,6 @@
          nacute.sc
          ncommaaccent.sc
          ncaron.sc
-         napostrophe.sc
          eng.sc
          omacron.sc
          obreve.sc

--- a/encodings/GF Glyph Sets/filter lists/nice names/expert_unique-glyphs.txt
+++ b/encodings/GF Glyph Sets/filter lists/nice names/expert_unique-glyphs.txt
@@ -128,7 +128,6 @@ lslash.sc
 nacute.sc
 ncommaaccent.sc
 ncaron.sc
-napostrophe.sc
 eng.sc
 omacron.sc
 obreve.sc

--- a/encodings/GF Glyph Sets/filter lists/uni names/expert_unique-glyphs.txt
+++ b/encodings/GF Glyph Sets/filter lists/uni names/expert_unique-glyphs.txt
@@ -128,7 +128,6 @@ lslash.sc
 nacute.sc
 uni0146.sc
 ncaron.sc
-napostrophe.sc
 eng.sc
 omacron.sc
 obreve.sc

--- a/encodings/GF Glyph Sets/glyphTypeSorting/EXPERT_composites_207.txt
+++ b/encodings/GF Glyph Sets/glyphTypeSorting/EXPERT_composites_207.txt
@@ -76,7 +76,6 @@
           lcommaaccent.sc
           ldot.sc
           nacute.sc
-          napostrophe.sc
           ncaron.sc
           ncommaaccent.sc
           ntilde.sc


### PR DESCRIPTION
The Unicode character U+0149 `napostrophe` was deprecated and removed
in the following commit: ba769ed6b693e8018e0e17b4df9541cb7befcba2

However, `napostrophe.sc` was never removed. This commit removes all
unneeded references to `napostrophe.sc` in the encodings.

fixes #69