### PR TITLE
Detect script and pass to ttfautohint

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -88,8 +88,9 @@ required, all others have sensible defaults:
 * ``ttDir``: Where to put TrueType static fonts. Defaults to ``$outputDir/ttf``.
 * ``otDir``: Where to put CFF static fonts. Defaults to ``$outputDir/otf``.
 * ``woffDir``: Where to put WOFF2 static fonts. Defaults to ``$outputDir/webfonts``.
-* ``cleanUp`: Whether or not to remove temporary files. Defaults to ``true``.
-* ``autohintTTF`: Whether or not to autohint TTF files. Defaults to ``true``.
+* ``cleanUp``: Whether or not to remove temporary files. Defaults to ``true``.
+* ``autohintTTF``: Whether or not to autohint TTF files. Defaults to ``true``.
+* ``ttfaUseScript``: Whether or not to detect a font's primary script and add a ``-D<script>`` flag to ttfautohint. Defaults to ``false``.
 * ``axisOrder``: STAT table axis order. Defaults to fvar order.
 * ``familyName``: Family name for variable fonts. Defaults to family name of first source file.
 * ``flattenComponents``: Whether to flatten components on export. Defaults to ``true``.
@@ -258,6 +259,8 @@ class GFBuilder:
             self.config["buildWebfont"] = self.config["buildStatic"]
         if "autohintTTF" not in self.config:
             self.config["autohintTTF"] = True
+        if "ttfaUseScript" not in self.config:
+            self.config["ttfaUseScript"] = False
         if "logLevel" not in self.config:
             self.config["logLevel"] = "INFO"
         if "cleanUp" not in self.config:
@@ -470,7 +473,7 @@ class GFBuilder:
     def post_process_ttf(self, filename):
         if self.config["autohintTTF"]:
             self.logger.debug("Autohinting")
-            autohint(filename, filename)
+            autohint(filename, filename, add_script=self.config["ttfaUseScript"])
         self.post_process(filename)
         if self.config["buildWebfont"]:
             self.logger.debug("Building webfont")

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -103,6 +103,7 @@ from fontTools.otlLib.builder import buildStatTable
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.woff2 import main as woff2_main
 from gftools.builder.schema import schema
+from gftools.builder.autohint import autohint
 from gftools.fix import fix_font
 from gftools.stat import gen_stat_tables, gen_stat_tables_from_config
 from gftools.utils import font_is_italic, font_familyname, font_stylename
@@ -469,18 +470,12 @@ class GFBuilder:
     def post_process_ttf(self, filename):
         if self.config["autohintTTF"]:
             self.logger.debug("Autohinting")
-            self.autohint(filename)
+            autohint(filename, filename)
         self.post_process(filename)
         if self.config["buildWebfont"]:
             self.logger.debug("Building webfont")
             woff2_main(["compress", filename])
             self.move_webfont(filename)
-
-    def autohint(self, filename):
-        from ttfautohint.options import parse_args as ttfautohint_parse_args
-        from ttfautohint import ttfautohint
-
-        ttfautohint(**ttfautohint_parse_args([filename, filename]))
 
     def build_vtt(self, font_dir):
         for font, vtt_source in self.config['vttSources'].items():

