### PR TITLE
packager: retain language field comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install packages
         run: |
           pip install .
-          pip install mypy==0.812 pytest
+          pip install mypy pytest
       - name: Run Tests
         run: |
           pytest ./Lib/gftools/tests/test_usage.py
@@ -33,4 +33,4 @@ jobs:
           pytest ./Lib/gftools/tests/test_stat.py
           pytest ./Lib/gftools/tests/test_html.py
           pytest ./Lib/gftools/tests/test_instancer.py
-          mypy ./Lib/gftools/packager.py
+          mypy --install-types --non-interactive ./Lib/gftools/packager.py

--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -38,6 +38,7 @@ from strictyaml import ( # type: ignore
 import functools
 from hashlib import sha1
 from fontTools.ttLib import TTFont # type: ignore
+from gftools.util import google_fonts as fonts
 
 # ignore type because mypy error: Module 'google.protobuf' has no
 # attribute 'text_format'
@@ -929,9 +930,8 @@ def _create_or_update_metadata_pb(upstream_conf: YAML,
     metadata.source.repository_url = upstream_conf['repository_url']
     metadata.source.commit = upstream_commit_sha
 
-  text_proto = text_format.MessageToString(metadata, as_utf8=True)
-  with open(metadata_file_name, 'w') as f:
-    f.write(text_proto)
+  language_comments = fonts.LanguageComments(fonts.LoadLanguages())
+  fonts.WriteProto(metadata, metadata_file_name, comments=language_comments)
 
 def _create_package_content(package_target_dir: str, repos_dir: str,
         upstream_conf_yaml: YAML, license_dir: str, gf_dir_content:dict,

--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -1125,7 +1125,7 @@ def _git_tree_from_dir(repo: pygit2.Repository, tmp_package_family_dir: str) -> 
   return trees['.']
 
 def _git_write_file(repo: pygit2.Repository, tree_builder: pygit2.TreeBuilder,
-                                        file_path: str, data: bytes) -> None:
+                                        file_path: str, data: str) -> None:
   blob_id = repo.create_blob(data)
   return _git_makedirs_write(repo, tree_builder, PurePath(file_path).parts,
                             blob_id, pygit2.GIT_FILEMODE_BLOB)

--- a/Lib/gftools/util/google_fonts.py
+++ b/Lib/gftools/util/google_fonts.py
@@ -463,7 +463,10 @@ def LicenseFromPath(path):
   return _EntryForEndOfPath(path, _KNOWN_LICENSE_DIRS)
 
 
-def LoadLanguages(languages_dir):
+def LoadLanguages(languages_dir=resource_filename(
+  "gftools",
+  os.path.join("lang", "languages"))
+):
   languages = {}
   for textproto_file in glob.iglob(os.path.join(languages_dir, '*.textproto')):
     with open(textproto_file, 'r', encoding='utf-8') as f:
@@ -490,10 +493,7 @@ def LoadRegions(regions_dir):
   return regions
 
 
-def SupportedLanguages(
-  ttFont,
-  languages=LoadLanguages(resource_filename("gftools", "lang/languages"))
-  ):
+def SupportedLanguages(ttFont, languages=LoadLanguages()):
   """Get languages supported by given ttFont.
 
   Languages are pulled from the given set. Based on whether exemplar character


### PR DESCRIPTION
Atm when we push a new family using the packager, it will write the language fields without including the comments. We discovered this in, https://github.com/google/fonts/pull/4215/files#diff-b6d066da27817af5009644b06c6baf1d3536cc27dd1449982d6fa016840a9555

This PR writes the comments by using the WriteProto function which is also used in `add-font` and `lang-support`