### PR TITLE
Add fix module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ install:
 
 script:
   - python ./Lib/gftools/tests/test_usage.py
+  - python ./Lib/gftools/tests/test_fix.py
   - mypy ./Lib/gftools/packager.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ install:
   - pip install .
 
 script:
-  - python ./Lib/gftools/tests/test_usage.py
-  - python ./Lib/gftools/tests/test_fix.py
+  - pytest ./Lib/gftools/tests/test_usage.py
+  - pytest ./Lib/gftools/tests/test_fix.py
   - mypy ./Lib/gftools/packager.py

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -1,0 +1,61 @@
+"""
+Functions to fix fonts so they conform to the Google Fonts
+specification
+https://github.com/googlefonts/gf-docs/tree/master/Spec
+"""
+from fontTools.ttLib import TTFont, newTable
+from fontTools.ttLib.tables import ttProgram
+
+
+def add_dummy_dsig(ttFont):
+    """Add a dummy dsig table to a font. Older versions of MS Word
+    require this table.
+
+    Args:
+        ttFont: a TTFont instance
+    """
+    newDSIG = ttLib.newTable("DSIG")
+    newDSIG.ulVersion = 1
+    newDSIG.usFlag = 0
+    newDSIG.usNumSigs = 0
+    newDSIG.signatureRecords = []
+    ttFont.tables["DSIG"] = newDSIG
+
+
+def fix_unhinted_font(ttFont):
+    """Improve the appearance of an unhinted font on Win platforms by:
+        - Overwriting the GASP table with a newtable that has a single
+          which range which is set to smooth.
+        - Overwriting the prep table with a new table that includes new
+          instructions.
+    
+    Args:
+        ttFont: a TTFont instance
+    """
+    gasp = newTable("gasp")
+    # Set GASP so all sizes are smooth
+    gasp.gaspRange = {0xFFFF: 15}
+
+    program = ttProgram.Program()
+    assembly = ["PUSHW[]", "511", "SCANCTRL[]", "PUSHB[]", "4", "SCANTYPE[]"]
+    program.fromAssembly(assembly)
+
+    prep = newTable("prep")
+    prep.program = program
+
+    ttFont["gasp"] = gasp
+    ttFont["prep"] = prep
+
+
+def fix_hinted_font(ttFont):
+    """Improve the appearance of a hinted font on Win platforms by enabling
+    the head table's flag 3
+
+    Args:
+        ttFont: a TTFont instance
+    """
+    head_flags = ttFont["head"].flags
+    if head_flags != head_flags | (1 << 3):
+        ttFont["head"].flags |= 1 << 3
+    else:
+        print("Skipping. Font already has bit 3 enabled")

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -229,9 +229,7 @@ def get_name_record(ttFont, nameID, fallbackID=None):
     if not record and fallbackID:
         record = name.getName(fallbackID, 3, 1, 0x409)
     if not record:
-        raise ValueError(
-            f"Cannot find record with nameID {nameID}"
-        )
+        raise ValueError(f"Cannot find record with nameID {nameID}")
     return record.toUnicode()
 
 
@@ -250,9 +248,7 @@ def fix_fvar_instances(ttFont):
     if not subfamily_name:
         raise ValueError("Name table is missing subFamily Name Record")
     is_italic = "italic" in nametable.getName(2, 3, 1, 0x409).toUnicode().lower()
-    is_roman_and_italic = any(
-        a for a in ("slnt", "ital") if a in default_axis_vals
-    )
+    is_roman_and_italic = any(a for a in ("slnt", "ital") if a in default_axis_vals)
 
     wght_axis = next((a for a in fvar.axes if a.axisTag == "wght"), None)
     wght_min = int(wght_axis.minValue)
@@ -261,7 +257,11 @@ def fix_fvar_instances(ttFont):
     def gen_instances(is_italic):
         results = []
         for wght_val in range(wght_min, wght_max + 100, 100):
-            name = WEIGHTS[wght_val] if not is_italic else f"{WEIGHTS[wght_val]} Italic".strip()
+            name = (
+                WEIGHTS[wght_val]
+                if not is_italic
+                else f"{WEIGHTS[wght_val]} Italic".strip()
+            )
             name = name.replace("Regular Italic", "Italic")
             if name == "":
                 name = "Regular"
@@ -301,9 +301,13 @@ def update_nametable(ttFont, family_name=None, style_name=None):
         platforms.add((rec.platformID, rec.platEncID, rec.langID))
     platforms_to_remove = platforms ^ set([(3, 1, 0x409)])
     if platforms_to_remove:
-        log.warning(f"Removing records which are not Win US English, {list(platforms_to_remove)}")
+        log.warning(
+            f"Removing records which are not Win US English, {list(platforms_to_remove)}"
+        )
         for platformID, platEncID, langID in platforms_to_remove:
-            nametable.removeNames(platformID=platformID, platEncID=platEncID, langID=langID)
+            nametable.removeNames(
+                platformID=platformID, platEncID=platEncID, langID=langID
+            )
 
     if not family_name:
         family_name = font_familyname(ttFont)
