### PR TITLE
qa: test VF families against VF families

### DIFF
--- a/Lib/gftools/tests/test_qa.py
+++ b/Lib/gftools/tests/test_qa.py
@@ -1,0 +1,63 @@
+import subprocess
+import unittest
+import tempfile
+import os
+
+
+class TestQA(unittest.TestCase):
+    def _test_diff_pr_vs_googlefonts(self):
+        with tempfile.TemporaryDirectory() as qa_out:
+            subprocess.call(
+                [
+                    "gftools",
+                    "qa",
+                    "-pr",
+                    "https://github.com/google/fonts/pull/2067",
+                    "-gfb",
+                    "--fontbakery",
+                    "-o",
+                    qa_out,
+                ]
+            )
+            self.assertTrue("Fontbakery" in os.listdir(qa_out))
+
+    def _test_diff_github_fonts_vs_googlefonts(self):
+        with tempfile.TemporaryDirectory() as qa_out:
+            subprocess.call(
+                [
+                    "gftools",
+                    "qa",
+                    "-gh",
+                    "https://github.com/googlefonts/AmaticSC/tree/master/fonts/ttf",
+                    "-gfb",
+                    "--fontbakery",
+                    "-o",
+                    qa_out,
+                ]
+            )
+            self.assertTrue("Fontbakery" in os.listdir(qa_out))
+
+    def test_diff_github_fonts_vs_googlefonts_vf(self):
+        with tempfile.TemporaryDirectory() as qa_out:
+            subprocess.call(
+                [
+                    "gftools",
+                    "qa",
+                    "-gh",
+                    "https://github.com/google/fonts/tree/master/ofl/mavenpro",
+                    "-gfb",
+                    "--fontbakery",
+                    "--diffenator",
+                    "--browser-previews",
+                    "--diffbrowsers",
+                    "--plot-glyphs",
+                    "-o",
+                    qa_out,
+                ]
+            )
+            for dir_ in ["Fontbakery", "Diffenator", "Diffbrowsers",
+                         "plot_glyphs", "browser_previews"]:
+                self.assertTrue(dir_ in os.listdir(qa_out))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -38,7 +38,9 @@ def download_family_from_Google_Fonts(family, dst=None):
     )
     fonts_zip = ZipFile(download_file(url))
     if dst:
-        return fonts_from_zip(fonts_zip, dst)
+        fonts = fonts_from_zip(fonts_zip, dst)
+        # Remove static fonts if the family is a variable font
+        return [f for f in fonts if "static" not in f]
     return fonts_from_zip(fonts_zip)
 
 


### PR DESCRIPTION
This PR allows users to compare a family of variable fonts against another family of variable fonts. Comparisons are made between matching instances only.

When we release VFs with multiple axes, we'll need to rethink this approach.  No one sane will want to check hundreds of instances.

I still need to update GFRegression so users can select which instances they want to see. Atm it will display all matching instances in two sets of VFs. Unfortunately the Browserstack screenshot api has an image limit of ~10k vertical pixels. To work around this for static fonts, I send only 4 matching fonts at a time. I'll use the same approach for VFs but use instances instead.