### PR TITLE
gftools qa: refactor get_bstack_credentials, fix logging

### DIFF
--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -24,8 +24,8 @@ from gftools.utils import (
     load_Google_Fonts_api_key,
 )
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 DIFFENATOR_THRESHOLDS = {
     "weak": dict(

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -4,6 +4,7 @@ from fontTools.ttLib import TTFont
 from diffenator.diff import DiffFonts
 from diffenator.font import DFont
 from diffbrowsers.diffbrowsers import DiffBrowsers
+from diffbrowsers.utils import load_browserstack_credentials
 from diffbrowsers.browsers import test_browsers
 from statistics import mode
 import argparse
@@ -25,7 +26,6 @@ from gftools.utils import (
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
 
 DIFFENATOR_THRESHOLDS = {
     "weak": dict(
@@ -99,15 +99,14 @@ def mkdir(path, overwrite=True):
 
 def get_bstack_credentials():
     """Return the users Browserstack credentials"""
-    try:
-        from diffbrowsers.utils import load_browserstack_credentials
-        return load_browserstack_credentials()
-    except:
+    credentials = load_browserstack_credentials()
+    if not credentials:
         username = os.environ.get("BSTACK_USERNAME")
         access_key = os.environ.get("BSTACK_ACCESS_KEY")
         if all([username, access_key]):
             return (username, access_key)
         return False
+    return credentials
 
 
 def run_fontbakery(fonts_paths, out):


### PR DESCRIPTION
- get_bstack_credentials needed refactoring because of the work done in [diffbrowsers/13](https://github.com/googlefonts/diffbrowsers/pull/13/files)
- Script should now log all info messages, including info messages from other tools