### PR TITLE
fix-vertical-metrics: add optional output path

### DIFF
--- a/bin/gftools-fix-vertical-metrics.py
+++ b/bin/gftools-fix-vertical-metrics.py
@@ -258,6 +258,7 @@ parser.add_argument('--autofix', action="store_true",
                      help="Autofix font metrics")
 parser.add_argument('ttf_font', nargs='+', metavar='ttf_font',
                     help="Font file in OpenType (TTF/OTF) format")
+parser.add_argument("-o", "--out", help="Output fontfile path")
 
 
 def vmetrics(ttFonts):
@@ -327,7 +328,10 @@ def main():
       if options.linegaps_typo or options.linegaps_typo == 0:
         ttfont['OS/2'].sTypoLineGap = options.linegaps_typo
 
-      ttfont.save(f[:-4] + '.fix.ttf')
+      if options.out:
+        ttfont.save(options.out)
+      else:
+        ttfont.save(f[:-4] + '.fix.ttf')
 
   elif options.autofix:
     ttFonts = []


### PR DESCRIPTION
Current implementation prepends .fix to the file suffix e.g `FontFamily-Regular.fix.ttf`. This is messy to manipulate in bash since you have to resort to slicing.

If a user does't supply an optional output, the existing implementation is used. This will ensure we don't break existing scripts.