@@ -323,7 +327,9 @@ def update_nametable(ttFont, family_name=None, style_name=None):
         nameids[1] = f"{family_name} {family_name_suffix}".strip()
         nameids[2] = "Regular" if "Italic" not in tokens else "Italic"
 
-        typo_family_suffix = " ".join(t for t in tokens if t not in list(WEIGHT_NAMES) + ["Italic"])
+        typo_family_suffix = " ".join(
+            t for t in tokens if t not in list(WEIGHT_NAMES) + ["Italic"]
+        )
         nameids[16] = f"{family_name} {typo_family_suffix}".strip()
         typo_style = " ".join(t for t in tokens if t in list(WEIGHT_NAMES) + ["Italic"])
         nameids[17] = typo_style

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -165,18 +165,19 @@ def fix_fs_selection(ttFont):
         ttFont: a TTFont instance
     """
     stylename = font_stylename(ttFont)
+    tokens = set(stylename.split())
     fs_selection = ttFont["OS/2"].fsSelection
 
     # turn off all bits except for bit 7 (USE_TYPO_METRICS)
     fs_selection &= 0b10000000
 
-    if "Italic" in stylename:
-        fs_selection |= 0b1
-    if stylename in ["Bold", "Bold Italic"]:
-        fs_selection |= 0b100000
+    if "Italic" in tokens:
+        fs_selection |= (1 << 0)
+    if set(["Bold"]) & tokens:
+        fs_selection |= (1 << 5)
     # enable Regular bit for all other styles
-    if stylename not in ["Bold", "Bold Italic"] and "Italic" not in stylename:
-        fs_selection |= 0b1000000
+    if not tokens & set(["Bold", "Italic"]):
+        fs_selection |= (1 << 6)
     ttFont["OS/2"].fsSelection = fs_selection
 
 
@@ -187,11 +188,12 @@ def fix_mac_style(ttFont):
         ttFont: a TTFont instance
     """
     stylename = font_stylename(ttFont)
-    mac_style = 0b0
-    if "Italic" in stylename:
-        mac_style |= 0b10
-    if stylename in ["Bold", "Bold Italic"]:
-        mac_style |= 0b1
+    tokens = set(stylename.split())
+    mac_style = 0
+    if "Italic" in tokens:
+        mac_style |= (1 << 1)
+    if "Bold" in tokens:
+        mac_style |= (1 << 0)
     ttFont["head"].macStyle = mac_style
 
 

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -7,7 +7,14 @@ from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables import ttProgram
 
 
-__all__ = ["add_dummy_dsig", "fix_unhinted_font", "fix_hinted_font"]
+__all__ = [
+    "add_dummy_dsig",
+    "fix_unhinted_font",
+    "fix_hinted_font",
+    "fix_fs_selection",
+    "fix_mac_style",
+    "font_stylename",
+]
 
 
 def add_dummy_dsig(ttFont):
@@ -62,3 +69,57 @@ def fix_hinted_font(ttFont):
         ttFont["head"].flags |= 1 << 3
     else:
         print("Skipping. Font already has bit 3 enabled")
