### PR TITLE
Use ttfs filenames instead of src filenames when building stat tables from config

### DIFF
--- a/Lib/gftools/tests/test_usage.py
+++ b/Lib/gftools/tests/test_usage.py
@@ -48,6 +48,7 @@ class TestGFToolsScripts(unittest.TestCase):
         self.example_font = os.path.join(self.example_dir, 'Cabin-Regular.ttf')
         self.example_family = glob(os.path.join("data", "test", "mavenpro", "*.ttf"))
         self.example_vf_font = os.path.join("data", "test", 'Lora-Roman-VF.ttf')
+        self.example_vf_stat = os.path.join("data", "test", 'lora_stat.yaml')
         self.example_builder_config = os.path.join("data", "test", 'builder_test.yaml')
         self.src_vtt_font = os.path.join("data", "test", "Inconsolata[wdth,wght].ttf")
         self.gf_family_dir = os.path.join('data', 'test', 'mock_googlefonts', 'ofl', 'abel')
@@ -231,7 +232,14 @@ class TestGFToolsScripts(unittest.TestCase):
         self.check_script(['python', self.get_path('check-vtt-compile'), self.src_vtt_font])
 
     def test_gen_stat(self):
-        self.check_script(['python', self.get_path('gen-stat'), self.example_vf_font, "--axis-order", "wght"])
+        self.check_script(
+            ['python', self.get_path('gen-stat'), self.example_vf_font, "--axis-order", "wght"]
+        )
+
+    def test_gen_stat2(self):
+        self.check_script(
+            ['python', self.get_path('gen-stat'), self.example_vf_font, "--src", self.example_vf_stat]
+        )
 
     def test_builder(self):
         self.check_script(['python', self.get_path('builder'), self.example_builder_config])

--- a/Lib/gftools/tests/test_usage.py
+++ b/Lib/gftools/tests/test_usage.py
@@ -231,7 +231,7 @@ class TestGFToolsScripts(unittest.TestCase):
         self.check_script(['python', self.get_path('check-vtt-compile'), self.src_vtt_font])
 
     def test_gen_stat(self):
-        self.check_script(['python', self.get_path('gen-stat'), self.example_vf_font])
+        self.check_script(['python', self.get_path('gen-stat'), self.example_vf_font, "--axis-order", "wght"])
 
     def test_builder(self):
         self.check_script(['python', self.get_path('builder'), self.example_builder_config])

--- a/bin/gftools-gen-stat.py
+++ b/bin/gftools-gen-stat.py
@@ -3,7 +3,25 @@
 gftools gen-stat
 
 Generate a STAT table for each font in a variable font family
-using the GF axis registry.
+using the GF axis registry. Alternatively, users can generate
+STAT tables from a yaml file which has the following structure:
+
+```
+Lora[wght].ttf:
+- name: Weight
+  tag: wght
+  values:
+  - name: Regular
+    value: 400
+    ...
+- name: Width
+  tag: wdth
+  values:
+  ...
+
+Lora-Italic[wght].ttf
+...
+```
 
 Usage:
 
@@ -18,6 +36,9 @@ gftools gen-stat font1.ttf font2.ttf --axis-order wdth wght --inplace
 
 # Overide which axis values are elided
 gftools gen-stat font.ttf --elided-values wght=400 --axis-order wdth wght
+
+# Generate stats from a file
+gftools gen-stat font.ttf --src my_stat.yaml
 
 """
 from fontTools.ttLib import TTFont
@@ -49,7 +70,7 @@ def main():
     parser.add_argument(
         "fonts", nargs="+", help="Variable TTF files which make up a family"
     )
-    parser.add_argument("--config", help="use yaml config file to build STAT", default=None)
+    parser.add_argument("--src", help="use yaml file to build STAT", default=None)
     parser.add_argument(
         "--axis-order",
         nargs="+",
@@ -74,8 +95,8 @@ def main():
 
     fonts = [TTFont(f) for f in args.fonts]
 
-    if args.config:
-        config = yaml.load(open(args.config), Loader=yaml.SafeLoader)
+    if args.src:
+        config = yaml.load(open(args.src), Loader=yaml.SafeLoader)
         gen_stat_tables_from_config(config, fonts)
     else:
         if not args.axis_order:

--- a/bin/gftools-gen-stat.py
+++ b/bin/gftools-gen-stat.py
@@ -21,9 +21,10 @@ gftools gen-stat font.ttf --elided-values wght=400 --axis-order wdth wght
 
 """
 from fontTools.ttLib import TTFont
-from gftools.stat import gen_stat_tables
+from gftools.stat import gen_stat_tables, gen_stat_tables_from_config
 from gftools.axisreg import axis_registry
 import argparse
+import yaml
 import os
 
 
@@ -48,10 +49,11 @@ def main():
     parser.add_argument(
         "fonts", nargs="+", help="Variable TTF files which make up a family"
     )
+    parser.add_argument("--config", help="use yaml config file to build STAT", default=None)
     parser.add_argument(
         "--axis-order",
         nargs="+",
-        required=True,
+        required=False,
         choices=axis_registry.keys(),
         help="List of space seperated axis tags used to set the STAT table "
         "axis order e.g --axis-order wdth wght ital",
@@ -71,10 +73,17 @@ def main():
     args = parser.parse_args()
 
     fonts = [TTFont(f) for f in args.fonts]
-    elided_values = (
-        parse_elided_values(args.elided_values) if args.elided_values else None
-    )
-    gen_stat_tables(fonts, args.axis_order, elided_values)
+
+    if args.config:
+        config = yaml.load(open(args.config), Loader=yaml.SafeLoader)
+        gen_stat_tables_from_config(config, fonts)
+    else:
+        if not args.axis_order:
+            raise ValueError("axis-order arg is missing")
+        elided_values = (
+            parse_elided_values(args.elided_values) if args.elided_values else None
+        )
+        gen_stat_tables(fonts, args.axis_order, elided_values)
 
     if args.out:
         if not os.path.isdir(args.out):

--- a/data/test/builder_test.yaml
+++ b/data/test/builder_test.yaml
@@ -2,4 +2,15 @@ sources:
   - Lora.glyphs
 outputDir: "."
 familyName: Lora
+stat:
+  Lora[wght].ttf:
+  - name: Weight
+    tag: wght
+    values:
+     - name: Regular
+       value: 400
+     - name: Bold
+       value: 700
+     - name: SemiBold
+       value: 600
 

--- a/data/test/lora_stat.yaml
+++ b/data/test/lora_stat.yaml
@@ -1,0 +1,10 @@
+Lora-Roman-VF.ttf:
+- name: Weight
+  tag: wght
+  values:
+  - name: Regular
+    value: 400
+  - name: Bold
+    value: 700
+  - name: SemiBold
+    value: 600


### PR DESCRIPTION
I've refactored the `stat.gen_stat_tables_from_config` function so we don't need to supply source files. Instead, we just specify the ttf filenames e.g 

Current:

```YAML
Family.glyphs:
- name: Weight
  tag: wght
...
```

This pr
```YAML
Family[wght].ttf
- name: Weight
  tag: wght
...
```



By doing this, I can reuse the function in `gftools gen-stat` without users needing to add the sources (in some projects, we may not even have sources).

cc @simoncozens. Still wip, will add some tests. I've also tidied up some functions since many of them were saving files in place so they didn't have good reuse etc.