### PR TITLE
 add-font: Support variable fonts

### DIFF
--- a/Lib/gftools/util/google_fonts.py
+++ b/Lib/gftools/util/google_fonts.py
@@ -434,18 +434,46 @@ def FamilyName(fontname):
   return re.sub('([a-z0-9])([A-Z])', r'\1 \2', fontname)
 
 
-def StyleWeight(styleweight):
-  """Breaks apart a style/weight specifier into a 2-tuple of (style, weight).
+def Weight(stylename):
+  """Derive weight from a stylename.
 
   Args:
-    styleweight: style/weight string, e.g. Bold, Regular, or ExtraLightItalic.
+    stylename: string, e.g. Bold, Regular, or ExtraLightItalic.
   Returns:
-    2-tuple of style (normal or italic) and weight.
+    weight: integer
   """
-  if styleweight.endswith('Italic'):
-    return ('italic', _KNOWN_WEIGHTS[styleweight[:-6]])
+  if stylename.endswith('Italic'):
+    return _KNOWN_WEIGHTS[stylename[:-6]]
+  return _KNOWN_WEIGHTS[stylename]
 
-  return ('normal', _KNOWN_WEIGHTS[styleweight])
+
+def VFWeight(font):
+  """Return a variable fonts weight. Return 400 if 400 is within the wght
+  axis range else return the value closest to 400
+
+  Args:
+    font: TTFont
+  Returns:
+    weight: integer
+  """
+  wght_axis = None
+  for axis in font['fvar'].axes:
+    if axis.axisTag == "wght":
+      wght_axis = axis
+      break
+  value = 400
+  if wght_axis:
+    if wght_axis.minValue >= 400:
+      value = wght_axis.minValue
+    if wght_axis.maxValue <= 400:
+      value = wght_axis.maxValue
+  # TODO (MF) check with GF Eng if we should just assume it's safe to return
+  # 400 if a wght axis doesn't exist.
+  return value
+
+
+def Style(stylename):
+  return 'italic' if "Italic" in stylename else "normal"
 
 
 def FamilyStyleWeight(path):
@@ -468,10 +496,10 @@ def FileFamilyStyleWeight(path):
   m = re.search(_FAMILY_WEIGHT_REGEX, path)
   if not m:
     raise ParseError('Could not parse %s' % path)
-  sw = StyleWeight(m.group(2))
-  return FileFamilyStyleWeightTuple(path, FamilyName(m.group(1)), sw[0],
-                                    sw[1])
-
+  style = Style(m.group(2))
+  weight = Weight(m.group(2))
+  return FileFamilyStyleWeightTuple(path, FamilyName(m.group(1)), style,
+                                    weight)
 
 def VFFamilyStyleWeight(path):
   """Extract family, style and weight from a variable font's name table.
@@ -491,9 +519,13 @@ def VFFamilyStyleWeight(path):
     styleName = font['name'].getName(2, 3, 1, 1033)
     style = typoStyleName.toUnicode() if typoStyleName else \
             styleName.toUnicode()
-    style = style.replace(" ", "")
-    sw = StyleWeight(style)
-    return FileFamilyStyleWeightTuple(path, family, sw[0], sw[1])
+    style = "italic" if "Italic" in style.replace(" ", "") else "normal"
+    # For each font in a variable font family, we do not want to return
+    # the style's weight. We want to return 400 if 400 is within the
+    # the wght axis range. If it isn't, we want the value closest to 400.
+    weight = VFWeight(font)
+    return FileFamilyStyleWeightTuple(path, family, style, weight)
+
 
 
 def ExtractNames(font, name_id):

--- a/Lib/gftools/util/google_fonts.py
+++ b/Lib/gftools/util/google_fonts.py
@@ -455,21 +455,21 @@ def FamilyStyleWeight(path):
     return FileFamilyStyleWeight(path)
 
 
-def FileFamilyStyleWeight(filename):
+def FileFamilyStyleWeight(path):
   """Extracts family, style, and weight from Google Fonts standard filename.
 
   Args:
-    filename: Font filename, eg Lobster-Regular.ttf.
+    path: Font path, eg ./fonts/ofl/lobster/Lobster-Regular.ttf.
   Returns:
     FileFamilyStyleWeightTuple for file.
   Raises:
     ParseError: if file can't be parsed.
   """
-  m = re.search(_FAMILY_WEIGHT_REGEX, filename)
+  m = re.search(_FAMILY_WEIGHT_REGEX, path)
   if not m:
-    raise ParseError('Could not parse %s' % filename)
+    raise ParseError('Could not parse %s' % path)
   sw = StyleWeight(m.group(2))
