### PR TITLE
Add GH Action GitHub + PyPI release automation on git version tag pushes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    tags:
+      - "v*" # Push events to matching `v*` version srings. e.g. v1.0, v20.15.10
+
+name: Create and Publish Release
+
+jobs:
+  build:
+    name: Create and Publish Release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install release dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools wheel twine
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: |
+            Please see the root of the repository for the CHANGELOG.md
+          draft: false
+          prerelease: false
+      - name: Build and publish to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,9 +26,6 @@ jobs:
         id: release_notes
         run: |
           CHANGELOG=$(git tag -l --format='%(contents)' ${{ github.ref }})
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
           echo "::set-output name=changelog::$CHANGELOG"
       - name: Create GitHub release
         id: create_release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,15 +31,7 @@ jobs:
           # https://github.com/actions/checkout/issues/290
           git fetch --tags --force
           TAG_NAME=${GITHUB_REF/refs\/tags\//}
-          CHANGELOG=$(git tag -l --format='%(contents)' $TAG_NAME)
-          # we have to escape all new line characters and carriage
-          # returns before passing them into set-output otherwise the
-          # body content of the release will only contain the first line
-          # https://github.com/actions/create-release/issues/38#issuecomment-640072234
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
-          echo "::set-output name=changelog::$CHANGELOG"
+          echo "$(git tag -l --format='%(contents)' $TAG_NAME)" > CHANGELOG.md
 
       - name: Create GitHub release
         id: create_release
@@ -51,10 +43,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          # To set the body arg, we fetch the changelog variable we created
-          # in the previous step. Implementation is based on
-          # the third example in https://github.com/actions/create-release/pull/11
-          body: ${{ steps.release_notes.outputs.changelog }}
+          body_path: CHANGELOG.md
           draft: false
           prerelease: false
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,6 +22,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools wheel twine
+      - name: Get release notes
+        id: release_notes
+        run: |
+          CHANGELOG=$(git tag -l --format='%(contents)' ${{ github.ref }})
+          CHANGELOG="${CHANGELOG//'%'/'%25'}"
+          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+          echo "::set-output name=changelog::$CHANGELOG"
       - name: Create GitHub release
         id: create_release
         uses: actions/create-release@v1
@@ -30,8 +38,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body: |
-            Please see the root of the repository for the CHANGELOG.md
+          body: ${{ steps.release_notes.outputs.changelog }}
           draft: false
           prerelease: false
       - name: Build and publish to PyPI

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,44 +9,55 @@ jobs:
   build:
     name: Create and Publish Release
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9]
+
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          fetch-depth: 0
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.x'
+
       - name: Install release dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools wheel twine
+
       - name: Get release notes
         id: release_notes
         run: |
+          # By default, GH Actions checkout will only fetch a single commit.
+          # For us to extract the release notes, we need to fetch the tags
+          # and tag annotations as well.
+          # https://github.com/actions/checkout/issues/290
           git fetch --tags --force
-          GITHUB_REF=${{ github.ref }}
           TAG_NAME=${GITHUB_REF/refs\/tags\//}
-          echo "Got tag: $TAG_NAME"
           CHANGELOG=$(git tag -l --format='%(contents)' $TAG_NAME)
+          # we have to escape all new line characters and carriage
+          # returns before passing them into set-output otherwise the
+          # body content of the release will only contain the first line
+          # https://github.com/actions/create-release/issues/38#issuecomment-640072234
           CHANGELOG="${CHANGELOG//'%'/'%25'}"
           CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
           CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
-          echo "Got changelog: $CHANGELOG"
           echo "::set-output name=changelog::$CHANGELOG"
+
       - name: Create GitHub release
         id: create_release
-        uses: actions/create-release@v1
+        # create-release@v1 doesn't support the body arg so we use
+        # create-release@master instead.
+        uses: actions/create-release@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body: "${{ steps.release_notes.outputs.changelog }}"
+          # To set the body arg, we fetch the changelog variable we created
+          # in the previous step. Implementation is based on
+          # the third example in https://github.com/actions/create-release/pull/11
+          body: ${{ steps.release_notes.outputs.changelog }}
           draft: false
           prerelease: false
+
       - name: Build and publish to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,7 +37,8 @@ jobs:
         id: create_release
         # create-release@v1 doesn't support the body arg so we use
         # create-release@master instead.
-        uses: actions/create-release@master
+        # CS attempt
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,20 +31,17 @@ jobs:
           # https://github.com/actions/checkout/issues/290
           git fetch --tags --force
           TAG_NAME=${GITHUB_REF/refs\/tags\//}
-          echo "$(git tag -l --format='%(contents)' $TAG_NAME)" > CHANGELOG.md
+          echo "$(git tag -l --format='%(contents)' $TAG_NAME)" > "${{ runner.temp }}/CHANGELOG.md"
 
       - name: Create GitHub release
         id: create_release
-        # create-release@v1 doesn't support the body arg so we use
-        # create-release@master instead.
-        # CS attempt
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body_path: CHANGELOG.md
+          body_path: "${{ runner.temp }}/CHANGELOG.md"
           draft: false
           prerelease: false
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,10 +13,11 @@ jobs:
       matrix:
         python-version: [3.9]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
+          fetch-depth: 0
           python-version: ${{ matrix.python-version }}
       - name: Install release dependencies
         run: |
@@ -25,7 +26,15 @@ jobs:
       - name: Get release notes
         id: release_notes
         run: |
-          CHANGELOG=$(git tag -l --format='%(contents)' ${{ github.ref }})
+          git fetch --tags --force
+          GITHUB_REF=${{ github.ref }}
+          TAG_NAME=${GITHUB_REF/refs\/tags\//}
+          echo "Got tag: $TAG_NAME"
+          CHANGELOG=$(git tag -l --format='%(contents)' $TAG_NAME)
+          CHANGELOG="${CHANGELOG//'%'/'%25'}"
+          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+          echo "Got changelog: $CHANGELOG"
           echo "::set-output name=changelog::$CHANGELOG"
       - name: Create GitHub release
         id: create_release
@@ -35,7 +44,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body: ${{ steps.release_notes.outputs.changelog }}
+          body: "${{ steps.release_notes.outputs.changelog }}"
           draft: false
           prerelease: false
       - name: Build and publish to PyPI


### PR DESCRIPTION
Adds a new GitHub Action configuration that prepares and pushes a GitHub release and PyPI source dist + wheel release when a `v` prefixed version git tag is pushed.  It can live side-by-side with the Travis CI unit testing / type checking  configuration.

@m4rc1e you will need to add the following data to the repository "Secrets" settings:

- PyPI username as `PYPI_USERNAME`
- PyPI password as `PYPI_PASSWORD`

If those data are missing when you push a version tag, you'll get a GH release but the PyPI push will fail.

This Action automatically adds the following to the body of every release:

> Please see the root of the repository for the CHANGELOG.md

You'll need to change this line to something that is appropriate here.




