### PR TITLE
QA: do not require gf-api-key

### DIFF
--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -53,18 +53,15 @@ def download_family_from_Google_Fonts(family, dst=None):
     return fonts_from_zip(fonts_zip)
 
 
-def Google_Fonts_has_family(family):
+def Google_Fonts_has_family(name):
     """Check if Google Fonts has the specified font family"""
-    gf_api_key = load_Google_Fonts_api_key() or os.environ.get("GF_API_KEY")
-    if not gf_api_key:
-        raise FileNotFoundError("~/.gf-api-key or env not found. See ReadMe to create one")
-    api_url = 'https://www.googleapis.com/webfonts/v1/webfonts?key={}'.format(gf_api_key)
-    r = requests.get(api_url)
-    families_on_gf = [f['family'] for f in r.json()['items']]
-
-    if family in families_on_gf:
-        return True
-    return False
+    # This endpoint is private and may change at some point
+    # TODO (MF) if another function needs this data, refactor it into a
+    # function and use a lru cache
+    r = requests.get("https://fonts.google.com/metadata/fonts")
+    data = json.loads(r.text[5:])
+    family_names = set(i["family"] for i in data["familyMetadataList"])
+    return name in family_names
 
 
 def load_Google_Fonts_api_key():

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -37,9 +37,7 @@ from gftools.utils import (
     download_family_from_Google_Fonts,
     download_files_in_github_pr,
     download_files_in_github_dir,
-    download_file,
     Google_Fonts_has_family,
-    load_Google_Fonts_api_key,
     mkdir,
 )
 from gftools.html import HtmlProof, HtmlDiff


### PR DESCRIPTION
@ctrlcctrlv This pr will fix #427. However, it still requires a request to be sent.

I will eventually refactor the script so this request isn't needed but this is quite a bit of extra work since we use it in the google/fonts CI and other upstreams.