### PR TITLE
Smooth all ppem sizes

### DIFF
--- a/Lib/gftools/builder/_ninja.py
+++ b/Lib/gftools/builder/_ninja.py
@@ -63,19 +63,20 @@ class NinjaBuilder(GFBuilder):
                 os.remove(temporary)
 
         # Clean up temp build files
-        search_directory = os.getcwd()
-        target_names = ["build.ninja", ".ninja_log", "instance_ufo", "master_ufo"]
-        for root, dirs, files in os.walk(search_directory, topdown=False):
-            for file in files:
-                if file in target_names:
-                    file_path = os.path.join(root, file)
-                    os.remove(file_path)
-                    print(f"Removed file: {file_path}")
-            for dir_name in dirs:
-                if dir_name in target_names:
-                    dir_path = os.path.join(root, dir_name)
-                    shutil.rmtree(dir_path)
-                    print(f"Removed directory: {dir_path}")
+        if self.config["cleanUp"]:
+            search_directory = os.getcwd()
+            target_names = ["build.ninja", ".ninja_log", "instance_ufo", "master_ufo"]
+            for root, dirs, files in os.walk(search_directory, topdown=False):
+                for file in files:
+                    if file in target_names:
+                        file_path = os.path.join(root, file)
+                        os.remove(file_path)
+                        print(f"Removed file: {file_path}")
+                for dir_name in dirs:
+                    if dir_name in target_names:
+                        dir_path = os.path.join(root, dir_name)
+                        shutil.rmtree(dir_path)
+                        print(f"Removed directory: {dir_path}")
 
         print("Done building fonts!")
 

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -143,7 +143,6 @@ def fix_unhinted_font(ttFont):
     """Improve the appearance of an unhinted font on Win platforms by:
         - Add a new GASP table with a newtable that has a single
           range which is set to smooth.
-        - Add a new prep table which is optimized for unhinted fonts.
 
     Args:
         ttFont: a TTFont instance
@@ -152,12 +151,6 @@ def fix_unhinted_font(ttFont):
     # Set GASP so all sizes are smooth
     gasp.gaspRange = {65535: 0x000a}
 
-    program = ttProgram.Program()
-    assembly = ["PUSHW[]", "511", "SCANCTRL[]", "PUSHB[]", "4", "SCANTYPE[]"]
-    program.fromAssembly(assembly)
-
-    prep = newTable("prep")
-    prep.program = program
 
     ttFont["gasp"] = gasp
     ttFont["prep"] = prep

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -150,7 +150,7 @@ def fix_unhinted_font(ttFont):
     """
     gasp = newTable("gasp")
     # Set GASP so all sizes are smooth
-    gasp.gaspRange = {0xFFFF: 15}
+    gasp.gaspRange = {65535: 0x000a}
 
     program = ttProgram.Program()
     assembly = ["PUSHW[]", "511", "SCANCTRL[]", "PUSHB[]", "4", "SCANTYPE[]"]


### PR DESCRIPTION
The current GASP setting in the fix_unhinted_font tooling actually turns on hinting across the entire range. An unhinted font should have gridfit turned off, and smoothing turned on. This fix corrects that.

Additionally, once the hinting has been turned off, the prep table modification has no impact on font rendering, so that code has been removed as well. 