### PR TITLE
Convert GitHub Actions configuration to main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
It looks like your default branch changed from `master` -> `main` and your Actions config defines runs on pushes to and PR's against `master`:

```yaml
on:
  push:
    branches: [master]
  pull_request:
    branches: [master]
```

This changes the config to `main`.  I *think* that this should address #320 

**Update** Confirmed: Closes #320 