### PR TITLE
Require pandas at runtime only

### DIFF
--- a/bin/gftools-add-designer.py
+++ b/bin/gftools-add-designer.py
@@ -33,7 +33,6 @@ import os
 from PIL import Image
 from gftools.designers_pb2 import DesignerInfoProto
 from google.protobuf import text_format
-from pandas.core.base import PandasObject
 
 
 def process_image(fp):
@@ -154,7 +153,10 @@ def main():
     args = parser.parse_args()
 
     if args.spreadsheet:
-        import pandas as pd
+        try:
+            import pandas as pd
+        except ImportError as e:
+            raise ValueError("The pandas library is required to read Excel spreadsheets")
 
         df = pd.read_excel(args.spreadsheet)
         entry = df.loc[df["Name"] == args.name]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,5 @@ strictyaml
 tabulate
 unidecode
 skia-pathops
-pandas
 xlrd
 openpyxl

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ setup(
         'brotli',
         'browserstack-local==1.2.2',
         'pybrowserstack-screenshots==0.1',
-        'pandas',
         'xlrd',
         'openpyxl',
     ]


### PR DESCRIPTION
Installing gftools on M1 is obnoxiously slow because there isn't a wheel for pandas and it has to be built from scratch for every venv you install it into, and it takes *ages*. And you don't even need it 90% of the time! It's only used if you're using `gftools add-designer` *and* your input is an Excel spreadsheet.

Now that we're using the gftools-builder in UFR, and hence gftools is migrating towards more of a general userbase kind of thing, we need to be more aware of this kind of stuff.

This PR removes the pandas dependency, but tells you off if you do `gftools add-designer --spreadsheet` without pandas installed.