### PR TITLE
Builder: build cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,5 @@ jobs:
           pytest ./Lib/gftools/tests/test_stat.py
           pytest ./Lib/gftools/tests/test_html.py
           pytest ./Lib/gftools/tests/test_instancer.py
+          pytest ./Lib/gftools/tests/test_builder.py
           mypy ./Lib/gftools/packager.py

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -110,7 +110,7 @@ import yaml
 
 class GFBuilder:
     def __init__(self, configfile=None, config=None):
-        self.configfile = configfile
+        self.configfile = os.path.abspath(configfile)
         if self.configfile:
             self.config = yaml.load(open(configfile), Loader=yaml.SafeLoader)
             if os.path.dirname(configfile):
@@ -173,7 +173,6 @@ class GFBuilder:
             )
             for file_ in files_added_during_build:
                 self.rm(file_)
-
 
     def load_masters(self):
         if self.masters:

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -110,12 +110,13 @@ import yaml
 
 class GFBuilder:
     def __init__(self, configfile=None, config=None):
-        self.configfile = os.path.abspath(configfile)
-        if self.configfile:
+        if configfile:
+            self.configfile = os.path.abspath(configfile)
             self.config = yaml.load(open(configfile), Loader=yaml.SafeLoader)
             if os.path.dirname(configfile):
                 os.chdir(os.path.dirname(configfile))
         else:
+            self.configfile = None
             self.config = config
         self.masters = {}
         self.logger = logging.getLogger("GFBuilder")

