### PR TITLE
Gftools builder cleanup

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -53,6 +53,7 @@ required, all others have sensible defaults:
 * ``ttDir``: Where to put TrueType static fonts. Defaults to ``$outputDir/ttf``.
 * ``otDir``: Where to put CFF static fonts. Defaults to ``$outputDir/otf``.
 * ``woffDir``: Where to put WOFF2 static fonts. Defaults to ``$outputDir/webfonts``.
+* ``cleanUp`: Whether or not to remove temporary files. Defaults to ``true``.
 * ``autohintTTF`: Whether or not to autohint TTF files. Defaults to ``true``.
 * ``axisOrder``: STAT table axis order. Defaults to fvar order.
 * ``familyName``: Family name for variable fonts. Defaults to family name of first source file.
@@ -175,6 +176,8 @@ class GFBuilder:
             self.config["autohintTTF"] = True
         if "logLevel" not in self.config:
             self.config["logLevel"] = "INFO"
+        if "cleanUp" not in self.config:
+            self.config["cleanUp"] = True
 
     def build_variable(self):
         self.mkdir(self.config["vfDir"], clean=True)
@@ -269,6 +272,8 @@ class GFBuilder:
         if self.config["buildWebfont"]:
             self.mkdir(self.config["woffDir"], clean=True)
         self.build_a_static_format("ttf", self.config["ttDir"], self.post_process_ttf)
+        if self.config["cleanUp"]:
+            self.rmdir("instance_ufos")
 
     def build_a_static_format(self, format, directory, postprocessor):
         self.mkdir(directory, clean=True)
@@ -288,9 +293,12 @@ class GFBuilder:
                 self.logger.info("Created static font %s" % fontfile)
                 postprocessor(fontfile)
 
+    def rmdir(self, directory):
+        shutil.rmtree(directory, ignore_errors=True)
+
     def mkdir(self, directory, clean=False):
         if clean:
-            shutil.rmtree(directory, ignore_errors=True)
+            self.rmdir(directory)
         os.makedirs(directory)
 
     def post_process(self, filename):

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -114,6 +114,16 @@ class GFBuilder:
             self.build_variable()
         if self.config["buildStatic"]:
             self.build_static()
+        # All done
+        self.logger.info(
+            "Building %s completed. All done!" % (
+                ", ".join([
+                    b.lstrip("build").lower()
+                    for b in ["buildVariable", "buildStatic", "buildWebfont"]
+                    if self.config[b]
+                ])
+            )
+        )
 
     def load_masters(self):
         if self.masters:

--- a/bin/gftools-builder.py
+++ b/bin/gftools-builder.py
@@ -38,6 +38,12 @@ parser.add_argument(
 )
 parser.add_argument("--stylespace", help="Path to a statmake stylespace file")
 
+parser.add_argument(
+    "--no-clean-up",
+    action="store_true",
+    default=False,
+    help="Do not remove temporary files (instance_ufos/)")
+
 parser.add_argument("file", nargs="+", help="YAML build config file *or* source files")
 
 parser.add_argument("--dump-config", type=str, help="Config file to generate")
@@ -58,6 +64,9 @@ else:
 
 if args.no_autohint:
     builder.config["autohintTTF"] = False
+
+if args.no_clean_up:
+    builder.config["cleanUp"] = False
 
 if args.debug:
     builder.config["logLevel"] = "DEBUG"


### PR DESCRIPTION
Fixes https://github.com/googlefonts/gftools/issues/290

- [x] Add log message to say "All done!"
- [x] Add --no-clean-up argument and clean up `instance_ufos/`  by default