### PR TITLE
Fix vf name table and builder vf filename

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -285,7 +285,7 @@ class GFBuilder:
     def rename_variable(self, fontfile):
         if "axisOrder" not in self.config:
             font = TTFont(fontfile)
-            self.config["axisOrder"] = [ax.axisTag for ax in font["fvar"].axes]
+            self.config["axisOrder"] = sorted([ax.axisTag for ax in font["fvar"].axes])
         axes = ",".join(self.config["axisOrder"])
         newname = fontfile.replace("-VF.ttf", "[%s].ttf" % axes)
         os.rename(fontfile, newname)

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -245,10 +245,14 @@ class GFBuilder:
             )
             output_files = self.run_fontmake(source, args)
             newname = self.rename_variable(output_files[0])
-            self.post_process(newname)
             ttFont = TTFont(newname)
             ttFonts.append(ttFont)
+
         self.gen_stat(ttFonts)
+        # We post process each variable font after generating the STAT tables
+        # because these tables are needed in order to fix the name tables.
+        for ttFont in ttFonts:
+            self.post_process(ttFont.reader.file.name)
 
     def run_fontmake(self, source, args):
         if "output_dir" in args:

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -423,9 +423,9 @@ def fix_nametable(ttFont):
         ttFont: a TTFont instance
     """
     if "fvar" in ttFont:
-        # TODO, regen the nametable so it reflects the default fvar axes
-        # coordinates. Implement once https://github.com/fonttools/fonttools/pull/2078
-        # is merged.
+        from fontTools.varLib.instancer.names import updateNameTable
+        dflt_axes = {a.axisTag: a.defaultValue for a in ttFont['fvar'].axes}
+        updateNameTable(ttFont, dflt_axes)
         return
     family_name = font_familyname(ttFont)
     style_name = font_stylename(ttFont)


### PR DESCRIPTION
This PR solves two issues regarding VF names:

- `gftools builder` currently generates the axes in a vf filename in non-alphabetical order. They should be ordered alphabetically
- `gftools.fix` cannot fix a VF's name table. We can now fix VF name tables because the updateNameTable PR in fontTools has been merged and a new release cut.