+
+
+def fix_fs_selection(ttFont):
+    """Fix the OS/2 table's fsSelection
+
+    Args:
+        ttFont: a TTFont instance
+    """
+    stylename = font_stylename(ttFont)
+    fs_selection = ttFont["OS/2"].fsSelection
+
+    # turn off all bits except for bit 7 (USE_TYPO_METRICS)
+    fs_selection &= 0b10000000
+
+    if "Italic" in stylename:
+        fs_selection |= 0b1
+    if stylename in ["Bold", "Bold Italic"]:
+        fs_selection |= 0b100000
+    # enable Regular bit for all other styles
+    if stylename not in ["Bold", "Bold Italic"] and "Italic" not in stylename:
+        fs_selection |= 0b1000000
+    ttFont["OS/2"].fsSelection = fs_selection
+
+
+def fix_mac_style(ttFont):
+    """Fix the head table's macStyle
+
+    Args:
+        ttFont: a TTFont instance
+    """
+    stylename = font_stylename(ttFont)
+    mac_style = 0b0
+    if "Italic" in stylename:
+        mac_style |= 0b10
+    if stylename in ["Bold", "Bold Italic"]:
+        mac_style |= 0b1
+    ttFont["head"].macStyle = mac_style
+
+
+def font_stylename(ttFont):
+    """Get a font's stylename using the name table. Since our fonts use the
+    RIBBI naming model, use the Typographic SubFamily Name (NAmeID 17) if it
+    exists, otherwise use the SubFamily Name (NameID 2)
+
+    Args:
+        ttFont: a TTFont instance
+    """
+    name = ttFont["name"]
+    style_record = name.getName(2, 3, 1, 0x409) or name.getName(17, 3, 1, 0x409)
+    if not style_record:
+        raise ValueError(
+            "Cannot find stylename since NameID 2 and NameID 16 are missing"
+        )
+    return style_record.toUnicode()

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -17,7 +17,7 @@ def add_dummy_dsig(ttFont):
     Args:
         ttFont: a TTFont instance
     """
-    newDSIG = ttLib.newTable("DSIG")
+    newDSIG = newTable("DSIG")
     newDSIG.ulVersion = 1
     newDSIG.usFlag = 0
     newDSIG.usNumSigs = 0

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -433,5 +433,5 @@ def fix_nametable(ttFont):
         # is merged.
         return
     family_name = font_familyname(ttFont)
-    style_name = font_stylename(font)
+    style_name = font_stylename(ttFont)
     update_nametable(ttFont, family_name, style_name)

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -7,6 +7,9 @@ from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables import ttProgram
 
 
+__all__ = ["add_dummy_dsig", "fix_unhinted_font", "fix_hinted_font"]
+
+
 def add_dummy_dsig(ttFont):
     """Add a dummy dsig table to a font. Older versions of MS Word
     require this table.

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -13,6 +13,7 @@ __all__ = [
     "add_dummy_dsig",
     "fix_unhinted_font",
     "fix_hinted_font",
+    "fix_fs_type",
     "fix_fs_selection",
     "fix_mac_style",
     "font_stylename",
@@ -78,6 +79,15 @@ def fix_hinted_font(ttFont):
         ttFont["head"].flags |= 1 << 3
     else:
         print("Skipping. Font already has bit 3 enabled")
+
+
+def fix_fs_type(ttFont):
+    """Set the OS/2 table's fsType flag to 0 (Installable embedding)
+
+    Args:
+        ttFont: a TTFont instance
+    """
+    ttFont['OS/2'].fsType = 0
 
 
 def fix_fs_selection(ttFont):

--- a/Lib/gftools/tests/test_fix.py
+++ b/Lib/gftools/tests/test_fix.py
@@ -56,32 +56,37 @@ def test_fix_fs_type(static_font):
     assert static_font["OS/2"].fsType == 0
 
 
+# Taken from https://github.com/googlefonts/gf-docs/tree/master/Spec#supported-styles
+STYLE_HEADERS = "style, weight_class, fs_selection, mac_style"
+STYLE_TABLE = [
+    ("Thin", 100, (1 << 6), (0 << 0)),
+    ("ExtraLight", 200, (1 << 6), (0 << 0)),
+    ("Light", 300, (1 << 6), (0 << 0)),
+    ("Regular", 400, (1 << 6), (0 << 0)),
+    ("Medium", 500, (1 << 6), (0 << 0)),
+    ("SemiBold", 600, (1 << 6), (0 << 0)),
+    ("Bold", 700, (1 << 5), (1 << 0)),
+    ("ExtraBold", 800, (1 << 6), (0 << 0)),
+    ("Black", 900, (1 << 6), (0 << 0)),
+    ("Thin Italic", 100, (1 << 0), (1 << 1)),
+    ("ExtraLight Italic", 200, (1 << 0), (1 << 1)),
+    ("Light Italic", 300, (1 << 0), (1 << 1)),
+    ("Italic", 400, (1 << 0), (1 << 1)),
+    ("Medium Italic", 500, (1 << 0), (1 << 1)),
+    ("SemiBold Italic", 600, (1 << 0), (1 << 1)),
+    ("Bold Italic", 700, (1 << 0) | (1 << 5), (1 << 0) | (1 << 1)),
+    ("ExtraBold Italic", 800, (1 << 0), (1 << 1)),
+    ("Black Italic", 900, (1 << 0), (1 << 1)),
+    # Variable fonts may have tokens other than weight and italic in their names
+    ("SemiCondensed Bold Italic", 700, (1 << 0) | (1 << 5), (1 << 0) | (1 << 1)),
+    ("12pt Italic", 400, (1 << 0), (1 << 1)),
+]
+
 @pytest.mark.parametrize(
-    "style, value",
-    [
-        ("Thin", 100),
-        ("ExtraLight", 200),
-        ("Light", 300),
-        ("Regular", 400),
-        ("Medium", 500),
-        ("SemiBold", 600),
-        ("Bold", 700),
-        ("ExtraBold", 800),
-        ("Black", 900),
-        ("Thin Italic", 100),
-        ("ExtraLight Italic", 200),
-        ("Light Italic", 300),
-        ("Italic", 400),
-        ("Medium Italic", 500),
-        ("SemiBold Italic", 600),
-        ("Bold Italic", 700),
-        ("ExtraBold Italic", 800),
-        ("Black Italic", 900),
-        ("SemiCondensed Bold Italic", 700),
-        ("12pt Italic", 400),
-    ],
+    STYLE_HEADERS,
+    STYLE_TABLE
 )
-def test_weight_class(static_font, style, value):
+def test_weight_class(static_font, style, weight_class, fs_selection, mac_style):
     name = static_font["name"]
     if style in ("Regular", "Italic", "Bold", "Bold Italic"):
         name.setName(style, 2, 3, 1, 0x409)
@@ -92,71 +97,29 @@ def test_weight_class(static_font, style, value):
             name.setName("Regular", 2, 3, 1, 0x409)
         name.setName(style, 17, 3, 1, 0x409)
     fix_weight_class(static_font)
-    assert static_font["OS/2"].usWeightClass == value
+    assert static_font["OS/2"].usWeightClass == weight_class
 
 
 @pytest.mark.parametrize(
-    "style, value",
-    [
-        ("Thin", (1 << 6)),
-        ("ExtraLight", (1 << 6)),
-        ("Light", (1 << 6)),
-        ("Regular", (1 << 6)),
-        ("Medium", (1 << 6)),
-        ("SemiBold", (1 << 6)),
-        ("Bold", (1 << 5)),
-        ("ExtraBold", (1 << 6)),
-        ("Black", (1 << 6)),
-        ("Thin Italic", (1 << 0)),
-        ("ExtraLight Italic", (1 << 0)),
-        ("Light Italic", (1 << 0)),
-        ("Italic", (1 << 0)),
-        ("Medium Italic", (1 << 0)),
-        ("SemiBold Italic", (1 << 0)),
-        ("Bold Italic", (1 << 0) | (1 << 5)),
-        ("ExtraBold Italic", (1 << 0)),
-        ("Black Italic", (1 << 0)),
-        ("SemiCondensed Bold Italic", (1 << 0) | (1 << 5)),
-        ("12pt Italic", (1 << 0)),
-    ],
+    STYLE_HEADERS,
+    STYLE_TABLE
 )
-def test_fs_selection(static_font, style, value):
+def test_fs_selection(static_font, style, weight_class, fs_selection, mac_style):
     # disable fsSelection bits above 6
     for i in range(7, 12):
         static_font["OS/2"].fsSelection &= ~(1 << i)
     name = static_font["name"]
     name.setName(style, 17, 3, 1, 0x409)
     fix_fs_selection(static_font)
-    assert static_font["OS/2"].fsSelection == value
+    assert static_font["OS/2"].fsSelection == fs_selection
 
 
 @pytest.mark.parametrize(
-    "style, value",
-    [
-        ("Thin", (0 << 0)),
-        ("ExtraLight", (0 << 0)),
-        ("Light", (0 << 0)),
-        ("Regular", (0 << 0)),
-        ("Medium", (0 << 0)),
-        ("SemiBold", (0 << 0)),
-        ("Bold", (1 << 0)),
-        ("ExtraBold", (0 << 0)),
-        ("Black", (0 << 0)),
-        ("Thin Italic", (1 << 1)),
-        ("ExtraLight Italic", (1 << 1)),
-        ("Light Italic", (1 << 1)),
-        ("Italic", (1 << 1)),
-        ("Medium Italic", (1 << 1)),
-        ("SemiBold Italic", (1 << 1)),
-        ("Bold Italic", (1 << 0) | (1 << 1)),
-        ("ExtraBold Italic", (1 << 1)),
-        ("Black Italic", (1 << 1)),
-        ("SemiCondensed Bold Italic", (1 << 0) | (1 << 1)),
-        ("12pt Italic", (1 << 1)),
-    ],
+    STYLE_HEADERS,
+    STYLE_TABLE
 )
-def test_fix_mac_style(static_font, style, value):
+def test_fix_mac_style(static_font, style, weight_class, fs_selection, mac_style):
     name = static_font["name"]
     name.setName(style, 17, 3, 1, 0x409)
     fix_mac_style(static_font)
-    assert static_font["head"].macStyle == value
+    assert static_font["head"].macStyle == mac_style

--- a/Lib/gftools/tests/test_fix.py
+++ b/Lib/gftools/tests/test_fix.py
@@ -123,3 +123,43 @@ def test_fix_mac_style(static_font, style, weight_class, fs_selection, mac_style
     name.setName(style, 17, 3, 1, 0x409)
     fix_mac_style(static_font)
     assert static_font["head"].macStyle == mac_style
+
+
+STYLENAME_HEADERS = "family_name, style, id1, id2, id16, id17"
+STYLENAME_TABLE = [
+    # Roman
+    ("Test Family", "Thin", "Test Family Thin", "Regular", "Test Family", "Thin"),
+    ("Test Family", "ExtraLight", "Test Family ExtraLight", "Regular", "Test Family", "ExtraLight"),
+    ("Test Family", "Light", "Test Family Light", "Regular", "Test Family", "Light"),
+    ("Test Family", "Regular", "Test Family", "Regular", "", ""),
+    ("Test Family", "Medium", "Test Family Medium", "Regular", "Test Family", "Medium"),
+    ("Test Family", "SemiBold", "Test Family SemiBold", "Regular", "Test Family", "SemiBold"),
+    ("Test Family", "Bold", "Test Family", "Bold", "", ""),
+    ("Test Family", "ExtraBold", "Test Family ExtraBold", "Regular", "Test Family", "ExtraBold"),
+    # Italics
+    ("Test Family", "Thin Italic", "Test Family Thin", "Italic", "Test Family", "Thin Italic"),
+    ("Test Family", "ExtraLight Italic", "Test Family ExtraLight", "Italic", "Test Family", "ExtraLight Italic"),
+    ("Test Family", "Light Italic", "Test Family Light", "Italic", "Test Family", "Light Italic"),
+    ("Test Family", "Italic", "Test Family", "Italic", "", ""),
+    ("Test Family", "Medium Italic", "Test Family Medium", "Italic", "Test Family", "Medium Italic"),
+    ("Test Family", "SemiBold Italic", "Test Family SemiBold", "Italic", "Test Family", "SemiBold Italic"),
+    ("Test Family", "Bold Italic", "Test Family", "Bold Italic", "", ""),
+    ("Test Family", "ExtraBold Italic", "Test Family ExtraBold", "Italic", "Test Family", "ExtraBold Italic"),
+    ("Test Family", "Black Italic", "Test Family Black", "Italic", "Test Family", "Black Italic"),
+    ("Test Family", "Black", "Test Family Black", "Regular", "Test Family", "Black"),
+]
+@pytest.mark.parametrize(
+    STYLENAME_HEADERS,
+    STYLENAME_TABLE
+)
+def test_update_nametable(static_font, family_name, style, id1, id2, id16, id17):
+    update_nametable(static_font, family_name, style)
+    nametable = static_font["name"]
+    assert nametable.getName(1, 3, 1, 0x409).toUnicode() == id1
+    assert nametable.getName(2, 3, 1, 0x409).toUnicode() == id2
+    if id16 and id17:
+        assert nametable.getName(16, 3, 1, 0x409).toUnicode() == id16
+        assert nametable.getName(17, 3, 1, 0x409).toUnicode() == id17
+
+
+# TODO test fix_nametable once https://github.com/fonttools/fonttools/pull/2078 is merged

--- a/Lib/gftools/tests/test_fix.py
+++ b/Lib/gftools/tests/test_fix.py
@@ -1,0 +1,162 @@
+from fontTools.ttLib import newTable, TTFont
+from gftools.fix import *
+import pytest
+import os
+
+@pytest.fixture
+def static_font():
+    f = TTFont(os.path.join("data", "test", "Lora-Regular.ttf"))
+    return f
+
+
+def test_remove_tables(static_font):
+    # Test removing a table which is part of UNWANTED_TABLES
+    tsi1_tbl = newTable("TSI1")
+    static_font["TSI1"] = tsi1_tbl
+    assert "TSI1" in static_font
+
+    tsi2_tbl = newTable("TSI2")
+    static_font["TSI2"] = tsi2_tbl
+    remove_tables(static_font, ["TSI1", "TSI2"])
+    assert "TSI1" not in static_font
+    assert "TSI2" not in static_font
+
+    # Test removing a table which is essential
+    remove_tables(static_font, ["glyf"])
+    assert "glyf" in static_font
+
+
+def test_add_dummy_dsig(static_font):
+    assert "DSIG" not in static_font
+    add_dummy_dsig(static_font)
+    assert "DSIG" in static_font
+
+
+def test_fix_hinted_font(static_font):
+    static_font["head"].flags &= ~(1 << 3)
+    assert static_font["head"].flags & (1 << 3) != 8
+    fix_hinted_font(static_font)
+    assert static_font["head"].flags & (1 << 3) == 8
+
+
+def test_fix_unhinted_font(static_font):
+    for tbl in ("prep", "gasp"):
+        if tbl in static_font:
+            del static_font[tbl]
+
+    fix_unhinted_font(static_font)
+    assert static_font["gasp"].gaspRange == {65535: 15}
+    assert "prep" in static_font
+
+
+def test_fix_fs_type(static_font):
+    static_font["OS/2"].fsType = 1
+    assert static_font["OS/2"].fsType == 1
+    fix_fs_type(static_font)
+    assert static_font["OS/2"].fsType == 0
+
+
+@pytest.mark.parametrize(
+    "style, value",
+    [
+        ("Thin", 100),
+        ("ExtraLight", 200),
+        ("Light", 300),
+        ("Regular", 400),
+        ("Medium", 500),
+        ("SemiBold", 600),
+        ("Bold", 700),
+        ("ExtraBold", 800),
+        ("Black", 900),
+        ("Thin Italic", 100),
+        ("ExtraLight Italic", 200),
+        ("Light Italic", 300),
+        ("Italic", 400),
+        ("Medium Italic", 500),
+        ("SemiBold Italic", 600),
+        ("Bold Italic", 700),
+        ("ExtraBold Italic", 800),
+        ("Black Italic", 900),
+        ("SemiCondensed Bold Italic", 700),
+        ("12pt Italic", 400),
+    ],
+)
+def test_weight_class(static_font, style, value):
+    name = static_font["name"]
+    if style in ("Regular", "Italic", "Bold", "Bold Italic"):
+        name.setName(style, 2, 3, 1, 0x409)
+    else:
+        if "Italic" in style:
+            name.setName("Italic", 2, 3, 1, 0x409)
+        else:
+            name.setName("Regular", 2, 3, 1, 0x409)
+        name.setName(style, 17, 3, 1, 0x409)
+    fix_weight_class(static_font)
+    assert static_font["OS/2"].usWeightClass == value
+
+
+@pytest.mark.parametrize(
+    "style, value",
+    [
+        ("Thin", (1 << 6)),
+        ("ExtraLight", (1 << 6)),
+        ("Light", (1 << 6)),
+        ("Regular", (1 << 6)),
+        ("Medium", (1 << 6)),
+        ("SemiBold", (1 << 6)),
+        ("Bold", (1 << 5)),
+        ("ExtraBold", (1 << 6)),
+        ("Black", (1 << 6)),
+        ("Thin Italic", (1 << 0)),
+        ("ExtraLight Italic", (1 << 0)),
+        ("Light Italic", (1 << 0)),
+        ("Italic", (1 << 0)),
+        ("Medium Italic", (1 << 0)),
+        ("SemiBold Italic", (1 << 0)),
+        ("Bold Italic", (1 << 0) | (1 << 5)),
+        ("ExtraBold Italic", (1 << 0)),
+        ("Black Italic", (1 << 0)),
+        ("SemiCondensed Bold Italic", (1 << 0) | (1 << 5)),
+        ("12pt Italic", (1 << 0)),
+    ],
+)
+def test_fs_selection(static_font, style, value):
+    # disable fsSelection bits above 6
+    for i in range(7, 12):
+        static_font["OS/2"].fsSelection &= ~(1 << i)
+    name = static_font["name"]
+    name.setName(style, 17, 3, 1, 0x409)
+    fix_fs_selection(static_font)
+    assert static_font["OS/2"].fsSelection == value
+
+
+@pytest.mark.parametrize(
+    "style, value",
+    [
+        ("Thin", (0 << 0)),
+        ("ExtraLight", (0 << 0)),
+        ("Light", (0 << 0)),
+        ("Regular", (0 << 0)),
+        ("Medium", (0 << 0)),
+        ("SemiBold", (0 << 0)),
+        ("Bold", (1 << 0)),
+        ("ExtraBold", (0 << 0)),
+        ("Black", (0 << 0)),
+        ("Thin Italic", (1 << 1)),
+        ("ExtraLight Italic", (1 << 1)),
+        ("Light Italic", (1 << 1)),
+        ("Italic", (1 << 1)),
+        ("Medium Italic", (1 << 1)),
+        ("SemiBold Italic", (1 << 1)),
+        ("Bold Italic", (1 << 0) | (1 << 1)),
+        ("ExtraBold Italic", (1 << 1)),
+        ("Black Italic", (1 << 1)),
+        ("SemiCondensed Bold Italic", (1 << 0) | (1 << 1)),
+        ("12pt Italic", (1 << 1)),
+    ],
+)
+def test_fix_mac_style(static_font, style, value):
+    name = static_font["name"]
+    name.setName(style, 17, 3, 1, 0x409)
+    fix_mac_style(static_font)
+    assert static_font["head"].macStyle == value

--- a/bin/gftools-fix-dsig.py
+++ b/bin/gftools-fix-dsig.py
@@ -20,6 +20,8 @@ from __future__ import print_function, unicode_literals
 import argparse
 import os
 from fontTools import ttLib
+from gftools.fix import add_dummy_dsig
+
 
 description = 'Fixes TTF to have a dummy DSIG table'
 parser = argparse.ArgumentParser(description=description)
@@ -63,7 +65,7 @@ def main():
               "signature (DSIG)".format(path))
 
     if write_DSIG:
-      set_empty_dsig(font)
+      add_dummy_dsig(font)
       font.save(path)
 
       if not args.force:

--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+gftools fix-font
+
+Update a font so it conforms to the Google Fonts specification
+https://github.com/googlefonts/gf-docs/tree/master/Spec
+"""
+import argparse
+from fontTools.ttLib import TTFont
+from gftools.fix import *
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("font", help="Path to font")
+    parser.add_argument("-o", "--out", help="Output path for fixed font")
+    args = parser.parse_args()
+
+    font = TTFont(args.font)
+
+    if "DSIG" not in font:
+        add_dummy_dsig(font)
+
+    if "fpgm" in font:
+        fix_hinted_font(font)
+    else:
+        fix_unhinted_font(font)
+
+    # TODO (Marc F) fsSelection, macStyle, usWeightClass, VF instances...
+
+    if args.out:
+        font.save(args.out)
+    else:
+        font.save(font.reader.file.name + ".fix")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -32,15 +32,17 @@ def main():
         fix_unhinted_font(font)
 
     if "fvar" in font:
-        remove_tables(font)
+        remove_tables(font, ["MVAR"])
 
     if args.hotfix:
         log.warning("Hotfixing fonts. Please consider fixing the source files instead")
+        remove_tables(font)
         fix_nametable(font)
         fix_fs_type(font)
         fix_fs_selection(font)
         fix_mac_style(font)
         fix_weight_class(font)
+        # TODO inherit vertical metrics if font exists on Google Fonts
 
         if "fvar" in font:
             fix_fvar_instances(font)

--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -6,27 +6,44 @@ Update a font so it conforms to the Google Fonts specification
 https://github.com/googlefonts/gf-docs/tree/master/Spec
 """
 import argparse
+import logging
 from fontTools.ttLib import TTFont
 from gftools.fix import *
+
+
+log = logging.getLogger(__name__)
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("font", help="Path to font")
     parser.add_argument("-o", "--out", help="Output path for fixed font")
+    parser.add_argument("--hotfix", action="store_true", help="Hotfix fonts.")
     args = parser.parse_args()
 
     font = TTFont(args.font)
 
     if "DSIG" not in font:
+        log.info("Adding dummy dsig")
         add_dummy_dsig(font)
 
     if "fpgm" in font:
+        log.info("Improving hinted render quality")
         fix_hinted_font(font)
     else:
+        log.info("Improving unhinted render quality")
         fix_unhinted_font(font)
 
-    # TODO (Marc F) fsSelection, macStyle, usWeightClass, VF instances...
+    if args.hotfix:
+        log.warning("Hotfixing fonts. Please consider fixing the source files instead")
+        log.info("Fixing fsSelection")
+        fix_fs_selection(font)
+        log.info("Fixing macStyle")
+        fix_mac_style(font)
+        # TODO usWeightClass, nametable...
+
+        if "fvar" in font:
+            fix_fvar_instances(font)
 
     if args.out:
         font.save(args.out)

--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -4,6 +4,13 @@ gftools fix-font
 
 Update a font so it conforms to the Google Fonts specification
 https://github.com/googlefonts/gf-docs/tree/master/Spec
+
+Usage:
+
+gftools fix-font font.ttf
+
+# Fix font issues that should be fixed in the source files
+gftools fix-font font.ttf --include-source-fixes
 """
 import argparse
 import logging
@@ -18,7 +25,11 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("font", help="Path to font")
     parser.add_argument("-o", "--out", help="Output path for fixed font")
-    parser.add_argument("--hotfix", action="store_true", help="Hotfix fonts.")
+    parser.add_argument(
+        "--include-source-fixes",
+        action="store_true",
+        help="Fix font issues that should be fixed in the source files."
+    )
     args = parser.parse_args()
 
     font = TTFont(args.font)
@@ -34,8 +45,11 @@ def main():
     if "fvar" in font:
         remove_tables(font, ["MVAR"])
 
-    if args.hotfix:
-        log.warning("Hotfixing fonts. Please consider fixing the source files instead")
+    if args.include_source_fixes:
+        log.warning(
+            "include-source-fixes is enabled. Please consider fixing the "
+            "source files instead."
+        )
         remove_tables(font)
         fix_nametable(font)
         fix_fs_type(font)
@@ -46,7 +60,8 @@ def main():
 
         if "fvar" in font:
             fix_fvar_instances(font)
-            # TODO (Marc F) add gen-stat
+            # TODO (Marc F) add gen-stat once merged 
+            # https://github.com/googlefonts/gftools/pull/263
 
     if args.out:
         font.save(args.out)

--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -36,6 +36,7 @@ def main():
         fix_fs_type(font)
         fix_fs_selection(font)
         fix_mac_style(font)
+        fix_weight_class(font)
         # TODO usWeightClass, nametable...
 
         if "fvar" in font:

--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -36,6 +36,7 @@ def main():
 
     if args.hotfix:
         log.warning("Hotfixing fonts. Please consider fixing the source files instead")
+        fix_nametable(font)
         fix_fs_type(font)
         fix_fs_selection(font)
         fix_mac_style(font)

--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -36,6 +36,8 @@ def main():
 
     if args.hotfix:
         log.warning("Hotfixing fonts. Please consider fixing the source files instead")
+        log.info("Fixing fsType")
+        fix_fs_type(font)
         log.info("Fixing fsSelection")
         fix_fs_selection(font)
         log.info("Fixing macStyle")

--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -31,16 +31,19 @@ def main():
     else:
         fix_unhinted_font(font)
 
+    if "fvar" in font:
+        remove_tables(font)
+
     if args.hotfix:
         log.warning("Hotfixing fonts. Please consider fixing the source files instead")
         fix_fs_type(font)
         fix_fs_selection(font)
         fix_mac_style(font)
         fix_weight_class(font)
-        # TODO usWeightClass, nametable...
 
         if "fvar" in font:
             fix_fvar_instances(font)
+            # TODO (Marc F) add gen-stat
 
     if args.out:
         font.save(args.out)

--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -24,23 +24,17 @@ def main():
     font = TTFont(args.font)
 
     if "DSIG" not in font:
-        log.info("Adding dummy dsig")
         add_dummy_dsig(font)
 
     if "fpgm" in font:
-        log.info("Improving hinted render quality")
         fix_hinted_font(font)
     else:
-        log.info("Improving unhinted render quality")
         fix_unhinted_font(font)
 
     if args.hotfix:
         log.warning("Hotfixing fonts. Please consider fixing the source files instead")
-        log.info("Fixing fsType")
         fix_fs_type(font)
-        log.info("Fixing fsSelection")
         fix_fs_selection(font)
-        log.info("Fixing macStyle")
         fix_mac_style(font)
         # TODO usWeightClass, nametable...
 

--- a/bin/gftools-fix-fstype.py
+++ b/bin/gftools-fix-fstype.py
@@ -27,6 +27,7 @@ from __future__ import print_function
 from argparse import (ArgumentParser,
                       RawTextHelpFormatter)
 from fontTools.ttLib import TTFont
+from gftools.fix import fix_fs_type
 parser = ArgumentParser(description=__doc__,
                         formatter_class=RawTextHelpFormatter)
 parser.add_argument('fonts',
@@ -40,7 +41,7 @@ def main():
     font = TTFont(font_path)
 
     if font['OS/2'].fsType != 0:
-      font['OS/2'].fsType = 0
+      fix_fs_type(font)
       font.save(font_path + '.fix')
       print('font saved %s.fix' % font_path)
     else:

--- a/bin/gftools-fix-hinting.py
+++ b/bin/gftools-fix-hinting.py
@@ -29,6 +29,7 @@ Bit 3 = Force ppem to integer values for all internal scaler math;
 from __future__ import print_function, unicode_literals
 import argparse
 from fontTools.ttLib import TTFont
+from gftools.fix import fix_hinted_font
 
 
 def font_has_hinting(font):
@@ -42,12 +43,7 @@ def main():
 
     font = TTFont(args.font)
     if font_has_hinting(font):
-        head_flags = font['head'].flags
-        if head_flags != head_flags | (1 << 3):
-            font['head'].flags |= (1 << 3)
-            font.save(args.font + ".fix")
-        else:
-            print("Skipping. Font already has bit 3 enabled")
+        fix_hinted_font(font)
     else:
         print("Skipping. Font is not hinted")
 

--- a/bin/gftools-fix-nonhinting.py
+++ b/bin/gftools-fix-nonhinting.py
@@ -51,6 +51,9 @@ from argparse import (ArgumentParser,
 import os
 from fontTools import ttLib
 from fontTools.ttLib.tables import ttProgram
+from gftools.fix import fix_unhinted_font
+
+
 parser = ArgumentParser(description=__doc__,
                         formatter_class=RawTextHelpFormatter)
 parser.add_argument('fontfile_in',
@@ -87,33 +90,7 @@ def main():
   else:
     print("PREP wasn't there")
 
-  # Create a new GASP table
-  gasp = ttLib.newTable("gasp")
-
-  # Set GASP to the magic number
-  gasp.gaspRange = {0xFFFF: 15}
-
-  # Create a new hinting program
-  program = ttProgram.Program()
-
-  assembly = ['PUSHW[]',
-              '511',
-              'SCANCTRL[]',
-              'PUSHB[]',
-              '4',
-              'SCANTYPE[]']
-  program.fromAssembly(assembly)
-
-  # Create a new PREP table
-  prep = ttLib.newTable("prep")
-
-  # Insert the magic program into it
-  prep.program = program
-
-  # Add the tables to the font, replacing existing ones
-  font["gasp"] = gasp
-  font["prep"] = prep
-
+  fix_unhinted_font(font)
   # Print the Gasp table
   print("GASP now: ", font["gasp"].gaspRange)
 

--- a/bin/gftools-fix-weightclass.py
+++ b/bin/gftools-fix-weightclass.py
@@ -21,6 +21,7 @@ the correct value.
 from __future__ import print_function
 from fontTools.ttLib import TTFont
 from fontbakery.parse import style_parse
+from gftools.fix import fix_weight_class
 import sys
 import os
 
@@ -28,25 +29,9 @@ import os
 def main(font_path):
     filename = os.path.basename(font_path)
     font = TTFont(font_path)
-    desired_style = style_parse(font)
     current_weight_class = font["OS/2"].usWeightClass
-    updated = False
-    if current_weight_class != desired_style.usWeightClass:
-        print(f"{filename}: Updating weightClass to {desired_style.usWeightClass}")
-        font['OS/2'].usWeightClass = desired_style.usWeightClass
-        updated = True
-    # If static otf, update Thin and ExtraLight
-    # TODO (M Foley) fontbakery's style_parse should do this
-    if "CFF " in font and 'fvar' not in font:
-        if desired_style.usWeightClass == 100:
-            print(f"{filename}: Updating weightClass to {250}")
-            font['OS/2'].usWeightClass = 250
-            updated = True
-        elif desired_style.usWeightClass == 200:
-            print(f"{filename}: Updating weightClass to {275}")
-            font['OS/2'].usWeightClass = 275
-            updated = True
-    if updated:
+    fix_weight_class(font)
+    if current_weight_class != font["OS/2"].usWeightClass:
         font.save(font.reader.file.name + ".fix")
     else:
         print("{}: Skipping. Current WeightClass is correct".format(filename))


### PR DESCRIPTION
We have a collection of fix scripts which contain useful snippets of code that should reside in their own module imo. By converting these snippets into functions, we'll get better reuse. There's also a lot of duplication so I'd like to cut down on this.

My end goal is to keep the individual fix scripts (without changing their apis) but I also just want a single `gftools fix-font` script which should do everything.

@alerque are you opposed to this idea?