### PR TITLE
Remove >= py3.8 shutil arg

### DIFF
--- a/Lib/gftools/html.py
+++ b/Lib/gftools/html.py
@@ -513,7 +513,8 @@ class HtmlProof(HtmlTemplater):
                 src_imgs = os.path.join(temp_html.out, "img")
                 dir_name = "-".join(s._style.replace(" ", "") for s in group)
                 dst_imgs = os.path.join(self.out, "img", dir_name)
-                shutil.copytree(src_imgs, dst_imgs, dirs_exist_ok=True)
+                shutil.rmtree(dst_imgs, ignore_errors=True)
+                shutil.copytree(src_imgs, dst_imgs)
 
 
 class HtmlDiff(HtmlTemplater):
@@ -639,7 +640,8 @@ class HtmlDiff(HtmlTemplater):
                 src_imgs = os.path.join(temp_html.out, "img")
                 dir_name = "-".join(s._style.replace(" ", "") for s in group)
                 dst_imgs = os.path.join(self.out, "img", dir_name)
-                shutil.copytree(src_imgs, dst_imgs, dirs_exist_ok=True)
+                shutil.rmtree(dst_imgs, ignore_errors=True)
+                shutil.copytree(src_imgs, dst_imgs)
 
 
 # Local server functions


### PR DESCRIPTION
Currently, we use `dirs_exist_ok=True` in `shutil.copytree`. This arg is only supported in Python3.8+.