### PR TITLE
gftools-fix-vf-meta: change OS/2 weightClass vals for Thin and ExtraLight

### DIFF
--- a/bin/gftools-fix-vf-meta.py
+++ b/bin/gftools-fix-vf-meta.py
@@ -27,8 +27,8 @@ if sys.version_info.major == 3:
     unicode = str
 
 OS_2_WEIGHT_CLASS = {
-    'Thin': 250,
-    'ExtraLight': 275,
+    'Thin': 100,
+    'ExtraLight': 200,
     'Light': 300,
     'Regular': 400,
     '': 400,


### PR DESCRIPTION
OS/2 weightClass values should be multiples of 100 for variable fonts according to an [FB check](https://github.com/googlefonts/fontbakery/blob/master/Lib/fontbakery/specifications/googlefonts.py#L3646-L3666)