### PR TITLE
Don't add dummy DSIG by default any more

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -702,8 +702,6 @@ def drop_mac_names(ttfont):
 
 def fix_font(font, include_source_fixes=False):
     font["OS/2"].version = 4
-    if "DSIG" not in font:
-        add_dummy_dsig(font)
 
     if "fpgm" in font:
         fix_hinted_font(font)


### PR DESCRIPTION
Fontbakery problem detection and gftools fixing has got out of sync again. (*as will always happen when the detection and the fixes are in different places...*) As per https://github.com/googlefonts/fontbakery/issues/3398, we don't want fonts to have a DSIG table:

> In fact, I think we should flip the check to WARN people if a DSIG is found at all, and tell them to remove it.