### PR TITLE
Update push-stats

### DIFF
--- a/Lib/gftools/push-templates/index.html
+++ b/Lib/gftools/push-templates/index.html
@@ -1,0 +1,332 @@
+<html>
+	<head>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
+		<style>
+			html{font-family:sans-serif;}
+	    h2 {
+		display: block;
+		font-size: 1.5em;
+		margin-block-start: 0.83em;
+		margin-block-end: 0.83em;
+		margin-inline-start: 0px;
+		margin-inline-end: 0px;
+		font-weight: bold;
+		margin-top: 48pt;
+	    }
+	    .nav {
+		position: fixed;
+		right: 30pt;
+		top: 30pt;
+	    }
+		</style>
+	</head>
+    <body>
+	<h1>Google Fonts Reporter</h1>
+	<div class="nav">
+	    <button data-duration="weekly">Weekly</button>
+	    <button data-duration="monthly">Monthly</button>
+	    <button data-duration="quarterly">Quarterly</button>
+	    <button data-duration="annually">Annually</button>
+
+	    <label for="start-date">Start:</label>
+            <select name="start-date">
+            {% for year in years %}
+                {% if year == current_year-2 %}
+                    <option selected="selected" value="{{ year }}">{{ year }}</option>
+                {% else %}
+                    <option value="{{ year }}">{{ year }}</option>
+                {% endif %}
+            {% endfor %}
+            </select>
+
+            <label for="end-date">End:</label>
+            <select name="end-date">
+            {% for year in years %}
+                {% if year == current_year+1 %}
+                    <option selected="selected" value="{{ year }}">{{ year }}</option>
+                {% else %}
+                    <option value="{{ year }}">{{ year }}</option>
+                {% endif %}
+            {% endfor %}
+            </select>
+	</div>
+	<h2>Pushes</h2>
+	<canvas id="commits-chart" width="800" height="450"></canvas>
+
+	<h2>Contributors</h2>
+	<canvas id="contributors-chart" width="800" height="450"></canvas>
+
+	<h2>Issues</h2>
+	<canvas id="issues-chart" width="800" height="450"></canvas>
+
+    </body>
+    <script>
+var data = {{ commit_data|safe }}
+var colors = [
+    "#193B59", // blue
+    "#BACAC0", // green
+    "#F2D2B6", // yellow
+    "#F2AD94", // orange
+    "#F2AD94" // red
+];
+
+
+offset_date = (date, duration) => {
+    if (duration === "daily") {
+	date.setHours(date.getHours() - 24)
+    }
+    else if (duration === "weekly") {
+	date.setHours(date.getHours() - 24*7)
+    }
+    else if (duration === "monthly") {
+	date.setMonth(date.getMonth() - 1)
+    }
+    else if (duration === "quarterly") {
+	date.setMonth(date.getMonth() - 3)
+    }
+    else if (duration === "annually") {
+	date.setYear(date.getFullYear() - 1);
+    }
+    else {
+	throw "duration param is not correct!";
+    }
+    return date
+
+}
+
+filter_commits = (data, start, end) => {
+    res = [];
+    for (i in data) {
+	if (data[i]['date'] >= start && data[i]['date'] <= end) {
+	    res.push(data[i]);
+	}
+    }
+    return res;
+}
+
+contributors_graph_data = (commits, top) => {
+    let res = {};
+    for (i in commits) {
+	let commit = commits[i];
+	let author = commit['author'];
+	if (!(author in res)) {
+	    res[author] = 0;
+	}
+	res[author] += 1;
+    }
+    var sorted = [];
+    for (k in res) {
+	sorted.push([k, res[k]]);
+    }
+    sorted.sort(function(a, b){
+	return b[1] - a[1]
+    });
+    sorted = sorted.slice(0, top);
+
+    var labels = [];
+    for (i in sorted) {
+	labels.push(sorted[i][0]);
+    }
+    var data = [];
+    for (i in sorted) {
+	data.push(sorted[i][1]);
+    }
+    return {
+	type: 'pie',
+	data: {
+	    labels: labels,
+	    datasets: [{
+		label: "Total commits",
+		backgroundColor: colors,
+		data: data
+	    }]
+	},
+	options: {
+	    title: {
+		display: true,
+		text: 'Total commits'
+		}
+	    }
+    };
+}
+
+
+commits_graph_data = (data, duration) => {
+    var delta = new Date(data[0]['date'])
+    var label = delta.toDateString();
+    let res = {};
+    for (i in data) {
+	let date = Date.parse(data[i]['date']);
+	var label = delta.toISOString();
+	if (date > delta) {
+	    if (data[i]['kind'] === "family") {
+		res[label]['family'] += 1;
+	    } else if (data[i]['kind'] === 'metadata') {
+		res[label]['metadata'] += 1;
+	    } else if (data[i]['kind'] === 'designer') {
+		res[label]['designer'] += 1;
+	    } else if (data[i]['kind'] === 'infrastructure') {
+		res[label]['infrastructure'] += 1;
+	    }
+	}
+	else {
+	    var delta = offset_date(delta, duration);
+	    var label = delta.toISOString();
+	    res[label] = {"family": 0, "metadata": 0, "designer": 0, "infrastructure": 0};
+	}
+    }
+    var keys = Object.keys(res).sort();
+    var data = {
+	"type": "line",
+	"data": {
+	    "labels": keys,
+	    "datasets": [
+		{
+		    "data": [],
+		    "label": "Designers",
+		    "borderColor": colors[1],
+		    lineTension: 0,  
+		    borderCapStyle: "bevel",
+		    "fill": false
+		},
+		{
+		    "data": [],
+		    "label": "Families",
+		    "borderColor": colors[0],
+		    lineTension: 0,  
+		    borderCapStyle: "bevel",
+		    "fill": false
+		},
+		{
+		    "data": [],
+		    "label": "Metadata",
+		    "borderColor": colors[2],
+		    lineTension: 0,  
+		    borderCapStyle: "bevel",
+		    "fill": false
+		},
+		{
+		    "data": [],
+		    "label": "Infrastructure",
+		    "borderColor": colors[3],
+		    lineTension: 0,  
+		    borderCapStyle: "bevel",
+		    "fill": false
+		},
+	    ] 
+	},
+	options: {
+	    title: {
+		display: true,
+		text: 'Pull requests merged'
+	    }
+	}
+    };
+    for (i in keys) {
+	var key = keys[i];
+	var d = res[key];
+	data['data']['datasets'][0]['data'].push(d['designer']);
+	data['data']['datasets'][1]['data'].push(d['family']);
+	data['data']['datasets'][2]['data'].push(d['metadata']);
+	data['data']['datasets'][3]['data'].push(d['infrastructure']);
+    }
+    return data
+}
+
+issues_graph_data = (issues, duration) => {
+    var delta = new Date(issues[0]['date'])
+    var label = delta.toDateString();
+    let res = {};
+    for (i in issues) {
+	let date = Date.parse(issues[i]['date']);
+	var label = delta.toISOString();
+	if (date > delta) {
+	    if (issues[i]['closed'] === false) {
+		res[label]['opened'] += 1
+	    } else {
+		res[label]['closed'] += 1
+	    }
+	}
+	else {
+	    console.log(duration)
+	    var delta = offset_date(delta, duration);
+	    var label = delta.toISOString();
+	    res[label] = {"opened": 0, "closed": 0};
+	}
+    }
+    var keys = Object.keys(res).sort();
+    var opened = [];
+    var closed = [];
+    for (i in keys) {
+	var issue = res[keys[i]];
+	opened.push(issue['opened'])
+	closed.push(issue['closed'])
+    }
+    var data = {
+	type: 'bar',
+	data: {
+	    labels: keys,
+	    datasets: [
+		{
+		label: "Opened",
+		backgroundColor: colors[0],
+		data: opened
+		}, {
+		label: "Closed",
+		backgroundColor: colors[2],
+		data: closed
+		}
+	    ]
+	},
+	options: {
+	    title: {
+		display: true,
+		text: 'Issues opened and closed'
+	    }
+	}
+    }
+    return data;
+}
+
+
+// init constants. TODO Use classes if this gets more complicated
+duration = "quarterly"
+start_date = document.getElementsByName("start-date")[0]
+end_date = document.getElementsByName("end-date")[0]
+
+commits_chart = new Chart(document.getElementById("commits-chart"), commits_graph_data(data['commits'], duration));
+contributors_chart = new Chart(document.getElementById("contributors-chart"), contributors_graph_data(data['commits'], 7));
+issues_chart = new Chart(document.getElementById("issues-chart"), issues_graph_data(data['issues'], duration));
+
+build_charts = (start, end, duration) => {
+    var commits = filter_commits(data['commits'], start, end);
+    var issues = filter_commits(data['issues'], start, end);
+    console.log(commits.length)
+    
+    commits_chart.destroy();
+    commits_chart = new Chart(document.getElementById("commits-chart"), commits_graph_data(commits, duration));
+    
+    contributors_chart.destroy();
+    contributors_chart = new Chart(document.getElementById("contributors-chart"), contributors_graph_data(commits, 7));
+
+    issues_chart.destroy();
+    issues_chart = new Chart(document.getElementById("issues-chart"), issues_graph_data(issues, duration));
+}
+
+const buttons = document.querySelectorAll('button');
+buttons.forEach(elem => elem.addEventListener("click", function(){
+    duration = elem.dataset.duration;
+    build_charts(start_date, end_date, duration)
+}, false))
+
+start_date.addEventListener("change", function() {
+    start_date = document.getElementsByName("start-date")[0].value;
+    build_charts(start_date, end_date, duration)
+}, false)
+end_date.addEventListener("change", function() {
+    end_date = document.getElementsByName("end-date")[0].value;
+    build_charts(start_date, end_date, duration)
+}, false)
+
+</script>
+</html>