--- a/Lib/gftools/builder/cache.py
+++ b/Lib/gftools/builder/cache.py
@@ -1,0 +1,205 @@
+import os
+import sqlite3
+from collections import defaultdict
+from pkg_resources import resource_filename
+from gftools.utils import md5_hash
+from pkg_resources import working_set
+import shutil
+import yaml
+import json
+
+
+class Cache(object):
+    def __init__(self, db_path=resource_filename("gftools", "builder_cache.db")):
+        """A simple cache for the gftools builder.
+
+        The aim of this cache is to check whether fontmake needs to regenerate
+        font binaries. This needs to happen if the source files have changed,
+        the python dependencies have been updated, the config file has been
+        modified (excludes changes made to font instances and stat changes) or
+        if the font binaries have been moved/deleted.
+
+        The cache doesn't store the contents of files or directories. It only
+        stores the file's path and an md5 checksum.
+
+        Args:
+            db_path: path to create db. By default it is saved to the gftools
+            dependency dir
+        """
+        self.db_path = db_path
+        self.con = sqlite3.connect(self.db_path)
+        self.cur = self.con.cursor()
+        self._init_db()
+
+    def _init_db(self):
+        self.cur.execute("CREATE TABLE IF NOT EXISTS file_cache (file, md5)")
+        self.cur.execute(
+            "CREATE TABLE IF NOT EXISTS dependency_cache (python_path, md5)"
+        )
+        self.cur.execute("CREATE TABLE IF NOT EXISTS config_cache (path, data)")
+        self.con.commit()
+
+    def delete_all_records(self):
+        """Delete all database records."""
+        self.cur.execute("DROP TABLE file_cache")
+        self.cur.execute("DROP TABLE dependency_cache")
+        self.cur.execute("DROP TABLE config_cache")
+        self._init_db()
+
+    def add_files(self, files):
+        file_hashes = self._hash_files(files)
+        for filepath, filehash in file_hashes.items():
+            self.cur.execute("SELECT * from file_cache WHERE file=?", (filepath,))
+            if not self.cur.fetchone():
+                self.cur.execute(
+                    "INSERT INTO file_cache VALUES (?,?)", (filepath, filehash)
+                )
+            else:
+                self.cur.execute(
+                    "UPDATE file_cache SET md5=? WHERE file=?", (filehash, filepath)
+                )
+        self.con.commit()
+        return files
+
+    def changed_files(self, files):
+        source_files = []
+        for f in files:
+            # Get ufo paths from a designspace
+            if f.endswith(".designspace"):
+                ds = designspaceLib()
+                ds.read(f)
+                for ufo in ds.sources:
+                    source_files.append(ufo)
+            source_files.append(f)
+
+        changed = []
+        file_hashes = self._hash_files(source_files)
+        for filepath, filehash in file_hashes.items():
+            self.cur.execute("SELECT * FROM file_cache WHERE file=?", (filepath,))
+            previous_hash = self.cur.fetchone()
+            if not previous_hash:
+                changed.append(filepath)
+                continue
+            _, previous_filehash = previous_hash
+            if previous_filehash != filehash:
+                changed.append(filepath)
+        return changed
+
+    def _hash_files(self, files):
+        return {f: md5_hash(f) for f in files}
+
+    def add_directory(self, fp):
+        # Remove any existing records which belong to the fp
+        self.cur.execute("DELETE FROM file_cache WHERE file LIKE '%%%s%%'" % fp)
+        files = [os.path.join(fp, f) for f in os.listdir(fp) if f != ".DS_Store"]
+        return self.add_files(files)
+
+    def changed_directory(self, fp):
+        files = [os.path.join(fp, f) for f in os.listdir(fp) if f != ".DS_Store"]
+        files = self._hash_files(files)
+        self.cur.execute("SELECT * FROM file_cache WHERE file LIKE '%%%s%%'" % fp)
+        previous_files = {k: v for k, v in self.cur.fetchall()}
+        diff = defaultdict(list)
+        for filepath, file_hash in files.items():
+            if filepath not in previous_files:
+                diff["new"].append(filepath)
+                continue
+
+            if files[filepath] != previous_files[filepath]:
+                diff["modified"].append(filepath)
+
+        for filepath, file_hash in previous_files.items():
+            if filepath not in files:
+                diff["missing"].append(filepath)
+                continue
+
+        return dict(diff)
+
+    def add_dependencies(self):
+        python_path = shutil.which("python")
+        dependencies = self._get_dependencies()
+        self.cur.execute(
+            "SELECT * from dependency_cache WHERE python_path=?", (python_path,)
+        )
+        if not self.cur.fetchone():
+            self.cur.execute(
+                "INSERT INTO dependency_cache VALUES (?,?)", (python_path, dependencies)
+            )
+        else:
+            self.cur.execute(
+                "UPDATE dependency_cache SET md5=? WHERE python_path=?",
+                (dependencies, python_path),
+            )
+        self.con.commit()
+        return dependencies
+
+    def changed_dependencies(self):
+        python_path = shutil.which("python")
+        dependencies = self._get_dependencies()
+        self.cur.execute(
+            "SELECT * FROM dependency_cache WHERE python_path=?", (python_path,)
+        )
+        previous_dependencies = self.cur.fetchone()
+        if not previous_dependencies:
+            return True
+        _, previous_dependencies = previous_dependencies
+        if previous_dependencies != dependencies:
+            return True
+        return False
+
+    def _get_dependencies(self):
+        return ",".join(str(s) for s in sorted(working_set))
+
+    def add_config(self, fp):
+        config_data = json.dumps(self._load_config(fp))
+        self.cur.execute("SELECT * FROM config_cache WHERE path=?", (fp,))
+        if not self.cur.fetchone():
+            self.cur.execute("INSERT INTO config_cache VALUES (?,?)", (fp, config_data))
+        else:
+            self.cur.execute(
+                "UPDATE config_cache SET data=? WHERE path=?", (config_data, fp)
+            )
+        self.con.commit()
+        return config_data
+
+    def changed_config(self, fp):
+        config_data = self._load_config(fp)
+        self.cur.execute("SELECT * FROM config_cache WHERE path=?", (fp,))
+        previous_config = self.cur.fetchone()
+        if not previous_config:
+            return True
+        previous_config_data = json.loads(previous_config[-1])
+        if previous_config_data != config_data:
+            return True
+        return False
+
+    def _load_config(self, fp):
+        with open(fp) as yaml_data:
+            data = yaml.load(yaml_data, Loader=yaml.FullLoader)
+            # Remove stat and instance data since we want users to
+            # be able to edit these since they don't rely on fontmake
+            if "stat" in data:
+                data.pop("stat")
+            if "instances" in data:
+                data.pop("instances")
+        return data
+
+    def add_project(self, project):
+        self.add_files(project.config["sources"])
+        self.add_config(project.configfile)
+        self.add_dependencies()
+
+    def changed_project(self, project):
+        return any(
+            [
+                self.changed_files(project.config["sources"]),
+                self.changed_config(project.configfile),
+                self.changed_dependencies(),
+            ]
+        )
+
+    def close(self):
+        self.con.close()
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()

