### PR TITLE
Unpin Pillow - issues that justified pinning are now closed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         'absl-py',
         'glyphsLib',
         'PyGithub',
-        'pillow==7.0.0',
+        'pillow',
         'protobuf',
         'requests',
         'tabulate',


### PR DESCRIPTION
The issues mentioned for the pinning (https://github.com/python-pillow/Pillow/issues/4509 and https://github.com/python-pillow/Pillow/issues/4518) are now closed.