--- a/Lib/gftools/push-templates/index.html
+++ b/Lib/gftools/push-templates/index.html
@@ -71,65 +71,65 @@ var colors = [
 ];
 
 
-offset_date = (date, duration) => {
+offsetDate = (date, duration) => {
     if (duration === "daily") {
-	date.setHours(date.getHours() - 24)
+        date.setHours(date.getHours() - 24);
     }
     else if (duration === "weekly") {
-	date.setHours(date.getHours() - 24*7)
+        date.setHours(date.getHours() - 24*7);
     }
     else if (duration === "monthly") {
-	date.setMonth(date.getMonth() - 1)
+        date.setMonth(date.getMonth() - 1);
     }
     else if (duration === "quarterly") {
-	date.setMonth(date.getMonth() - 3)
+        date.setMonth(date.getMonth() - 3);
     }
     else if (duration === "annually") {
-	date.setYear(date.getFullYear() - 1);
+        date.setYear(date.getFullYear() - 1);
     }
     else {
-	throw "duration param is not correct!";
+        throw "duration param is not correct!";
     }
-    return date
+    return date;
 
 }
 
-filter_commits = (data, start, end) => {
+filterCommits = (data, start, end) => {
     res = [];
     for (i in data) {
 	if (data[i]['date'] >= start && data[i]['date'] <= end) {
 	    res.push(data[i]);
-	}
+        }
     }
     return res;
 }
 
-contributors_graph_data = (commits, top) => {
+contributorsGraphData = (commits, top) => {
     let res = {};
     for (i in commits) {
-	let commit = commits[i];
-	let author = commit['author'];
-	if (!(author in res)) {
-	    res[author] = 0;
-	}
-	res[author] += 1;
+        let commit = commits[i];
+        let author = commit['author'];
+        if (!(author in res)) {
+            res[author] = 0;
+        }
+        res[author] += 1;
     }
     var sorted = [];
     for (k in res) {
 	sorted.push([k, res[k]]);
     }
-    sorted.sort(function(a, b){
+    sorted.sort(function(a, b) {
 	return b[1] - a[1]
     });
     sorted = sorted.slice(0, top);
 
     var labels = [];
     for (i in sorted) {
-	labels.push(sorted[i][0]);
+        labels.push(sorted[i][0]);
     }
     var data = [];
     for (i in sorted) {
-	data.push(sorted[i][1]);
+        data.push(sorted[i][1]);
     }
     return {
 	type: 'pie',
@@ -151,12 +151,12 @@ contributors_graph_data = (commits, top) => {
 }
 
 
-commits_graph_data = (data, duration) => {
+commitsGraphData = (data, duration) => {
     var delta = new Date(data[0]['date'])
     var label = delta.toDateString();
     let res = {};
     for (i in data) {
-	let date = Date.parse(data[i]['date']);
+        let date = Date.parse(data[i]['date']);
 	var label = delta.toISOString();
 	if (date > delta) {
 	    if (data[i]['kind'] === "family") {
@@ -170,7 +170,7 @@ commits_graph_data = (data, duration) => {
 	    }
 	}
 	else {
-	    var delta = offset_date(delta, duration);
+	    var delta = offsetDate(delta, duration);
 	    var label = delta.toISOString();
 	    res[label] = {"family": 0, "metadata": 0, "designer": 0, "infrastructure": 0};
 	}
@@ -233,7 +233,7 @@ commits_graph_data = (data, duration) => {
     return data
 }
 
-issues_graph_data = (issues, duration) => {
+issuesGraphData = (issues, duration) => {
     var delta = new Date(issues[0]['date'])
     var label = delta.toDateString();
     let res = {};
@@ -249,7 +249,7 @@ issues_graph_data = (issues, duration) => {
 	}
 	else {
 	    console.log(duration)
-	    var delta = offset_date(delta, duration);
+	    var delta = offsetDate(delta, duration);
 	    var label = delta.toISOString();
 	    res[label] = {"opened": 0, "closed": 0};
 	}
@@ -291,42 +291,46 @@ issues_graph_data = (issues, duration) => {
 
 // init constants. TODO Use classes if this gets more complicated
 duration = "quarterly"
-start_date = document.getElementsByName("start-date")[0]
-end_date = document.getElementsByName("end-date")[0]
+startDate = document.getElementsByName("start-date")[0].value
+endDate = document.getElementsByName("end-date")[0].value
 
-commits_chart = new Chart(document.getElementById("commits-chart"), commits_graph_data(data['commits'], duration));
-contributors_chart = new Chart(document.getElementById("contributors-chart"), contributors_graph_data(data['commits'], 7));
-issues_chart = new Chart(document.getElementById("issues-chart"), issues_graph_data(data['issues'], duration));
+commitsChart = null;
+contributorsChart = null;
+issuesChart = null;
 
-build_charts = (start, end, duration) => {
-    var commits = filter_commits(data['commits'], start, end);
-    var issues = filter_commits(data['issues'], start, end);
-    console.log(commits.length)
+
+buildCharts = (start, end, duration) => {
+    var commits = filterCommits(data['commits'], start, end);
+    var issues = filterCommits(data['issues'], start, end);
     
-    commits_chart.destroy();
-    commits_chart = new Chart(document.getElementById("commits-chart"), commits_graph_data(commits, duration));
-    
-    contributors_chart.destroy();
-    contributors_chart = new Chart(document.getElementById("contributors-chart"), contributors_graph_data(commits, 7));
-
-    issues_chart.destroy();
-    issues_chart = new Chart(document.getElementById("issues-chart"), issues_graph_data(issues, duration));
+    if (commitsChart != null) {
+        commitsChart.destroy();
+        contributorsChart.destroy();
+        issuesChart.destroy();
+    }
+    commitsChart = new Chart(document.getElementById("commits-chart"), commitsGraphData(commits, duration));
+    contributorsChart = new Chart(document.getElementById("contributors-chart"), contributorsGraphData(commits, 7));
+    issuesChart = new Chart(document.getElementById("issues-chart"), issuesGraphData(issues, duration));
 }
 
 const buttons = document.querySelectorAll('button');
-buttons.forEach(elem => elem.addEventListener("click", function(){
+buttons.forEach(elem => elem.addEventListener("click", function() {
     duration = elem.dataset.duration;
-    build_charts(start_date, end_date, duration)
-}, false))
+    buildCharts(startDate, endDate, duration)
+}, false));
 
-start_date.addEventListener("change", function() {
-    start_date = document.getElementsByName("start-date")[0].value;
-    build_charts(start_date, end_date, duration)
-}, false)
-end_date.addEventListener("change", function() {
-    end_date = document.getElementsByName("end-date")[0].value;
-    build_charts(start_date, end_date, duration)
-}, false)
+startDateBtn = document.getElementsByName("start-date")[0]
+startDateBtn.addEventListener("change", function() {
+    startDate = document.getElementsByName("start-date")[0].value;
+    buildCharts(startDate, endDate, duration)
+}, false);
+endDateBtn = document.getElementsByName("end-date")[0]
+endDateBtn.addEventListener("change", function() {
+    endDate = document.getElementsByName("end-date")[0].value;
+    buildCharts(startDate, endDate, duration)
+}, false);
+
+buildCharts(startDate, endDate, duration);
 
 </script>
 </html>

--- a/bin/gftools-push-stats.py
+++ b/bin/gftools-push-stats.py
@@ -69,7 +69,7 @@ def get_commits(repo):
 
 
 def get_issues(repo):
-    issues = list(repo.get_issues(state="all", since=datetime(2021, 5, 1)))
+    issues = list(repo.get_issues(state="all", since=datetime(2014, 1, 1)))
     res = []
     for i in issues:
         if i.pull_request:  # ignore prs

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
                       'template.upstream.yaml',
                       "axisregistry/*.textproto",
                       "udhr_all.txt",
-                      "templates/*.html"
+                      "templates/*.html",
+                      "push-templates/*.html"
                   ]
                  },
     scripts=gftools_scripts(),


### PR DESCRIPTION
`gftools push-stats` is currently a very primitive script. It's only able to report changes between two dates and it also uses the json files from each font server so changes made by the backend team are also included. Unfortunately this means massive collection wide hotfixes are also included.

This update uses the commit date from the repo itself and issue data from the github repo. The biggest change is that the tool will now generate html reports

![pl](https://user-images.githubusercontent.com/7525512/129746660-3f4105a0-bcc8-4321-b37a-b08ea2cd36f0.png)

My aim is to have this tool plumbed into github actions on the google/fonts repo. We can then generate a new report every week and have a dedicated url. This means anyone can view our progress without needing to bother me to generate reports/collect data.

This is still quite wip but I hope to have it finished by the end of the week. The JS is still a complete mess but I will tidy it in the coming days.
