### PR TITLE
fix-isfixedpitch: fix crash when familyType == 0

### DIFF
--- a/bin/gftools-fix-isfixedpitch.py
+++ b/bin/gftools-fix-isfixedpitch.py
@@ -63,6 +63,7 @@ def fix_isFixedPitch(ttfont):
                   " Setting values to defaults (FamilyType = 2, Proportion = 9).")
             ttfont['OS/2'].panose.bFamilyType = 2
             ttfont['OS/2'].panose.bProportion = 9
+            expected = None
         else:
             expected = None
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open('README.md') as f:
 
 setup(
     name="gftools",
-    version='0.4.0',
+    version='0.4.1',
     url='https://github.com/googlefonts/tools/',
     description='Google Fonts Tools is a set of command-line tools'
                 ' for testing font projects',


### PR DESCRIPTION
Found by @rosawagner when working on Syne, https://gitlab.com/RosaWagner/syne-typeface/-/blob/master/fonts/ttf/SyneMono-Regular.ttf