--- a/Lib/gftools/tests/test_builder.py
+++ b/Lib/gftools/tests/test_builder.py
@@ -16,23 +16,21 @@ def test_caching_files():
         # Test empty files
         files = [f1.name, f2.name]
         cache.add_files(files)
-        assert cache.changed_files(files) == []
+        assert cache.changed_files(files) == {}
 
         # Test updating just a single file
         f1.write(b"foobar")
         f1.seek(0)
-        assert len(cache.changed_files(files)) == 1
-        assert cache.changed_files(files)[0] == f1.name
+        assert f1.name in cache.changed_files(files)['modified']
 
         # Test updating both files
         f2.write(b"foobar2")
         f2.seek(0)
-        assert len(cache.changed_files(files)) == 2
-        assert set(files) == set(cache.changed_files(files))
+        assert set(files) == set(cache.changed_files(files)['modified'])
 
         # Readd the modified files and retest
         cache.add_files(files)
-        assert cache.changed_files(files) == []
+        assert cache.changed_files(files) == {}
         cache.con.close()
 
 
@@ -66,34 +64,30 @@ def test_caching_directory():
 
         cache = Cache(db_path=db.name)
 
-        # Test an empty dir
-        cache.add_directory(test_dir)
-        assert cache.changed_directory(test_dir) == {}
-
         # Test on a new file
         f1 = os.path.join(test_dir, "f1.txt")
         with open(f1, "w") as doc:
             doc.write("Hello world")
-        assert cache.changed_directory(test_dir) == {"new": [f1]}
+        assert cache.changed_files([f1]) == {"new": [f1]}
 
         # Add another file
         f2 = os.path.join(test_dir, "f2.txt")
         with open(f2, "w") as doc:
             doc.write("Hello world")
-        assert cache.changed_directory(test_dir) == {"new": [f1, f2]}
+        assert cache.changed_files([f1, f2]) == {"new": [f1, f2]}
 
         # update cache
-        cache.add_directory(test_dir)
+        cache.add_files([f1, f2])
 
         # delete a cached file
         os.remove(f2)
-        assert cache.changed_directory(test_dir) == {"missing": [f2]}
+        assert cache.changed_files([f1]) == {"missing": [f2]}
 
         # modify a cached file
-        cache.add_directory(test_dir)
+        cache.add_files([f1])
         with open(f1, "w") as doc:
             doc.write("Hello again")
-        assert cache.changed_directory(test_dir) == {"modified": [f1]}
+        assert cache.changed_files([f1]) == {"modified": [f1]}
 
 
 def test_caching_ufo_file():
@@ -106,12 +100,10 @@ def test_caching_ufo_file():
 
         cache = Cache(db_path=db.name)
         files_added = cache.add_files([test_ufo_path])
-        # Jost-Regular.ufo contains 540 individual files
-        assert len(files_added) == 540
 
         # Let's test on an identical file
         files_changed = cache.changed_files([test_ufo_path])
-        assert len(files_changed) == 0
+        assert files_changed == {}
 
         # Let's modify a file
         a_glyph = os.path.join(test_ufo_path, "glyphs", "a.glif")
@@ -119,17 +111,5 @@ def test_caching_ufo_file():
             glyph.write("foobar")
         files_changed = cache.changed_files([test_ufo_path])
         assert len(files_changed) == 1
-
-        # Let's modify another file and not update the cache
-        b_glyph = os.path.join(test_ufo_path, "glyphs", "b.glif")
-        with open(b_glyph, "w") as glyph:
-            glyph.write("foobar")
-        files_changed = cache.changed_files([test_ufo_path])
-        assert len(files_changed) == 2
-
-        # Let's recache
-        cache.add_files([test_ufo_path])
-        files_changed = cache.changed_files([test_ufo_path])
-        assert len(files_changed) == 0
 
         # What about deletions/additions?