--- a/Lib/gftools/builder/autohint.py
+++ b/Lib/gftools/builder/autohint.py
@@ -1,0 +1,97 @@
+from ttfautohint import ttfautohint
+from fontTools.ttLib import TTFont
+from ttfautohint.options import parse_args as ttfautohint_parse_args
+from fontTools import unicodedata
+from collections import Counter
+import sys
+
+AUTOHINT_SCRIPTS = [
+    "adlm",
+    "arab",
+    "armn",
+    "avst",
+    "bamu",
+    "beng",
+    "buhd",
+    "cakm",
+    "cans",
+    "cari",
+    "cher",
+    "copt",
+    "cprt",
+    "cyrl",
+    "deva",
+    "dsrt",
+    "ethi",
+    "geor",
+    "geok",
+    "glag",
+    "goth",
+    "grek",
+    "gujr",
+    "guru",
+    "hebr",
+    "hmnp",
+    "kali",
+    "khmr",
+    "khms",
+    "knda",
+    "lao",
+    "latn",
+    "latb",
+    "latp",
+    "lisu",
+    "mlym",
+    "medf",
+    "mong",
+    "mymr",
+    "nkoo",
+    "olck",
+    "orkh",
+    "osge",
+    "osma",
+    "rohg",
+    "saur",
+    "shaw",
+    "sinh",
+    "sund",
+    "taml",
+    "tavt",
+    "telu",
+    "tfng",
+    "thai",
+    "vaii",
+    "yezi",
+]
+
+
+def autohint_script_tag(ttFont):
+    script_count = Counter()
+    for x in font.getBestCmap().keys():
+        for script in unicodedata.script_extension(chr(x)):
+            if script[0] != "Z":
+                script_count[script] += 1
+    # If there isn't a clear winner, give up
+    if (
+        len(script_count) > 2
+        and script_count.most_common(2)[0][1] < 2 * script_count.most_common(2)[1][1]
+    ):
+        return
+
+    most_common = script_count.most_common(1)
+    if most_common:
+        script = most_common[0][0].lower()
+        if script in AUTOHINT_SCRIPTS:
+            return script
+
+
+def autohint(infile, outfile, args=None):
+    font = TTFont(infile)
+    if not args:
+        args = []
+        script = autohint_script_tag(font)
+        if script:
+            args.append("-D" + script)
+    print(args)
+
+    ttfautohint(**ttfautohint_parse_args([infile, outfile, *args]))

--- a/Lib/gftools/builder/autohint.py
+++ b/Lib/gftools/builder/autohint.py
@@ -85,12 +85,13 @@ def autohint_script_tag(ttFont):
             return script
 
 
-def autohint(infile, outfile, args=None):
+def autohint(infile, outfile, args=None, add_script=False):
     font = TTFont(infile)
     if not args:
         args = []
-        script = autohint_script_tag(font)
-        if script:
-            args.append("-D" + script)
+        if add_script:
+            script = autohint_script_tag(font)
+            if script:
+                args.append("-D" + script)
 
     ttfautohint(**ttfautohint_parse_args([infile, outfile, *args]))

--- a/Lib/gftools/builder/autohint.py
+++ b/Lib/gftools/builder/autohint.py
@@ -67,7 +67,7 @@ AUTOHINT_SCRIPTS = [
 
 def autohint_script_tag(ttFont):
     script_count = Counter()
-    for x in font.getBestCmap().keys():
+    for x in ttFont.getBestCmap().keys():
         for script in unicodedata.script_extension(chr(x)):
             if script[0] != "Z":
                 script_count[script] += 1
@@ -92,6 +92,5 @@ def autohint(infile, outfile, args=None):
         script = autohint_script_tag(font)
         if script:
             args.append("-D" + script)
-    print(args)
 
     ttfautohint(**ttfautohint_parse_args([infile, outfile, *args]))

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -74,5 +74,6 @@ schema = Map(
         Optional("axisOrder"): Seq(Str()),
         Optional("flattenComponents"): Bool(),
         Optional("decomposeTransformedComponents"): Bool(),
+        Optional("ttfaUseScript"): Bool(),
     }
 )


### PR DESCRIPTION
The Noto build scripts pass a `-D<script>` argument to ttfautohint to enable script-specific hinting adjustments. This is a nice idea, and we should do it if possible. Also, the way Noto implements it is [horrible and arbitrary](https://github.com/googlefonts/noto-source/blob/3eab4dae98b0a40d38d216cab2a66b32000f3bfc/misc_scripts/publish-one-noto-font.sh#L48) and I'd like to move Noto's build scripts to cleaner code based on gftools where possible.

This checks whether a font file has a clear "winning" script (defined as having more than twice as many code points as any other script in the font) and, if ttfautohint has a script-specific handler for that script, passes the appropriate `-D` flag.