### PR TITLE
setup.py: Set QA dependencies as extra requirement

### DIFF
--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -23,7 +23,6 @@ import re
 import shutil
 from collections import namedtuple
 from github import Github
-from diffbrowsers.utils import load_browserstack_credentials as bstack_creds
 if sys.version_info[0] == 3:
     from configparser import ConfigParser
 else:
@@ -66,18 +65,6 @@ def load_Google_Fonts_api_key():
         credentials = config.items("Credentials")
         return credentials[0][1]
     return None
-
-
-def load_browserstack_credentials():
-    """Return the user's Browserstack credentials"""
-    credentials = bstack_creds()
-    if not credentials:
-        username = os.environ.get("BSTACK_USERNAME")
-        access_key = os.environ.get("BSTACK_ACCESS_KEY")
-        if all([username, access_key]):
-            return (username, access_key)
-        return False
-    return credentials
 
 
 def parse_github_pr_url(url):

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Please install these tools using pip:
 
     pip install gftools
 
+If you need to use `gftools qa`, you will need to install Harfbuzz, Cairo, FreeType and pkg-config. These can be installed on OS X using homebrew:
+
+    brew install cairo freetype harfbuzz pkg-config
+
+Once You have installed these system packages, install gftools using the following command:
+
+    pip install gftools[qa]
+
 
 ### Requirements and Dependencies
 
@@ -49,10 +57,6 @@ Make sure the submodule is up to date by running:
 
     git submodule update --init --recursive
 
-
-Running gftools-qa also requires Harfbuzz, Cairo, FreeType and pkg-config. These can be installed on OS X using homebrew:
-
-`brew install cairo freetype harfbuzz pkg-config`
 
 ### Google Fonts API Key
 

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -21,10 +21,6 @@ Fonts:
 `gftools qa -gh www.github.com/user/repo/tree/fonts/ttf -gfb -a -o qa`
 """
 from fontTools.ttLib import TTFont
-from diffenator.diff import DiffFonts
-from diffenator.font import DFont
-from diffbrowsers.diffbrowsers import DiffBrowsers
-from diffbrowsers.browsers import test_browsers
 import argparse
 import shutil
 import os
@@ -45,14 +41,34 @@ from gftools.utils import (
     download_file,
     Google_Fonts_has_family,
     load_Google_Fonts_api_key,
-    load_browserstack_credentials,
     mkdir,
 )
-
+try:
+    from diffenator.diff import DiffFonts
+    from diffenator.font import DFont
+    from diffbrowsers.diffbrowsers import DiffBrowsers
+    from diffbrowsers.browsers import test_browsers
+    from diffbrowsers.utils import load_browserstack_credentials as bstack_creds
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(("gftools was installed without the QA "
+        "dependencies. To install the dependencies, see the ReadMe, "
+        "https://github.com/googlefonts/gftools#installation"))
 
 __version__ = "2.0.2"
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+def load_browserstack_credentials():
+    """Return the user's Browserstack credentials"""
+    credentials = bstack_creds()
+    if not credentials:
+        username = os.environ.get("BSTACK_USERNAME")
+        access_key = os.environ.get("BSTACK_ACCESS_KEY")
+        if all([username, access_key]):
+            return (username, access_key)
+        return False
+    return credentials
 
 
 class FontQA:

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ setup(
         'Programming Language :: Python :: 3'
     ],
     setup_requires=['setuptools_scm'],
+    # Dependencies needed for gftools qa.
+    extras_require={"qa": ['fontbakery', 'fontdiffenator', 'gfdiffbrowsers']},
     install_requires=[
 #       'fontforge', # needed by build-font2ttf script
 #                      but there's no fontforge package on pypi
@@ -79,8 +81,6 @@ setup(
         'requests',
         'tabulate',
         'unidecode',
-        'fontbakery',
-        'fontdiffenator',
-        'gfdiffbrowsers',
+        'opentype-sanitizer',
     ]
     )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open('README.md') as f:
 
 setup(
     name="gftools",
-    version='0.3.0',
+    version='0.3.1',
     url='https://github.com/googlefonts/tools/',
     description='Google Fonts Tools is a set of command-line tools'
                 ' for testing font projects',


### PR DESCRIPTION
Many users only want the fix scripts. They do not require gftools qa.

If users install gftools without the QA dependencies and tries to run `gftools qa` an error is raised which points to our readme which has the further installation instructions.


cc @arialcrime

@chrissimpkins I will update both google/fonts and Google Sans travis files.