### PR TITLE
Fix vf filename round 2

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -283,11 +283,11 @@ class GFBuilder:
             return [os.path.join(original_output_dir, x) for x in file_names]
 
     def rename_variable(self, fontfile):
-        if "axisOrder" not in self.config:
-            font = TTFont(fontfile)
-            self.config["axisOrder"] = sorted([ax.axisTag for ax in font["fvar"].axes])
-        axes = ",".join(self.config["axisOrder"])
-        newname = fontfile.replace("-VF.ttf", "[%s].ttf" % axes)
+        font = TTFont(fontfile)
+        assert "fvar" in font
+        axis_tags = sorted([ax.axisTag for ax in font["fvar"].axes])
+        axis_tags = ",".join(axis_tags)
+        newname = fontfile.replace("-VF.ttf", "[%s].ttf" % axis_tags)
         os.rename(fontfile, newname)
         return newname
 


### PR DESCRIPTION
Currently, we use the axisOrder parameter to construct VF filenames. This doesn't work correctly since a VF filename must only list the axes which are in the font, not all the axes which make up a family.

This issue becomes apparent when you have a VF family which consists of multiple fonts e.g:

Current implementation:
`MyFamily[wdth,wght,ital].ttf`
`MyFamily-Italic[wdth,wght,ital].ttf`

Neither font has an `ital` axis in the fvar tables so they shouldn't be included in the filename 

This pr will produce the following:
`MyFamily[wdth,wght].ttf`
`MyFamily-Italic[wdth,wght].ttf`

