### PR TITLE
Change import order to fix logging bug

### DIFF
--- a/Lib/gftools/util/google_fonts.py
+++ b/Lib/gftools/util/google_fonts.py
@@ -49,7 +49,6 @@ import gftools.fonts_public_pb2 as fonts_pb2
 from fontTools import ttLib
 from absl import flags
 from gftools.util import py_subsets
-from absl import app
 from google.protobuf import text_format
 
 
@@ -984,4 +983,5 @@ def main(argv):
 
 
 if __name__ == '__main__':
+  from absl import app
   app.run(main)


### PR DESCRIPTION
I'm trying to use gftools.fix in a script, and found that it was making my logging code disappear. I tracked it down to the call to `from absl import app` in `gftools.utils.google_fonts`. This only needs to be imported when unit testing and when `gftools.utils.google_fonts` is run as `__main__`. This PR moves the import to within the `if __name__ == '__main__':` to avoid interfering with other modules' logging.