### PR TITLE
Fix URL to encodings subdirectory on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google Fonts Tools
 
-This project contains tools used for working with the Google Fonts collection, plus **Google Fonts Glyph Set Documentation** in the [/encodings](/encodings) subdirectory. While these tools are primarily intended for contributors to the Google Fonts project, anyone who works with fonts could find them useful.
+This project contains tools used for working with the Google Fonts collection, plus **Google Fonts Glyph Set Documentation** in the [encodings](https://github.com/googlefonts/gftools/tree/master/Lib/gftools/encodings) subdirectory. While these tools are primarily intended for contributors to the Google Fonts project, anyone who works with fonts could find them useful.
 
 The tools and files under this directory are available under the Apache License v2.0, for details see [LICENSE](LICENSE)
 


### PR DESCRIPTION
README edit for a changed path to the `encodings` subdirectory