### PR TITLE
qa: Update GF Regression url

### DIFF
--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -57,7 +57,7 @@ logger.setLevel(logging.INFO)
 
 class FontQA:
 
-    GFR_URL = "http://35.188.158.120/"
+    GFR_URL = "http://35.238.63.0/"
 
     def __init__(self, fonts, fonts_before=None, out="out"):
         self._fonts = fonts


### PR DESCRIPTION
GF Regression's VM needed some maintenance (first time in a year). Once the changes had been made, the VM's ip address changed. I didn't realise that the address was ephemeral only. This means if the VM is restarted, a new address is assigned. Going forward this shouldn't happen since it now uses a static ip address. 

https://cloud.google.com/compute/docs/ip-addresses/

I apologise for the inconvenience. Fortunately the old ip address was only used here and in FB dashboard. I'll submit a pr to fb dashboard now and inform TN to upgrade gftools.