### PR TITLE
builder: Fix getting familyName if config does not specify one

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -146,7 +146,12 @@ class GFBuilder:
                 self.config["familyName"] = designspace.sources[0].familyName
             else:
                 self.load_masters()
-                familynames = set([x.info.familyName for x in self.masters.values()])
+
+                familynames = set()
+                for masters in self.masters.values():
+                    for master in masters:
+                        familynames.add(master.info.familyName)
+
                 if len(familynames) != 1:
                     raise ValueError(
                         "Inconsistent family names in sources (%s). Set familyName in config instead"


### PR DESCRIPTION
Currently, `set([x.info.familyName for x in self.masters.values()])` doesn't work because `self.masters.values()` is a nested list structured as `[src1->[master1, master2], src2->[master1, master2]]`. To fix, I do another loop in `self.masters.values()` so i access the individual masters. 


Fixes #314 

cc @simoncozens.