### PR TITLE
Packager: Fix typo in packager -B help

### DIFF
--- a/bin/gftools-packager.py
+++ b/bin/gftools-packager.py
@@ -139,7 +139,7 @@ parser.add_argument(
 parser.add_argument(
             '-B', '--allow-build',
             action='store_true',
-            help='Allow executing the bash command in stored in the "build" '
+            help='Allow executing the bash command stored in the "build" '
             'key of upstream-conf, if present. Don\'t allow this lightly '
             'and review build command, build process and its dependencies prior. '
             'This support for building from sources is provisional, a '


### PR DESCRIPTION
```
Changes "Allow executing the bash command in stored in the "build" key of upstream-conf, if present."
to      "Allow executing the bash command stored in the "build" key of upstream-conf, if present."
```