### PR TITLE
Ensure that update_nametable correctly generates typo records

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -364,24 +364,20 @@ def update_nametable(ttFont, family_name=None, style_name=None):
     if not style_name:
         style_name = font_stylename(ttFont)
 
-    is_ribbi = style_name in ("Regular", "Bold", "Italic", "Bold Italic")
+    ribbi = ("Regular", "Bold", "Italic", "Bold Italic")
+    tokens = family_name.split() + style_name.split()
 
-    nameids = {}
-    if is_ribbi:
-        nameids[1] = family_name
-        nameids[2] = style_name
-    else:
-        tokens = style_name.split()
-        family_name_suffix = " ".join([t for t in tokens if t not in ["Italic"]])
-        nameids[1] = f"{family_name} {family_name_suffix}".strip()
-        nameids[2] = "Regular" if "Italic" not in tokens else "Italic"
-
-        typo_family_suffix = " ".join(
-            t for t in tokens if t not in list(WEIGHT_NAMES) + ["Italic"]
-        )
-        nameids[16] = f"{family_name} {typo_family_suffix}".strip()
-        typo_style = " ".join(t for t in tokens if t in list(WEIGHT_NAMES) + ["Italic"])
-        nameids[17] = typo_style
+    nameids = {
+        1: " ".join(t for t in tokens if t not in ribbi),
+        2: " ".join(t for t in tokens if t in ribbi) or "Regular",
+        16: " ".join(t for t in tokens if t not in list(WEIGHT_NAMES) + ['Italic']),
+        17: " ".join(t for t in tokens if t in list(WEIGHT_NAMES) + ['Italic']) or "Regular"
+    }
+    # Remove typo name if they match since they're redundant
+    if nameids[16] == nameids[1]:
+        del nameids[16]
+    if nameids[17] == nameids[2]:
+        del nameids[17]
 
     family_name = nameids.get(16) or nameids.get(1)
     style_name = nameids.get(17) or nameids.get(2)

--- a/Lib/gftools/tests/test_instancer.py
+++ b/Lib/gftools/tests/test_instancer.py
@@ -40,3 +40,26 @@ def test_gen_static_font_custom_names(var_font):
     assert _name_record(static_font, 16) == "Custom Family"
     assert _name_record(static_font, 17) == "Black"
 
+
+def test_gen_static_font_custom_names_without_declaring_wght(var_font):
+    static_font = gen_static_font(var_font, {"wght": 900}, "Custom Family", "8pt SemiCondensed")
+    assert _name_record(static_font, 1) == "Custom Family 8pt SemiCondensed"
+    assert _name_record(static_font, 2) == "Regular"
+    assert _name_record(static_font, 16) == None
+    assert _name_record(static_font, 17) == None
+
+
+def test_gen_static_font_custom_names_ribbi(var_font):
+    static_font = gen_static_font(var_font, {"wght": 900}, "Custom Family", "8pt SemiCondensed Bold Italic")
+    assert _name_record(static_font, 1) == "Custom Family 8pt SemiCondensed"
+    assert _name_record(static_font, 2) == "Bold Italic"
+    assert _name_record(static_font, 16) == None
+    assert _name_record(static_font, 17) == None
+
+
+def test_gen_static_font_custom_names_non_ribbi(var_font):
+    static_font = gen_static_font(var_font, {"wght": 900}, "Custom Family", "8pt SemiCondensed Medium")
+    assert _name_record(static_font, 1) == "Custom Family 8pt SemiCondensed Medium"
+    assert _name_record(static_font, 2) == "Regular"
+    assert _name_record(static_font, 16) == "Custom Family 8pt SemiCondensed"
+    assert _name_record(static_font, 17) == "Medium"


### PR DESCRIPTION
The current implementation will generate incorrect typographic name records for style names which do not include a weight token e.g:

family_name: Roboto
style_name: 8pt SemiCondensed

result:
familyName id1: Roboto 8pt SemiCondensed (correct since non wght and ital tokens are appended to the family name)
subFamilyname id2: Regular (correct)
typoFamilyName id16: Roboto 8pt SemiCondensed (not needed since it is the same as the familyName
typoSubFamilyName id17: "" (not needed since it is the same as the styleName. Should never be blank!)

My new heuristic will delete the typo records for the example given. The existing testcases also pass and I've added new ones to catch this issue.