### PR TITLE
Update fix-weightClass and fix-vf-meta

### DIFF
--- a/bin/gftools-fix-vf-meta.py
+++ b/bin/gftools-fix-vf-meta.py
@@ -24,7 +24,7 @@ from fontTools.ttLib import TTFont
 import argparse
 
 
-WGHT_NAMES = {v:k for k,v in _KNOWN_WEIGHTS.items()}
+WGHT_NAMES = {v:k for k,v in _KNOWN_WEIGHTS.items() if k != "Hairline"}
 WGHT_NAMES[400] = "Regular"
 WGHT_NAMES[1000] = "ExtraBlack"
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open('README.md') as f:
 
 setup(
     name="gftools",
-    version='0.3.13',
+    version='0.3.14',
     url='https://github.com/googlefonts/tools/',
     description='Google Fonts Tools is a set of command-line tools'
                 ' for testing font projects',


### PR DESCRIPTION
Both scripts has issues with setting usWeightClass values correctly.

fix-vf-meta:
I remove the hairline style. Fixes #221 

fix-weightclass:
I've used the fontbakery.parse module. This script will now set the usWeightClass correctly for otfs, ttfs and vfs.