### PR TITLE
Update build-ofl script for Python3 compatibility

### DIFF
--- a/bin/gftools-build-ofl.py
+++ b/bin/gftools-build-ofl.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
+# coding: utf-8
+#
 # Copyright 2016 The Fontbakery Authors
 # Copyright 2017 The Google Font Tools Authors
 #
@@ -14,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+Generate an OFL.txt license document
+"""
 import argparse
 import os
 import logging


### PR DESCRIPTION
This update will allow the script `build-ofl` to work with both
Python2 and Python3

Fixes #68 for this script