### PR TITLE
add-font: get actual font name for metadata rather than splitting file name

### DIFF
--- a/bin/gftools-add-font.py
+++ b/bin/gftools-add-font.py
@@ -179,11 +179,7 @@ def _MakeMetadata(fontdir, is_new):
 
 def _getFontFamilyName(fontfile):
   font = ttLib.TTFont(fontfile)
-  
   nametable = font['name']
-
-  help(nametable.getName)
-
   family_name = None
   typographic_name = nametable.getName(16, 3, 1, 1033)
   if typographic_name:

--- a/bin/gftools-add-font.py
+++ b/bin/gftools-add-font.py
@@ -123,7 +123,7 @@ def _MakeMetadata(fontdir, is_new):
   font_license = fonts.LicenseFromPath(fontdir)
 
   metadata = fonts_pb2.FamilyProto()
-  metadata.name = file_family_style_weights[0].family
+  metadata.name = _getFontFamilyName(first_file)
 
   if not is_new:
     old_metadata = fonts_pb2.FamilyProto()
@@ -150,7 +150,7 @@ def _MakeMetadata(fontdir, is_new):
                                        '???.').strip()
 
     font_metadata = metadata.fonts.add()
-    font_metadata.name = family
+    font_metadata.name = _getFontFamilyName(first_file)
     font_metadata.style = style
     font_metadata.weight = weight
     font_metadata.filename = filename
@@ -175,6 +175,23 @@ def _MakeMetadata(fontdir, is_new):
         var_axes.max_value = axes[3]
 
   return metadata
+
+
+def _getFontFamilyName(fontfile):
+  font = ttLib.TTFont(fontfile)
+  
+  nametable = font['name']
+
+  help(nametable.getName)
+
+  family_name = None
+  typographic_name = nametable.getName(16, 3, 1, 1033)
+  if typographic_name:
+      family_name = typographic_name.toUnicode()
+  else:
+      family_name = nametable.getName(1, 3, 1, 1033).toUnicode()
+
+  return family_name
 
 
 def _AxisInfo(fontfile):


### PR DESCRIPTION
This aims to resolve https://github.com/googlefonts/gftools/issues/122

I've added Marc's suggested code to get the font nameID 16, else nameID 1, and this results in a more-accurate result for font names in metadata generated by `gftools-add-font.py`.

I have a few questions before I'll feel confident in this merge:

- **Is there a cleaner way to add this functionality?** E.g. should the new `_getFontFamilyName` function be placed somewhere else, such as in `util/google_fonts.py`?

- **Will this work for VFs?** Might it accidentally include a style name, because nameID 1 will likely include the default style name? (Also, in the context of this update, does it matter whether it works for VFs, as there are other issues with these, currently, outside of this?)

Thanks for suggesting the logic for that function! That made this an easy update, once I figured out what lines were writing the name metadata.