### PR TITLE
Use use_scm_version instead of manually bumping version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ wheels/
 MANIFEST
 
 # auto-generated version file
-Lib/fontmake/_version.py
+Lib/gftools/_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+# auto-generated version file
+Lib/fontmake/_version.py

--- a/Lib/gftools/__init__.py
+++ b/Lib/gftools/__init__.py
@@ -1,0 +1,4 @@
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"

--- a/Lib/gftools/__init__.py
+++ b/Lib/gftools/__init__.py
@@ -1,4 +1,4 @@
 try:
-    from ._version import version as __version__
+    from ._version import version as __version__  # type: ignore
 except ImportError:
     __version__ = "0.0.0+unknown"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open('README.md') as f:
 
 setup(
     name="gftools",
-    version='0.5.1',
+    use_scm_version={"write_to": "Lib/gftools/_version.py"},
     url='https://github.com/googlefonts/tools/',
     description='Google Fonts Tools is a set of command-line tools'
                 ' for testing font projects',


### PR DESCRIPTION
If you browse the history of this repo and other repos I work on, I typically include a commit to bump the version number. This PR will use the version number from the git tag instead.