### PR TITLE
Builder: Add error handling to check config files

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -129,15 +129,10 @@ class GFBuilder:
             return load(unprocessed_yaml, schema).data
         except YAMLValidationError as e:
             if "unexpected key not in schema" in e.problem:
-                bad_key = str(re.findall(r"'(.*?)'", e.problem))
-                config_keys = re.findall(r'"(.*?)"', str(schema._validator))
-                config_keys.extend(re.findall(r"'(.*?)'", str(schema._validator)))
-                key_close_matches = difflib.get_close_matches(bad_key, config_keys, 8, 0.4)
+                bad_key = str(e.problem)
                 raise YAMLError(
-                    f"\nERROR **********************"
                     f"\nA key in the configuration file, typically ``config.yaml``, is likely misspelled."
-                    f"\nError caused by key: {bad_key}"
-                    f"\nPossible misspelled key close matches: {key_close_matches}"
+                    f"\nError caused by: {bad_key}"
                 )
             else:
                 raise ValueError(

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -10,6 +10,7 @@ stat_schema = Seq(
                 "name": Str(),
                 "value": Int(),
                 Optional("nominalValue"): Int(),
+                Optional("linkedValue"): Int(),
                 Optional("rangeMinValue"): Int(),
                 Optional("rangeMaxValue"): Int(),
                 Optional("flags"): Int()
@@ -30,10 +31,11 @@ schema = Map(
     {
         "sources": Seq(Str()),
         Optional("logLevel"): Str(),
+        Optional("stylespaceFile"): Str(),
+        Optional("stat"): stat_schema | MapPattern(Str(), stat_schema),
         Optional("familyName"): Str(),
         Optional("includeSourceFixes"): Bool(),
         Optional("stylespaceFile"): Str(),
-        Optional("stat"): stat_schema | MapPattern(Str(), stat_schema),
         Optional("instances"): instance_schema,
         Optional("buildVariable"): Bool(),
         Optional("buildStatic"): Bool(),
@@ -51,4 +53,3 @@ schema = Map(
         Optional("flattenComponents"): Bool(),
     }
 )
-

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -1,0 +1,54 @@
+from strictyaml import load, Map, MapPattern, Str, Int, Seq, YAMLError, Optional, Bool
+
+
+stat_schema = Seq(
+    Map({
+        "name": Str(),
+        "tag": Str(),
+        "values": Seq(
+            Map({
+                "name": Str(),
+                "value": Int(),
+                Optional("nominalValue"): Int(),
+                Optional("rangeMinValue"): Int(),
+                Optional("rangeMaxValue"): Int(),
+                Optional("flags"): Int()
+            })
+        )
+    }),
+)
+
+instance_schema = MapPattern(Str(), Seq(
+    Map({
+        Optional("familyName"): Str(),
+        Optional("styleName"): Str(),
+        "coordinates": MapPattern(Str(), Int()),
+    })
+))
+
+schema = Map(
+    {
+        "sources": Seq(Str()),
+        Optional("logLevel"): Str(),
+        Optional("familyName"): Str(),
+        Optional("includeSourceFixes"): Bool(),
+        Optional("stylespaceFile"): Str(),
+        Optional("stat"): stat_schema | MapPattern(Str(), stat_schema),
+        Optional("instances"): instance_schema,
+        Optional("buildVariable"): Bool(),
+        Optional("buildStatic"): Bool(),
+        Optional("buildOTF"): Bool(),
+        Optional("buildTTF"): Bool(),
+        Optional("buildWebfont"): Bool(),
+        Optional("outputDir"): Str(),
+        Optional("vfDir"): Str(),
+        Optional("ttDir"): Str(),
+        Optional("otDir"): Str(),
+        Optional("woffDir"): Str(),
+        Optional("cleanUp"): Bool(),
+        Optional("autohintTTF"): Bool(),
+        Optional("axisOrder"): Seq(Str()),
+        Optional("flattenComponents"): Bool(),
+    }
+)
+

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -1,4 +1,17 @@
-from strictyaml import load, Map, MapPattern, Str, Int, Seq, YAMLError, Optional, Bool
+"""
+This schema represents all known key/value pairs for the builder config file.
+"""
+from strictyaml import (
+                        load,
+                        Map,
+                        MapPattern,
+                        Str,
+                        Int,
+                        Seq,
+                        YAMLError,
+                        Optional,
+                        Bool
+                        )
 
 
 stat_schema = Seq(

--- a/Lib/gftools/tests/test_builder.py
+++ b/Lib/gftools/tests/test_builder.py
@@ -1,0 +1,59 @@
+from gftools.builder import GFBuilder
+import tempfile
+import pytest
+import yaml
+import os
+from strictyaml import load, YAMLError
+from strictyaml.exceptions import YAMLValidationError
+
+
+def monkey_patch_config_defaults(self):
+    """we're not testing this"""
+    pass
+
+
+GFBuilder.fill_config_defaults = monkey_patch_config_defaults
+
+@pytest.fixture
+def config_file():
+    return {
+        "buildStatic": True,
+        "includeSourceFixes": False,
+        "instances": {
+            "MavenPro[wght].ttf": [
+                {"coordinates": {"wght": 500}, "familyName": "Dejon"},
+                {"coordinates": {"wght": 400}, "familyName": "Dejon Special"},
+                {"coordinates": {"wght": 500}, "familyName": "Bogart"},
+            ]
+        },
+        "sources": ["MavenPro.glyphs"],
+    }
+
+
+def test_good_config(config_file):
+    # check a good config file
+    with tempfile.NamedTemporaryFile("r+", suffix=".yml") as f:
+        f.write(yaml.dump(config_file))
+        f.seek(0)
+        GFBuilder(f.name)
+
+
+def test_bad_config_structure(config_file):
+    # change sources to a string when it should be a list
+    config_file["sources"] = "foobar"
+    with tempfile.NamedTemporaryFile("r+", suffix=".yml") as f:
+        f.write(yaml.dump(config_file))
+        f.seek(0)
+        with pytest.raises(ValueError, match="The yaml config file isn't structured properly"):
+            GFBuilder(f.name)
+
+
+def test_bad_config_key(config_file):
+    # Spell a key incorrectly
+    config_file["source"] = config_file["sources"]
+    del config_file["sources"]
+    with tempfile.NamedTemporaryFile("r+", suffix=".yml") as f:
+        f.write(yaml.dump(config_file))
+        f.seek(0)
+        with pytest.raises(YAMLError, match="A key in the configuration file"):
+            GFBuilder(f.name)

--- a/bin/gftools-builder.py
+++ b/bin/gftools-builder.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 import argparse
+import difflib
+import sys
+import traceback
 from gftools.builder import GFBuilder
 from gftools.builder import __doc__ as GFBuilder_doc
 
@@ -72,7 +75,6 @@ if args.debug:
     builder.config["logLevel"] = "DEBUG"
 
 if args.dump_config:
-    import sys
     import yaml
 
     with open(args.dump_config, "w") as fp:
@@ -80,4 +82,15 @@ if args.dump_config:
         fp.write(yaml.dump(config, Dumper=yaml.SafeDumper))
     sys.exit()
 
-builder.build()
+try:
+    builder.build()
+except KeyError as bad_key:
+    print(traceback.format_exc())
+    print("Error: A key in the configuration file, typically ``config.yaml``, is likely misspelled.")
+    print("Error caused by key:", bad_key)
+    config_keys = []
+    for key in builder.config.keys():
+        config_keys.append(key)
+    key_close_matches = difflib.get_close_matches(str(bad_key), config_keys)
+    print("Possibly misspelled key in the configuration file: ", key_close_matches)
+    sys.exit(1)


### PR DESCRIPTION
As suggested in issue #345. I need some feedback to make sure I'm going in the right direction.

So far, if I change `sources` to something like `sssources` in `sources/config.yaml`, I get the following error that includes the original traceback and some more helpful error messages giving hints on how to fix the problem:
```
$ gftools builder sources/config.yaml

Traceback (most recent call last):
  File "/Users/Air/GF-2021/python/gftools/bin/gftools-builder.py", line 86, in <module>
    builder.build()
  File "/Users/Air/GF-2021/python/gftools/Lib/gftools/builder/__init__.py", line 145, in build
    self.build_variable()
  File "/Users/Air/GF-2021/python/gftools/Lib/gftools/builder/__init__.py", line 238, in build_variable
    for source in self.config["sources"]:
KeyError: 'sources'

Error: A key in the configuration file, typically ``config.yaml``, is likely misspelled.
Error caused by key: 'sources'
Possibly misspelled key in the configuration file:  ['sssources']
```

This is not currently working with some of the other keys, I'm looking into that now...
