### PR TITLE
gftools-add-font: support py3

### DIFF
--- a/Lib/gftools/util/google_fonts.py
+++ b/Lib/gftools/util/google_fonts.py
@@ -46,9 +46,9 @@ if __name__ == '__main__':
 
 import gftools.fonts_public_pb2 as fonts_pb2
 from fontTools import ttLib
-import gflags as flags
+from absl import flags
 from gftools.util import py_subsets
-from google.apputils import app
+from absl import app
 from google.protobuf import text_format
 
 

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 from fontTools import ttLib
-from StringIO import StringIO
-from urllib import urlopen
+import requests
+from io import BytesIO
 from zipfile import ZipFile
 
 # =====================================
@@ -29,8 +29,8 @@ def download_family_from_Google_Fonts(family_name):
 
 
 def download_file(url):
-    request = urlopen(url)
-    return StringIO(request.read())
+    request = requests.get(url, stream=True)
+    return BytesIO(request.content)
 
 
 def fonts_from_zip(zipfile):
@@ -40,3 +40,16 @@ def fonts_from_zip(zipfile):
     if file_name.endswith(".ttf"):
       fonts.append([file_name, ttLib.TTFont(zipfile.open(file_name))])
   return fonts
+
+
+def cmp(x, y):
+    """
+    Replacement for built-in function cmp that was removed in Python 3
+
+    Compare the two objects x and y and return an integer according to
+    the outcome. The return value is negative if x < y, zero if x == y
+    and strictly positive if x > y.
+    """
+
+    return (x > y) - (x < y)
+

--- a/bin/gftools-add-font.py
+++ b/bin/gftools-add-font.py
@@ -39,7 +39,8 @@ Generating a METADATA.pb file for an existing family:
 
 1. run the following: python add_font.py --update /path/to/existing/family
 """
-
+from __future__ import print_function
+from functools import cmp_to_key
 import contextlib
 import errno
 import glob
@@ -49,10 +50,11 @@ import time
 from fontTools import ttLib
 
 
-import gflags as flags
+from absl import flags
 import gftools.fonts_public_pb2 as fonts_pb2
 from gftools.util import google_fonts as fonts
-from google.apputils import app
+from gftools.utils import cmp
+from absl import app
 from google.protobuf import text_format
 
 FLAGS = flags.FLAGS
@@ -89,7 +91,7 @@ def _FileFamilyStyleWeights(fontdir):
   result = [fonts.FileFamilyStyleWeight(f) for f in files]
   def _Cmp(r1, r2):
     return cmp(r1.weight, r2.weight) or -cmp(r1.style, r2.style)
-  result = sorted(result, _Cmp)
+  result = sorted(result, key=cmp_to_key(_Cmp))
 
   family_names = {i.family for i in result}
   if len(family_names) > 1:
@@ -225,12 +227,12 @@ def _WriteTextFile(filename, text):
     with open(filename, 'r') as f:
       current = f.read()
     if current == text:
-      print 'No change to %s' % filename
+      print('No change to %s' % filename)
       return
 
   with open(filename, 'w') as f:
     f.write(text)
-  print 'Wrote %s' % filename
+  print('Wrote %s' % filename)
 
 
 
@@ -255,7 +257,7 @@ def main(argv):
 
   desc = os.path.join(fontdir, 'DESCRIPTION.en_us.html')
   if os.path.isfile(desc):
-    print 'DESCRIPTION.en_us.html exists'
+    print('DESCRIPTION.en_us.html exists')
   else:
     _WriteTextFile(desc, 'N/A')
 
@@ -264,4 +266,4 @@ def main(argv):
 
 
 if __name__ == '__main__':
-  app.run()
+    app.run(main)

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
 #                      see: https://github.com/fontforge/fontforge/issues/2048
         'FontTools',
         'Flask',
-        'google-apputils',
+        'absl-py',
         'glyphsLib',
         'pillow',
         'protobuf',


### PR DESCRIPTION
Script is still backwards compatible with py2.7+. I've only tested it on a handful of families.

I've had to implement a work around for the cmp function since py3 removed it. I used the python porting [guide](https://portingguide.readthedocs.io/en/latest/comparisons.html#the-cmp-function) as a reference.

@garretrieger are you folks running a verion of python which is greater than or equal to 2.7? if not, I'll remove the use of functools.

I'm hoping to fix #89 soon. I may need help coordinating the fix so I don't break GF's internals.
