### PR TITLE
Ensure fsSelection bit 7 is set

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -218,7 +218,7 @@ def fix_fs_selection(ttFont):
     old_selection = fs_selection = ttFont["OS/2"].fsSelection
 
     # turn off all bits except for bit 7 (USE_TYPO_METRICS)
-    fs_selection &= 1 << 7
+    fs_selection = 1 << 7
 
     if "Italic" in tokens:
         fs_selection |= 1 << 0


### PR DESCRIPTION
fontbakery is [now](https://github.com/googlefonts/fontbakery/issues/3241) demanding the OS/2.fsSelection bit 7 be set. When fixing the fsSelection field, we should set it.