### PR TITLE
Update currencies in GF Latin Plus

### DIFF
--- a/Lib/gftools/encodings/GF Glyph Sets/README.md
+++ b/Lib/gftools/encodings/GF Glyph Sets/README.md
@@ -50,7 +50,7 @@ Structure and Hierarchy of Glyph Sets for Latin:
 
   - Western & Central European
   - Vietnamese
-  - Currencies (₡ ₣ ₤ ₦ ₧ ₩ ₫ ₭ ₱ ₲ ₵ ₹ ₺ ₼ ₽)
+  - Currencies (₡ ₦ ₱ ₩ ฿ ₫ ₭ ₲ ₵ ₹ ₨ ₺ ₼ ₸ ₽)
   - Alternate Numerals: Proportonal Lining
 
 Includes characters from the following unicode ranges:


### PR DESCRIPTION
@LisaHuang2017 and I compiled a table to look at currency symbols in the [latin-ext_unique-glyphs.nam](https://github.com/googlefonts/gftools/blob/master/Lib/gftools/encodings/latin-ext_unique-glyphs.nam) encoding.

We found compelling evidence to **remove several symbols from the GF Latin Plus character set**. Each of these currencies has long since been replaced by the Euro.
- ₤, Italian Lira (replaced by Euro in Italic, San Marino, and the Vatican since 2002)
- ₧, Spanish Peseta (replaced by Euro in Spain and Andorra since 2002)
- ₣, French Franc (replaced by Euro since 1999/2002)

Additionally, we found evidence suggesting that **several currencies should be added** to the Latin Plus set:
- ₨, rupee, in use by approx. 262M+ people in Mauritius, Nepal, Pakistan, Seychelles, Sri Lanka
- ฿, baht, in use by approx. 68M people in Thailand
- ₸, tenge, in use by approx. 18M people in Kazakhstan (which has officially switched to a Latin-based script)

I haven't added currency symbols with fewer than 50M users in countries which have a different primary script than Latin. However, we may wish to adjust the rubric to include some or all of these:
- ₴, hryvnia, used by 42M+ people in Ukraine
- ₪, new sheqel, used by 9M in Israel
- ₭, kip, used by 6M in Laos
- ₮, tugrik, used by 3M in Mongolia
- ₾, lari, used by 3M in Georgia

Also, a wildcard that we may wish to include:
- ₿, Bitcoin, used by a hard-to-estimate number of people, but maybe 35M+ and growing

Potentially, symbols from the latter categories could be included in the "Optional additions," or in "GF Latin Pro."

Also notable is the lack of the ƒ, florin (Unicode 0192), from any of the GF encodings. It is no longer used in the Netherlands, but it is used by 300,000 people in Aruba, Curaçao, and the Dutch half of Sint Maarten, as well as in photography (to denote aperture). This might be another good symbol for GF Latin Pro.


| Unicode                                                                                                           | Symbol | Name                    | Currently in use    | Countries in use                                                                                                                         | Approx. Pop.                                                                                                                                                                                                                                              | Main Script                 | Notes                                                                                                                                                                                                                                                                                  |
| ----------------------------------------------------------------------------------------------------------------- | ------ | ----------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Latin Core**                                                                                                    |        |                         |                     |                                                                                                                                          |                                                                                                                                                                                                                                                           |                             |                                                                                                                                                                                                                                                                                        |
| 0024                                                                                                              | **$**  | dollar                  | yes                 | US, UK, …                                                                                                                                | 400M+ (7B?)                                                                                                                                                                                                                                               | Latin                       |                                                                                                                                                                                                                                                                                        |
| 00A2                                                                                                              | **¢**  | cent                    | yes                 | US, UK, Mexico                                                                                                                           | 400M+                                                                                                                                                                                                                                                     | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20AC                                                                                                              | **€**  | Euro                    | yes                 | European Union                                                                                                                           | 508M+                                                                                                                                                                                                                                                     | Latin                       |                                                                                                                                                                                                                                                                                        |
| 00A3                                                                                                              | **£**  | sterling / pound        | yes                 | UK, British territories                                                                                                                  | 66M+                                                                                                                                                                                                                                                      | Latin                       |                                                                                                                                                                                                                                                                                        |
| 00A5                                                                                                              | **¥**  | yen                     | yes                 | Japan, China (PRC)                                                                                                                       | 127M+, 1.386B+                                                                                                                                                                                                                                            | Japanese, Chinese           |                                                                                                                                                                                                                                                                                        |
| 00A4                                                                                                              | **¤**  | currency                | yes                 | generic sign                                                                                                                             | ?                                                                                                                                                                                                                                                         |                             |                                                                                                                                                                                                                                                                                        |
| [latin-ext](https://github.com/googlefonts/gftools/blob/master/Lib/gftools/encodings/latin-ext_unique-glyphs.nam) |        |                         |                     |                                                                                                                                          |                                                                                                                                                                                                                                                           |                             |                                                                                                                                                                                                                                                                                        |
| 20B9                                                                                                              | **₹**  | rupeeIndian             | yes                 | India                                                                                                                                    | 1,325M+                                                                                                                                                                                                                                                   | Devanagari, Latin           |                                                                                                                                                                                                                                                                                        |
| 20A8                                                                                                              | **₨**  | rupee                   | yes                 | Mauritius, Nepal, Pakistan, Seychelles, Sri Lanka                                                                                        | 262M+                                                                                                                                                                                                                                                     | mix Latin and local scripts |                                                                                                                                                                                                                                                                                        |
| 20A6                                                                                                              | **₦**  | naira                   | yes                 | Nigeria                                                                                                                                  | 191M                                                                                                                                                                                                                                                      | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20BD                                                                                                              | **₽**  | ruble                   | yes                 | Russia                                                                                                                                   | 146M                                                                                                                                                                                                                                                      | Cyrillic                    |                                                                                                                                                                                                                                                                                        |
| 20B1                                                                                                              | **₱**  | peso                    | yes                 | Philippines                                                                                                                              | 101M+                                                                                                                                                                                                                                                     | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20AB                                                                                                              | **₫**  | dong                    | yes                 | Vietnam                                                                                                                                  | 94M                                                                                                                                                                                                                                                       | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20BA                                                                                                              | **₺**  | liraTurkish             | yes                 | Turkey                                                                                                                                   | 83M                                                                                                                                                                                                                                                       | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20A9                                                                                                              | **₩**  | won                     | yes                 | South and North Korea                                                                                                                    | 51M + 25M                                                                                                                                                                                                                                                 | Hangul                      |                                                                                                                                                                                                                                                                                        |
| 0E3F                                                                                                              | **฿**  | baht                    | yes                 | Thailand                                                                                                                                 | 68M                                                                                                                                                                                                                                                       | Thai                        |                                                                                                                                                                                                                                                                                        |
| 20B4                                                                                                              | **₴**  | hryvnia                 | yes                 | Ukraine                                                                                                                                  | 42M+                                                                                                                                                                                                                                                      | Cyrillic                    |                                                                                                                                                                                                                                                                                        |
| 20BF                                                                                                              | **₿**  | bitcoin                 | yes                 | World Wide Web                                                                                                                           | Hard to say. [25M](https://www.bitcoinmarketjournal.com/how-many-people-use-bitcoin/) to [35M](https://insight.jbs.cam.ac.uk/2018/second-annual-survey-of-global-cryptoasset-activity/) | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20B5                                                                                                              | **₵**  | cedi                    | yes                 | Ghana                                                                                                                                    | 28M                                                                                                                                                                                                                                                       | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20B8                                                                                                              | **₸**  | tenge                   | yes                 | Kazakhstan                                                                                                                               | 18M                                                                                                                                                                                                                                                       | Kazakh Latin + Cyrillic     |                                                                                                                                                                                                                                                                                        |
| 20BC                                                                                                              | **₼**  | manat                   | yes                 | Azerbaijan                                                                                                                               | 10M                                                                                                                                                                                                                                                       | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20AA                                                                                                              | **₪**  | new sheqel              | yes                 | State of Israel                                                                                                                          | 9M                                                                                                                                                                                                                                                        | Hebrew                      |                                                                                                                                                                                                                                                                                        |
| 20B2                                                                                                              | **₲**  | guarani                 | yes                 | Paraguay                                                                                                                                 | 7M+                                                                                                                                                                                                                                                       | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20AD                                                                                                              | **₭**  | kip                     | yes                 | Laos                                                                                                                                     | 6M                                                                                                                                                                                                                                                        | Lao                         |                                                                                                                                                                                                                                                                                        |
| 20A1                                                                                                              | **₡**  | colon monetary          | yes                 | Costa Rica                                                                                                                               | 5M                                                                                                                                                                                                                                                        | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20AE                                                                                                              | **₮**  | tugrik (or tögrög)      | yes                 | Mongolia                                                                                                                                 | 3M                                                                                                                                                                                                                                                        | Mongolian                   |                                                                                                                                                                                                                                                                                        |
| 20BE                                                                                                              | **₾**  | lari                    | yes                 | Georgia                                                                                                                                  | 3M+                                                                                                                                                                                                                                                       | Georgian                    |                                                                                                                                                                                                                                                                                        |
| 20A0                                                                                                              | **₠**  | euro-currency           | no             | European Union                                                                                                                           | 0                                                                                                                                                                                                                                                         |                             |                                                                                                                                                                                                                                                                                        |
| 20A2                                                                                                              | **₢**  | cruzeiro                | no                  | Brazil                                                                                                                                   | 0                                                                                                                                                                                                                                                         |                             |                                                                                                                                                                                                                                                                                        |
| 20A3                                                                                                              | **₣**  | franc                   | no                  | France                                                                                                                                   | 0                                                                                                                                                                                                                                                         |                             | Replaced in 1999 by Euro.<br><br>“the symbol [₣](https://en.wikipedia.org/wiki/%E2%82%A3) was suggested in France by Prime Minister [Édouard Balladur](https://en.wikipedia.org/wiki/%C3%89douard_Balladur), but it was never used” ([Wikipedia](https://en.wikipedia.org/wiki/Franc)) |
| 20A4                                                                                                              | **₤**  | lira                    | no                  | Italy                                                                                                                                    | 0                                                                                                                                                                                                                                                         |                             |                                                                                                                                                                                                                                                                                        |
| 20A5                                                                                                              | **₥**  | mill                    | no (or ‘sometimes’) | US, UK, Malta…                                                                                                                           |                                                                                                                                                                                                                                                           |                             |                                                                                                                                                                                                                                                                                        |
| 20A7                                                                                                              | **₧**  | peseta                  | no                  | Spain                                                                                                                                    | 0                                                                                                                                                                                                                                                         |                             |                                                                                                                                                                                                                                                                                        |
| 20AF                                                                                                              | **₯**  | drachma                 | no                  | Greece                                                                                                                                   | 0                                                                                                                                                                                                                                                         | Greek                       |                                                                                                                                                                                                                                                                                        |
| 20B0                                                                                                              | **₰**  | pfennig or german penny | no                  | Germany                                                                                                                                  | 0                                                                                                                                                                                                                                                         | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20B3                                                                                                              | **₳**  | austral                 | no                  | Argentina                                                                                                                                | 0                                                                                                                                                                                                                                                         | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20B6                                                                                                              | **₶**  | livre tournois          | no                  | France                                                                                                                                   | 0                                                                                                                                                                                                                                                         | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20B7                                                                                                              | **₷**  | spesmilo                | no                  | UK, Switzerland                                                                                                                          | 0                                                                                                                                                                                                                                                         | Latin                       |                                                                                                                                                                                                                                                                                        |
| 20BB                                                                                                              | ₻      | mark                    | no                  | Germany, Scotland                                                                                                                        | 0                                                                                                                                                                                                                                                         | Latin                       |                                                                                                                                                                                                                                                                                        |
| **Not** **in current GF charsets**                                                                                |        |                         |                     |                                                                                                                                          |                                                                                                                                                                                                                                                           |                             |                                                                                                                                                                                                                                                                                        |
| 0192                                                                                                              | **ƒ**  | florin                  | yes                 | [Aruba, Curaçao, and the Dutch half of Sint Maarten](https://typedrawers.com/discussion/349/florin-sign-f) and in photography (aperture) | 310K                                                                                                                                                                                                                                                      | Latin                       | https://typedrawers.com/discussion/349/florin-sign-f                                                                                                                                                                                                                                   |