### PR TITLE
Add distribution and packaging patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,27 @@
+
+
+# Basic
+
 *.pyc
 .DS_Store
+
+
+# Distribution / packaging
+
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST


### PR DESCRIPTION
I'm preparing for a new release on PyPI and needed to add distribution and packaging patterns to the .gitignore file.