### PR TITLE
builder: add support for STAT format4 axisValues

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -30,6 +30,15 @@ which looks like this::
           nominalValue: 1
           rangeMaxValue: 50
         ...
+    statFormat4:
+      - name: Green
+        location:
+          wght: 300
+          wdth: 200
+      - name: Blue
+        location:
+          wght: 400
+          wdth: 200
     ...
     instances:
       Texturina[wght].ttf:
@@ -340,10 +349,15 @@ class GFBuilder:
             if any(font_is_italic(f) for f in varfonts):
                 self.config["axisOrder"].append("ital")
 
+        locations = self.config.get("statFormat4", None)
+        if locations and 'stat' not in self.config:
+            raise ValueError(
+                "Cannot add statFormat 4 axisValues since no stat table has been declared."
+            )
         if "stylespaceFile" in self.config and self.config["stylespaceFile"]:
             self.gen_stat_stylespace(self.config["stylespaceFile"], varfonts)
         elif "stat" in self.config:
-            gen_stat_tables_from_config(self.config["stat"], varfonts)
+            gen_stat_tables_from_config(self.config["stat"], varfonts, locations=locations)
         else:
             gen_stat_tables(varfonts, self.config["axisOrder"])
 

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -32,6 +32,14 @@ stat_schema = Seq(
     }),
 )
 
+stat_format4_schema = Seq(
+    Map({
+        "name": Str(),
+        Optional("flags"): Int(),
+        "location": MapPattern(Str(), Int()),
+    })
+)
+
 instance_schema = MapPattern(Str(), Seq(
     Map({
         Optional("familyName"): Str(),
@@ -46,6 +54,7 @@ schema = Map(
         Optional("logLevel"): Str(),
         Optional("stylespaceFile"): Str(),
         Optional("stat"): stat_schema | MapPattern(Str(), stat_schema),
+        Optional("statFormat4"): stat_format4_schema | MapPattern(Str(), stat_format4_schema),
         Optional("familyName"): Str(),
         Optional("includeSourceFixes"): Bool(),
         Optional("stylespaceFile"): Str(),

--- a/Lib/gftools/stat.py
+++ b/Lib/gftools/stat.py
@@ -368,7 +368,7 @@ def gen_stat_tables(
         _update_fvar_nametable_records(ttFont, stat_table)
         buildStatTable(ttFont, stat_table)
 
-def gen_stat_tables_from_config(stat, varfonts, has_italic=None):
+def gen_stat_tables_from_config(stat, varfonts, has_italic=None, locations=None):
     """
     Generate a stat table for each font in a family from a Python configuration.
 
@@ -448,5 +448,10 @@ def gen_stat_tables_from_config(stat, varfonts, has_italic=None):
                 else:
                     stat[-1] = ital_stat_for_roman
             this_stat = stat
+
+        if isinstance(locations, dict):
+            if filename not in locations:
+                raise ValueError("Filename %s not found in locations" % filename)
+            locations = locations[filename]
         _update_fvar_nametable_records(ttFont, this_stat)
-        buildStatTable(ttFont, this_stat)
+        buildStatTable(ttFont, this_stat, locations=locations)


### PR DESCRIPTION
Fixes #333

Users will need to declare format 4 axisValues in a separate section in their builder files. This mimics the implementation in fontTools where format4 axisValues are declared in a different variable in `buildStat`.

```
stat:
  - name: Weight
    tag: wght
    values:
    - name: Regular
      value: 500
    - name: Bold
      value: 700
statFormat4: # <--- new section
  - name: "Echo Fox"
    location:
      wght: 400
  - name: "Echo Space"
    location:
      wght: 700
```

A stat table also needs to be declared in order for this to work.