### PR TITLE
lower minimum percentage needed to apply "ext" subset

### DIFF
--- a/bin/gftools-add-font.py
+++ b/bin/gftools-add-font.py
@@ -62,9 +62,10 @@ FLAGS = flags.FLAGS
 flags.DEFINE_integer('min_pct', 50,
                      'What percentage of subset codepoints have to be supported'
                      ' for a non-ext subset.')
-flags.DEFINE_integer('min_pct_ext', 10,
-                     'What percentage of subset codepoints have to be supported'
-                     ' for a -ext subset.')
+# if a single glyph from the 81 glyphs in *-ext_unique-glyphs.nam file is present, the font can have the "ext" subset
+flags.DEFINE_float('min_pct_ext', 0.01,
+                   'What percentage of subset codepoints have to be supported'
+                   ' for a -ext subset.')
 
 
 def _FileFamilyStyleWeights(fontdir):


### PR DESCRIPTION
This is a patch for https://github.com/google/fonts/issues/187.

It may or may not be the best solution for the problem, but as I understand it, we want to add `ext` subsets into metadata if fonts contain even a single glyph of a given `ext` subset. By setting the default `min_pct_ext` to `0.01`, this mean that if 1 glyph of up to 1000 is present from an `ext` encoding file, it will apply that subset label. Because Cyrillic has the most glyphs in an `ext` encoding file at 333 glyphs, this gives some headroom. 

It doesn't apply `ext` subsets to all fonts, so it seems to be doing the job.

There are still further edits to make to `add-font`, but this one should correct this specific issue in future uses.