### PR TITLE
Builder: Add includeSourceFixes to config file

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -176,6 +176,8 @@ class GFBuilder:
             self.config["logLevel"] = "INFO"
         if "cleanUp" not in self.config:
             self.config["cleanUp"] = True
+        if "includeSourceFixes" not in self.config:
+            self.config["includeSourceFixes"] = False
 
     def build_variable(self):
         self.mkdir(self.config["vfDir"], clean=True)
@@ -302,7 +304,7 @@ class GFBuilder:
     def post_process(self, filename):
         self.logger.info("Postprocessing font %s" % filename)
         font = TTFont(filename)
-        fix_font(font)
+        fix_font(font, include_source_fixes=self.config["includeSourceFixes"])
         font.save(filename)
 
     def post_process_ttf(self, filename):

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -283,7 +283,7 @@ def fix_fvar_instances(ttFont):
             )
             name = name.replace("Regular Italic", "Italic")
 
-            coordinates = default_axis_vals
+            coordinates = deepcopy(default_axis_vals)
             coordinates["wght"] = wght_val
 
             inst = NamedInstance()


### PR DESCRIPTION
This is a followup to pull request #296 that was automatically closed by mistake when this project renamed its **"master"** branch to **"main"**.

**Be sure to also read all the comments posted in the original PR (#296)**

Original PR description as submitted on  by @m4rc1e:
----

The builder will post process built fonts by calling the `gftools.fix.fix_font` function. This function has an additional arg called `include_source_fixes` which will hotfix a font (we advise that users fixes the sources). This PR will allow users to specify in their config file that they want to enable these fixes.

----
**Be sure to also read all the comments posted in the original PR (#296)**
