### PR TITLE
Update gftools-qa to log INFO message when using fontbakery

### DIFF
--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -186,7 +186,7 @@ class FontQA:
         out = os.path.join(self.out, "Fontbakery")
         mkdir(out)
         cmd = (
-            ["fontbakery", "check-googlefonts", "-l", "WARN"]
+            ["fontbakery", "check-googlefonts", "-l", "INFO"]
             + [f.reader.file.name for f in self.fonts]
             + ["-C"]
             + ["--ghmarkdown", os.path.join(out, "report.md")]


### PR DESCRIPTION
fixes #483