### PR TITLE
Add fix_glyph_names()

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -8,6 +8,7 @@ from fontTools.ttLib import TTFont, newTable, getTableModule
 from fontTools.ttLib.tables import ttProgram
 from fontTools.ttLib.tables._c_m_a_p import CmapSubtable
 from fontTools.ttLib.tables._f_v_a_r import NamedInstance
+from ufo2ft.postProcessor import PostProcessor
 from gftools.util.google_fonts import _KNOWN_WEIGHTS
 from gftools.utils import (
     download_family_from_Google_Fonts,
@@ -25,6 +26,7 @@ from gftools.utils import (
 from gftools.util.styles import (get_stylename, is_regular, is_bold, is_italic)
 from gftools.stat import gen_stat_tables
 
+from collections import namedtuple
 from os.path import basename, splitext
 from copy import deepcopy
 import logging
@@ -751,6 +753,29 @@ def drop_mac_names(ttfont):
             ttfont['name'].names.remove(name)
             changed = True
     return changed
+
+def fix_glyph_names(ttFont):
+    """Renames the font's glyphs to production names."""
+    # Piggy-back ufo2ft's implementation of production names
+    # This wants a glyphSet which maps names to objects which
+    # contain .name and .unicode attributes
+    fake_layer = namedtuple("fake_layer", ["name", "unicode"])
+    cmap = ttFont["cmap"].buildReversed()
+    glyphset = {}
+    old_names = ttFont.getGlyphOrder()
+    for glyph in old_names:
+        if glyph in cmap:
+            codepoint = list(cmap.get(glyph))[0]
+        else:
+            codepoint = None
+        glyphset[glyph] = fake_layer(glyph, codepoint)
+    # We have no UFO, so we have to fake up the object
+    pp = PostProcessor.__new__(PostProcessor)
+    pp.otf = ttFont
+    pp.glyphSet = glyphset
+    pp._postscriptNames = None
+    pp.process_glyph_names(useProductionNames=True)
+    return old_names != ttFont.getGlyphOrder()
 
 
 def fix_font(font, include_source_fixes=False, new_family_name=None):


### PR DESCRIPTION
This adds a fix for the fontbakery glyph naming check; it uses ufo2ft's logic to rename glyphs to production names. This is useful because in a variable-first workflow, you build the variable font first and then add GSUB/GPOS/GDEF tables to it from a variable feature file afterwards. To do this, the glyph names in the font have to be the same as the ones in the feature file, and hence you have to pass `--no-production-names` to fontmake, and then do the renaming afterwards. (You could use Rust's `ttf-rename-glyphs` but that's not part of our workflow yet. ;-)

Because this is a slightly obscure use case, I've not added it to `fix_font`.