### PR TITLE
qa: Group VF instances correctly

### DIFF
--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -187,7 +187,8 @@ class FontQA:
                      self.instances[k]['filename']) for k in self.matching_instances]
         font_groups = self.chunkify(sorted(fonts), 4)
         for group in font_groups:
-            dir_name = "_".join([i[0] for i in group])
+            styles = [i[0] for i in group]
+            dir_name = "_".join(styles)
             fonts_before = [i[1] for i in group]
             fonts_after = [i[2] for i in group]
             out = os.path.join(dst, dir_name)
@@ -198,10 +199,10 @@ class FontQA:
                 browsers=browsers_to_test,
             )
             diff_browsers.new_session(set(fonts_before), set(fonts_after))
-            diff_browsers.diff_view("waterfall")
+            diff_browsers.diff_view("waterfall", styles=styles)
             info = os.path.join(out, "info.json")
             json.dump(diff_browsers.stats, open(info, "w"))
-            diff_browsers.diff_view("glyphs_all", pt=16)
+            diff_browsers.diff_view("glyphs_all", pt=16, styles=styles)
 
     def fontbakery(self):
         logger.info("Running Fontbakery")
@@ -267,8 +268,8 @@ class FontQA:
                 gfr_is_local=False,
             )
             diff_browsers.new_session(font_group, font_group)
-            diff_browsers.diff_view("waterfall")
-            diff_browsers.diff_view("glyphs_all", pt=15)
+            diff_browsers.diff_view("waterfall", styles=name_group)
+            diff_browsers.diff_view("glyphs_all", styles=name_group, pt=15)
 
     def googlefonts_upgrade(self):
         self.fontbakery()

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -53,7 +53,7 @@ except ModuleNotFoundError:
         "dependencies. To install the dependencies, see the ReadMe, "
         "https://github.com/googlefonts/gftools#installation"))
 
-__version__ = "2.0.3"
+__version__ = "2.1.3"
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open('README.md') as f:
 
 setup(
     name="gftools",
-    version='0.3.5',
+    version='0.3.6',
     url='https://github.com/googlefonts/tools/',
     description='Google Fonts Tools is a set of command-line tools'
                 ' for testing font projects',


### PR DESCRIPTION
Previous implementation couldn't run groups of instances through diffbrowsers and browser-previews correctly. It created the necessary groups but every group would contain all VF instances.