### PR TITLE
Use --succinct flag to FB

### DIFF
--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -186,7 +186,7 @@ class FontQA:
         out = os.path.join(self.out, "Fontbakery")
         mkdir(out)
         cmd = (
-            ["fontbakery", "check-googlefonts", "-l", "INFO"]
+            ["fontbakery", "check-googlefonts", "-l", "INFO", "--succinct"]
             + [f.reader.file.name for f in self.fonts]
             + ["-C"]
             + ["--ghmarkdown", os.path.join(out, "report.md")]


### PR DESCRIPTION
See #488. In fact, fontbakery *does* remove the rationales when `--succinct` is passed (in reports, not just in terminal), and also we are seeing problems with reports failing to upload because they are too big.