-  return FileFamilyStyleWeightTuple(filename, FamilyName(m.group(1)), sw[0],
+  return FileFamilyStyleWeightTuple(path, FamilyName(m.group(1)), sw[0],
                                     sw[1])
 
 

--- a/Lib/gftools/util/google_fonts.py
+++ b/Lib/gftools/util/google_fonts.py
@@ -448,6 +448,13 @@ def StyleWeight(styleweight):
   return ('normal', _KNOWN_WEIGHTS[styleweight])
 
 
+def FamilyStyleWeight(path):
+    filename = os.path.basename(path)
+    if "[" in filename and "]" in filename:
+        return VFFamilyStyleWeight(path)
+    return FileFamilyStyleWeight(path)
+
+
 def FileFamilyStyleWeight(filename):
   """Extracts family, style, and weight from Google Fonts standard filename.
 
@@ -464,6 +471,29 @@ def FileFamilyStyleWeight(filename):
   sw = StyleWeight(m.group(2))
   return FileFamilyStyleWeightTuple(filename, FamilyName(m.group(1)), sw[0],
                                     sw[1])
+
+
+def VFFamilyStyleWeight(path):
+  """Extract family, style and weight from a variable font's name table.
+
+  Args:
+      path: Font path, eg ./fonts/ofl/lobster/Lobster[wght].ttf.
+  Returns:
+    FileFamilyStyleWeightTuple for file.
+  """
+  with ttLib.TTFont(path) as font:
+    typoFamilyName = font['name'].getName(16, 3, 1, 1033)
+    familyName = font['name'].getName(2, 3, 1, 1033)
+    family = typoFamilyName.toUnicode() if typoFamilyName else \
+             familyName.toUnicode()
+
+    typoStyleName = font['name'].getName(17, 3, 1, 1033)
+    styleName = font['name'].getName(2, 3, 1, 1033)
+    style = typoStyleName.toUnicode() if typoStyleName else \
+            styleName.toUnicode()
+    style = style.replace(" ", "")
+    sw = StyleWeight(style)
+    return FileFamilyStyleWeightTuple(path, family, sw[0], sw[1])
 
 
 def ExtractNames(font, name_id):

--- a/Lib/gftools/util/google_fonts.py
+++ b/Lib/gftools/util/google_fonts.py
@@ -483,7 +483,7 @@ def VFFamilyStyleWeight(path):
   """
   with ttLib.TTFont(path) as font:
     typoFamilyName = font['name'].getName(16, 3, 1, 1033)
-    familyName = font['name'].getName(2, 3, 1, 1033)
+    familyName = font['name'].getName(1, 3, 1, 1033)
     family = typoFamilyName.toUnicode() if typoFamilyName else \
              familyName.toUnicode()
 

--- a/bin/gftools-add-font.py
+++ b/bin/gftools-add-font.py
@@ -171,8 +171,7 @@ def _MakeMetadata(fontdir, is_new):
         var_axes = metadata.axes.add()
         var_axes.tag = axes[0]
         var_axes.min_value = axes[1]
-        var_axes.default_value = axes[2]
-        var_axes.max_value = axes[3]
+        var_axes.max_value = axes[2]
 
   return metadata
 
@@ -192,7 +191,7 @@ def _AxisInfo(fontfile):
     else:
       fvar = font['fvar']
       axis_info = [
-          (a.axisTag, a.minValue, a.defaultValue, a.maxValue) for a in fvar.axes
+          (a.axisTag, a.minValue, a.maxValue) for a in fvar.axes
       ]
       return tuple(sorted(axis_info))
 

--- a/bin/gftools-add-font.py
+++ b/bin/gftools-add-font.py
@@ -88,7 +88,7 @@ def _FileFamilyStyleWeights(fontdir):
   if not files:
     raise OSError(errno.ENOENT, 'no font files found')
 
-  result = [fonts.FileFamilyStyleWeight(f) for f in files]
+  result = [fonts.FamilyStyleWeight(f) for f in files]
   def _Cmp(r1, r2):
     return cmp(r1.weight, r2.weight) or -cmp(r1.style, r2.style)
   result = sorted(result, key=cmp_to_key(_Cmp))


### PR DESCRIPTION
Running `gftools add-font` on a variable font family should now work. I haven't gone overboard with the implementation since we'll probably need to refactor this script once we start pushing vfs with multiple axes.

Since we're not able to extract the style and weight info from a VF's filename, I've had to use the name table.

I've also tidied up `FileFamilyStyleWeight` func arg. It takes a path, not just a filename.