### PR TITLE
QA: Update posting results to github issues/prs

### DIFF
--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -1244,6 +1244,15 @@ def create_github_issue_comment(repo_owner: str, repo_name: str,
   }
   return _post_github(url, payload)
 
+def create_github_issue(repo_owner: str, repo_name: str,
+                        pr_title: str, pr_body: str):
+  url = (f'{GITHUB_V3_REST_API}/repos/{repo_owner}/{repo_name}/issues')
+  payload = {
+    'title': pr_title,
+    'body': pr_body
+  }
+  return _post_github(url, payload)
+
 def _make_pr(repo: pygit2.Repository, local_branch_name: str,
                                   pr_upstream: str, push_upstream: str,
                                   pr_title: str, pr_message_body: str):


### PR DESCRIPTION
Currently, the GF bot doesn't post a comment in pull requests made to google/fonts. I temporarily disabled it because the old implementation would make a zip file and post it to the GFR server. This feature is now redundant because we use github artifacts instead.

This PR will allow us to reenable the bot but it will only post the fontbakery results as a comment. If users want to see the full test results/files, they will have to download the github artifact instead.

By doing the above, I can finally drop the GFR server for good since no services use it. I plan to keep it online for ~5 months but it will be retired.

@graphicore I've added another Github helper function to the packager, `create_github_issue`. I hope you don't mind? I'm tempted to move the git functionality out of packager and into its own module someday.