### PR TITLE
Temporary small fix on gftools-fix-weightclass.py 

### DIFF
--- a/bin/gftools-fix-weightclass.py
+++ b/bin/gftools-fix-weightclass.py
@@ -38,7 +38,7 @@ WEIGHTS = {
     "ThinItalic": 250,
     "ExtraLightItalic": 275,
     "LightItalic": 300,
-    "RegularItalic": 400,
+    "Italic": 400,
     "MediumItalic": 500,
     "SemiBoldItalic": 600,
     "BoldItalic": 700,

--- a/bin/gftools-fix-weightclass.py
+++ b/bin/gftools-fix-weightclass.py
@@ -34,7 +34,16 @@ WEIGHTS = {
     "SemiBold": 600,
     "Bold": 700,
     "ExtraBold": 800,
-    "Black": 900
+    "Black": 900,
+    "ThinItalic": 250,
+    "ExtraLightItalic": 275,
+    "LightItalic": 300,
+    "RegularItalic": 400,
+    "MediumItalic": 500,
+    "SemiBoldItalic": 600,
+    "BoldItalic": 700,
+    "ExtraBoldItalic": 800,
+    "BlackItalic": 900
 }
 
 
@@ -61,4 +70,3 @@ if __name__ == "__main__":
         print("Please include a path to a font")
     else:
         main(sys.argv[1])
-


### PR DESCRIPTION
I need this script to also fix weight class in OTF italic instances, so I made a raw and simple fix. Although it is probably not the cleanest way to do it. 

A nice update would be:

- [ ] work for style name build as: weight + any other style (italic, condensed…) 
- [ ] specify these values are for otf
- [ ] add accurate values for ttf and variable
