### PR TITLE
gftools rename-font added.

### DIFF
--- a/Lib/gftools/tests/test_usage.py
+++ b/Lib/gftools/tests/test_usage.py
@@ -205,6 +205,9 @@ class TestGFToolsScripts(unittest.TestCase):
 
     def test_what_subsets(self):
         self.check_script(['python', self.get_path('what-subsets'), self.example_font])
+
+    def test_rename_font(self):
+        self.check_script(['python', self.get_path('rename-font'), self.example_font, "Foobar"])
 # Temporarily disabling this until we close issue #13
 # (https://github.com/googlefonts/tools/issues/13)
 # See also https://github.com/googlefonts/fontbakery/issues/1535

--- a/bin/gftools-rename-font.py
+++ b/bin/gftools-rename-font.py
@@ -1,0 +1,77 @@
+"""
+Rename a font.
+
+Changes font menu name and filename. User can also specify their
+own output path.
+
+Usage:
+gftools rename-font font.ttf "New Family Name"
+"""
+import argparse
+from fontTools.ttLib import TTFont
+
+
+FAMILY_NAME = (1, 3, 1, 1033)
+TYPO_FAMILY_NAME = (16, 3, 1, 1033)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("font")
+    parser.add_argument("new_name")
+    parser.add_argument("-o", "--out")
+    args = parser.parse_args()
+
+    font = TTFont(args.font)
+    nametable = font["name"]
+    current_name = nametable.getName(*TYPO_FAMILY_NAME) or \
+        nametable.getName(*FAMILY_NAME)
+    if not current_name:
+        raise Exception(
+            "Name table does not contain nameID 1 or nameID 16. "
+            "This tool does not work on webfonts."
+        )
+    current_name = current_name.toUnicode()
+    print("Updating font name records")
+    for record in nametable.names:
+        record_string = record.toUnicode()
+
+        no_space = current_name.replace(" ", "")
+        hyphenated = current_name.replace(" ", "-")
+        # name with no spaces
+        if no_space in record_string:
+            new_string = record_string.replace(no_space, args.new_name.replace(" ", ""))
+        # name with hyphens instead of spaces
+        elif hyphenated in record_string:
+            new_string = record_string.replace(hyphenated, args.new_name.replace(" ", "-"))
+        # name with spaces
+        else:
+            new_string = record_string.replace(current_name, args.new_name)
+
+        if new_string is not record_string:
+            record_info = (
+                record.nameID,
+                record.platformID,
+                record.platEncID,
+                record.langID
+            )
+            print(
+                "Updating {}: '{}' to '{}'".format(
+                    record_info,
+                    record_string,
+                    new_string,
+                )
+            )
+            record.string = new_string
+    if args.out:
+        out = args.out
+    else:
+        out = args.font.replace(
+            current_name.replace(" ", ""), args.new_name.replace(" ", "")
+        )
+    print("Saving font: {}".format(out))
+    font.save(out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We already have a script to update individual name records. However, we don't have a script to update a font's family name well.

It isn't as simple as just updating nameID 1. You have to update the fullname, psname and other references which may exist, such as the copyright string.

This script will update all name records by doing the following:

- Find the existing family name. If nameID 16 exists, use this. If not, use nameID 1
- Loop through records and replace the following patterns:
    - Name without spaces (used in full font name, version etc)
    - Name with hyphens (used in ps name)
    - Name with spaces

Each record that gets modified is output to the terminal.

```
marcfoley$ gftools rename-font.py /Users/marcfoley/Desktop/Faustina\[wght\].ttf "Faustina 2"
Updating font name records
Updating (0, 3, 1, 1033): 'Copyright 2016 The Faustina Project Authors (https://github.com/Omnibus-Type/Faustina)' to 'Copyright 2016 The Faustina2 Project Authors (https://github.com/Omnibus-Type/Faustina2)'
Updating (1, 3, 1, 1033): 'Faustina' to 'Faustina2'
Updating (3, 3, 1, 1033): '1.100;OMNI;Faustina-Regular' to '1.100;OMNI;Faustina2-Regular'
Updating (4, 3, 1, 1033): 'Faustina Regular' to 'Faustina2 Regular'
Updating (6, 3, 1, 1033): 'Faustina-Regular' to 'Faustina2-Regular'
Saving font: /Users/marcfoley/Desktop/Faustina2[wght].ttf
```