### PR TITLE
fixed missing parentheses error in fix-fstype.py

### DIFF
--- a/bin/gftools-fix-fstype.py
+++ b/bin/gftools-fix-fstype.py
@@ -41,9 +41,9 @@ def main():
     if font['OS/2'].fsType != 0:
       font['OS/2'].fsType = 0
       font.save(font_path + '.fix')
-      print 'font saved %s.fix' % font_path
+      print('font saved %s.fix' % font_path)
     else:
-      print 'SKIPPING: %s fsType is already 0' % font_path
+      print('SKIPPING: %s fsType is already 0' % font_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```
      print('font saved %s.fix' % font_path)
    else:
      print('SKIPPING: %s fsType is already 0' % font_path)
```

lines 44,46 were missing parentheses in call to print