--- a/Lib/gftools/tests/test_builder.py
+++ b/Lib/gftools/tests/test_builder.py
@@ -1,0 +1,95 @@
+from gftools.builder.cache import Cache
+import pytest
+import tempfile
+import os
+
+
+def test_caching_files():
+
+    with tempfile.NamedTemporaryFile(suffix=".db") as db, \
+         tempfile.NamedTemporaryFile() as f1, \
+         tempfile.NamedTemporaryFile() as f2:
+
+        cache = Cache(db_path=db.name)
+
+        # Test empty files
+        files = [f1.name, f2.name]
+        cache.add_files(files)
+        assert cache.changed_files(files) == []
+
+        # Test updating just a single file
+        f1.write(b"foobar")
+        f1.seek(0)
+        assert len(cache.changed_files(files)) == 1
+        assert cache.changed_files(files)[0] == f1.name
+
+        # Test updating both files
+        f2.write(b"foobar2")
+        f2.seek(0)
+        assert len(cache.changed_files(files)) == 2
+        assert set(files) == set(cache.changed_files(files))
+
+        # Readd the modified files and retest
+        cache.add_files(files)
+        assert cache.changed_files(files) == []
+        cache.con.close()
+
+
+def test_caching_config_file():
+
+    with tempfile.NamedTemporaryFile(suffix=".db") as db, \
+        tempfile.NamedTemporaryFile() as f1:
+
+        # Test adding a new config and testing the same config gainst it
+        cache = Cache(db_path=db.name)
+        f1.write(b"familyName: Foobar\nincludeSourceFixes: true")
+        f1.seek(0)
+
+        cache.add_config(f1.name)
+        assert cache.changed_config(f1.name) == False
+
+        # Update the config file and retest it
+        f1.write(b"familyName: Barfoo\nincludeSourceFixes: false")
+        f1.seek(0)
+        assert cache.changed_config(f1.name) == True
+
+        # Readd the modified config and retest
+        cache.add_config(f1.name)
+        assert cache.changed_config(f1.name) == False
+
+
+def test_caching_directory():
+
+    with tempfile.NamedTemporaryFile(suffix=".db") as db, \
+        tempfile.TemporaryDirectory() as test_dir:
+
+        cache = Cache(db_path=db.name)
+
+        # Test an empty dir
+        cache.add_directory(test_dir)
+        assert cache.changed_directory(test_dir) == {}
+
+        # Test on a new file
+        f1 = os.path.join(test_dir, "f1.txt")
+        with open(f1, "w") as doc:
+            doc.write("Hello world")
+        assert cache.changed_directory(test_dir) == {"new": [f1]}
+
+        # Add another file
+        f2 = os.path.join(test_dir, "f2.txt")
+        with open(f2, "w") as doc:
+            doc.write("Hello world")
+        assert cache.changed_directory(test_dir) == {"new": [f1, f2]}
+
+        # update cache
+        cache.add_directory(test_dir)
+
+        # delete a cached file
+        os.remove(f2)
+        assert cache.changed_directory(test_dir) == {"missing": [f2]}
+
+        # modify a cached file
+        cache.add_directory(test_dir)
+        with open(f1, "w") as doc:
+            doc.write("Hello again")
+        assert cache.changed_directory(test_dir) == {"modified": [f1]}

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -32,6 +32,7 @@ import time
 import json
 from browserstack.local import Local
 from PIL import Image
+import hashlib
 if sys.version_info[0] == 3:
     from configparser import ConfigParser
 else:
@@ -504,3 +505,7 @@ def read_proto(fp, schema):
         data = text_format.Parse(f.read(), schema)
     return data
 
+
+def md5_hash(fp):
+    with open(fp, 'rb') as data:
+        return hashlib.md5(data.read()).hexdigest()

--- a/data/test/builder_test.yaml
+++ b/data/test/builder_test.yaml
@@ -2,6 +2,7 @@ sources:
   - Lora.glyphs
 outputDir: "."
 familyName: Lora
+cleanUp: false
 stat:
   Lora[wght].ttf:
   - name: Weight


### PR DESCRIPTION
If a user hasn't updated their source files or they haven't tampered with the binary output dirs, there's no reason why we need to recompile the fonts using fontmake when they run the builder. In order to implement this, I've made a very simple checksum file cache which uses sqlite3 (no external dependencies etc).


So far there are two reasons why a user may rerun the builder when they haven't touched the sources:
1. modifying a VF STAT table
2. Instantiating static fonts

The performance gains are excellent. For Maven Pro, cached builds go from 40 secs to 6 secs. This will definitely make STAT and instantiating less frustrating.


Still wip. Need to hook it up to static font generation.


Implements https://github.com/googlefonts/gftools/issues/353