### PR TITLE
qa: get fonts from private github repos

### DIFF
--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -114,7 +114,8 @@ def download_fonts_in_pr(url, dst=None):
                 continue
             if filename.endswith(".ttf") and item["status"] != "removed":
                 if dst:
-                    font_dst = os.path.join(dst, os.path.basename(filename))
+                    dl_filename = sanitize_github_filename(os.path.basename(filename))
+                    font_dst = os.path.join(dst, os.path.basename(dl_filename))
                     download_file(download_url, font_dst)
                     font_paths.append(font_dst)
                 else:
@@ -144,13 +145,20 @@ def download_fonts_in_github_dir(url, dst=None):
         if item["name"].endswith(".ttf"):
             f = item["download_url"]
             if dst:
-                font_dst = os.path.join(dst, os.path.basename(f))
+                dl_filename = sanitize_github_filename(os.path.basename(f))
+                font_dst = os.path.join(dst, dl_filename)
                 download_file(f, font_dst)
                 font_paths.append(font_dst)
             else:
                 dl = download_file(f)
                 font_paths.append(dl)
     return font_paths
+
+
+def sanitize_github_filename(f):
+    """stip token suffix from filenames downloaded from private repos.
+    Oswald-Regular.ttf?token=123545 --> Oswald-Regular.ttf"""
+    return re.sub(r"\?token=.*", "", os.path.basename(f))
 
 
 def download_file(url, dst_path=None):

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -50,7 +50,7 @@ from gftools.utils import (
 )
 
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -87,10 +87,9 @@ class FontQA:
                 (
                     "Cannot find matching fonts!\n"
                     "fonts: [{}]\nfonts_before: [{}]".format(
-                        ", ".join(
-                            set(fonts_h.keys()), ", ".join(set(font_before_h.keys()))
-                        )
-                    )
+                        ", ".join(set(self._instances.keys())),
+                        ", ".join(set(self._instances_before.keys()))
+                     )
                 )
             )
         return shared
@@ -114,7 +113,10 @@ class FontQA:
                 name = name.replace(" ", "")
                 styles.append(name)
         else:
-            styles.append(os.path.basename(ttfont.reader.file.name).split("-")[1][:-4])
+            filename = os.path.basename(ttfont.reader.file.name)
+            style = filename.split("-")[1]
+            style = re.sub(".ttf|.otf", "", style)
+            styles.append(style)
         return styles
 
     def diffenator(self, **kwargs):


### PR DESCRIPTION
Current implementation cannot get fonts from private github repos. Well, it's able to download them but github appends the user's token to the filename. This causes problems when FontQA attempts to match the fonts. This pr will strip the token from the filename. It also allows filenames which contains suffixes which are not styles e.g FontFamily-Regular-Android.ttf will now work.