### PR TITLE
Refactor gftools push-status

### DIFF
--- a/Lib/gftools/axisreg.py
+++ b/Lib/gftools/axisreg.py
@@ -1,6 +1,6 @@
 from pkg_resources import resource_filename
 from gftools.axes_pb2 import AxisProto, FallbackProto
-from google.protobuf import text_format
+from gftools.utils import read_proto
 from glob import glob
 import os
 
@@ -14,13 +14,11 @@ def AxisRegistry():
     axis_reg_dir = resource_filename("gftools", "axisregistry")
     proto_files = glob(os.path.join(axis_reg_dir, "*.textproto"))
     for proto_file in proto_files:
-        axis = AxisProto()
-        with open(proto_file, "rb") as textproto:
-            text_format.Parse(textproto.read(), axis)
-            results[axis.tag] = axis
-            # Remove spaces from names
-            for fallback in results[axis.tag].fallback:
-                fallback.name = fallback.name.replace(" ", "")
+        axis = read_proto(proto_file, AxisProto())
+        results[axis.tag] = axis
+        # Remove spaces from names
+        for fallback in results[axis.tag].fallback:
+            fallback.name = fallback.name.replace(" ", "")
     return results
 
 

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -27,6 +27,7 @@ import browserstack_screenshots
 from collections import namedtuple
 from github import Github
 from pkg_resources import resource_filename
+from google.protobuf import text_format
 import time
 import json
 from browserstack.local import Local
@@ -496,3 +497,10 @@ def gen_gif(img_a_path, img_b_path, dst):
 def partition(items, size):
     """partition([1,2,3,4,5,6], 2) --> [[1,2],[3,4],[5,6]]"""
     return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+def read_proto(fp, schema):
+    with open(fp, "rb") as f:
+        data = text_format.Parse(f.read(), schema)
+    return data
+

--- a/bin/gftools-push-status.py
+++ b/bin/gftools-push-status.py
@@ -13,7 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Check the status of families being pushed to Google Fonts
+"""Check the status of families being pushed to Google Fonts.
+
+Families are pushed to a sandbox server and inspected before
+they are sent to the production server. The files "to_sandbox.txt" and
+"to_production.txt" in the google/fonts repo list which families need
+pushing to their respective servers.
+
+This script will check whether the families listed in the text files
+have been pushed. A lint command is also provided to ensure they list
+valid directory paths.
 
 Usage:
 gftools push-status /path/to/google/fonts/repo
@@ -110,7 +119,7 @@ def missing_paths(fp):
     return [p for p in dirs if not p.is_dir()]
 
 
-def lint_report(fp):
+def lint_server_files(fp):
     template = "{}: Following paths are not valid dirs:\n{}\n\n"
     prod_path = fp / "to_production.txt"
     prod_missing = "\n".join(map(str, missing_paths(prod_path)))
@@ -138,7 +147,7 @@ def main():
     )
     args = parser.parse_args()
     if args.lint:
-        lint_report(args.path)
+        lint_server_files(args.path)
     else:
         push_report(args.path)
 


### PR DESCRIPTION
I decided to refactor this script since we also need to check if the push files contain typos. I could've forced this feature in but the code was already a mess.

If you supply the arg `--lint`, it will check if all paths specified in the server files are valid directories e.g 
`gftools push-status path/to/google/fonts --lint`. I will hook this command up to the google/fonts ci as well.

If our push pipeline increases in complexity, we should probably move these functions to their own dedicated module etc. For now, I think it's still fine as a script.