### PR TITLE
qa: do not produce browser diff for all glyphs at 14px.

### DIFF
--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -186,7 +186,7 @@ def run_diffbrowsers(font_before, font_after, out, auth, local=False,
     info = os.path.join(out, "info.json")
     json.dump(diff_browsers.stats, open(info, "w"))
     if has_vfs:
-        for i in range(14, 17):    
+        for i in range(15, 17):    
             diff_browsers.diff_view("glyphs_all", pt=i)
 
 


### PR DESCRIPTION
I've dropped this because the size is too small to worry about in most cases. Also by dropping it, Travis will shave off 5-7 mins per an instance/static font. This should help keep diffs under 50 mins.