### PR TITLE
qa: add args.out_url

### DIFF
--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -410,8 +410,16 @@ def main():
         action="store_true",
         help=(
             "Post report data to either the pull request as a comment "
-            "open a new issue"
+            "open a new issue. This can only be used if fonts have been "
+            "fetched from either a pull request or github dir."
         ),
+    )
+    parser.add_argument(
+        "--out-url",
+        help=(
+            "Post report data to a github pr. This can be used with any font "
+            "fetching method."
+        )
     )
     parser.add_argument("--version", action="version", version=__version__)
     args = parser.parse_args()
@@ -489,7 +497,9 @@ def main():
     if args.diffbrowsers:
         qa.diffbrowsers()
 
-    if args.out_github and args.pull_request:
+    if args.out_url:
+        qa.post_to_github(args.out_url)
+    elif args.out_github and args.pull_request:
         qa.post_to_github(args.pull_request)
     elif args.out_github and args.github_dir:
         qa.post_to_github(args.github_dir)


### PR DESCRIPTION
This option will allow users to post report data to any pull request.

We currently have an argument called -ogh. This also allows users to post report data to github. However, the pull request or github dir must contain font binaries.

This arg is more flexible since fonts are not required. It allows users to build fonts using a CI such as travis and then run gftools on the built fonts and post the results back to the pr.