### PR TITLE
Drop python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         platform: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Package and PR a family update to google/fonts. Much more detailed [documentatio
 
 ## Tool Installation
 
+
+**Please note that gftools requires [Python 3.7](http://www.python.org/download/) or later.**
+
 Please install these tools using pip:
 
     pip install gftools

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3'
     ],
+    python_requires=">=3.7",
     setup_requires=['setuptools_scm>=4,<6.1'],
     # Dependencies needed for gftools qa.
     extras_require={"qa": ['fontbakery', 'fontdiffenator', 'gfdiffbrowsers']},


### PR DESCRIPTION
Since both fonttools and FB have dropped Python 3.6, we should do the same. It also won't be supported from next year anyway.