### PR TITLE
fix typo

### DIFF
--- a/Lib/gftools/encodings/GF Glyph Sets/README.md
+++ b/Lib/gftools/encodings/GF Glyph Sets/README.md
@@ -51,7 +51,7 @@ Structure and Hierarchy of Glyph Sets for Latin:
   - Western & Central European
   - Vietnamese
   - Currencies (₡ ₣ ₤ ₦ ₧ ₩ ₫ ₭ ₱ ₲ ₵ ₹ ₺ ₼ ₽)
-  - Alternate Numerals: Proportonal Lining
+  - Alternate Numerals: Proportional Lining
 
 Includes characters from the following unicode ranges:
 


### PR DESCRIPTION
I'm using this as an excuse to ask why this is even needed? Should the default figures be tabular (or maybe even tabular old-style)? (Hardly reasonable).