### PR TITLE
Drop Debg table on fix

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -78,6 +78,7 @@ UNWANTED_TABLES = frozenset(
         "TSI5",
         "prop",
         "MVAR",
+        "Debg",
     ]
 )
 


### PR DESCRIPTION
Guess what! It's another [fontbakery check](https://github.com/googlefonts/fontbakery/issues/3357) that got out of sync with the fix script! 