### PR TITLE
VFWeight: return weight as int

### DIFF
--- a/Lib/gftools/util/google_fonts.py
+++ b/Lib/gftools/util/google_fonts.py
@@ -469,7 +469,7 @@ def VFWeight(font):
       value = wght_axis.maxValue
   # TODO (MF) check with GF Eng if we should just assume it's safe to return
   # 400 if a wght axis doesn't exist.
-  return value
+  return int(value)
 
 
 def Style(stylename):


### PR DESCRIPTION
After merging #154, it failed on some VFs because it was returning a float when our protobuf expects the weight to be an int.