### PR TITLE
Add missing header for add-font python3 update

### DIFF
--- a/bin/gftools-add-font.py
+++ b/bin/gftools-add-font.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-#
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Copyright 2018 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Marc made a PR with some python3 updates but It was missing a python3, this pr just adds that. 