### PR TITLE
Move Github client from packager to own module

### DIFF
--- a/Lib/gftools/github.py
+++ b/Lib/gftools/github.py
@@ -1,0 +1,100 @@
+import os
+import pprint
+import requests
+import typing
+import urllib
+
+
+GITHUB_GRAPHQL_API = 'https://api.github.com/graphql'
+GITHUB_V3_REST_API = 'https://api.github.com'
+
+
+class GitHubClient:
+    def __init__(self, repo_owner, repo_name):
+        if not 'GH_TOKEN' in os.environ:
+            raise Exception("GH_TOKEN environment variable not set")
+        self.gh_token = os.environ['GH_TOKEN']
+        self.repo_owner = repo_owner
+        self.repo_name = repo_name
+    
+    def _post(self, url, payload: typing.Dict):
+        headers = {'Authorization': f'bearer {self.gh_token}'}
+        response = requests.post(url, json=payload, headers=headers)
+        if response.status_code == requests.codes.unprocessable:
+            # has a helpful response.json with an 'errors' key.
+            pass
+        else:
+            response.raise_for_status()
+        json = response.json()
+        if 'errors' in json:
+            errors = pprint.pformat(json['errors'], indent=2)
+            raise Exception(f'GitHub POST query failed to url {url}:\n {errors}')
+        return json
+    
+    def _get(self, url):
+        headers = {'Authorization': f'bearer {self.gh_token}'}
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        json = response.json()
+        if 'errors' in json:
+            errors = pprint.pformat(json['errors'], indent=2)
+            raise Exception(f'GitHub REST query failed:\n {errors}')
+        return json
+        
+    def _run_graphql(self, query, variables):
+        payload = {'query': query, 'variables': variables}
+        return self._post(GITHUB_GRAPHQL_API, payload)
+    
+    def rest_url(self, path, **kwargs):
+        base_url = f'{GITHUB_V3_REST_API}/repos/{self.repo_owner}/{self.repo_name}/{path}'
+        if kwargs:
+            base_url += '?' + '&'.join(f'{k}={urllib.parse.quote(v)}' for k, v in kwargs.items())
+        return base_url
+
+    def get_blob(self, file_sha):
+        url = self._rest_repo_url + f'/git/blobs/{file_sha}'
+        headers = {
+            'Accept': 'application/vnd.github.v3.raw',
+            'Authorization': f'bearer {github_api_token}'
+        }
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        return response
+    
+    def open_prs(self, pr_head: str, pr_base_branch: str) -> typing.List:
+        return self._get(self.rest_url("pulls", state="open"))
+    
+    def create_pr(self, title: str, body: str, head: str, base: str):
+        return self._post(
+            self.rest_url("pulls"),
+            {
+                'title': title,
+                'body': body,
+                'head': head,
+                'base': base,
+                'maintainer_can_modify': True
+            }
+        )
+    
+    def create_issue_comment(self, issue_number: int, body: str):
+        return self._post(
+            self.rest_url(f'issues/{issue_number}/comments'),
+            {
+                'body': body
+            }
+        )
+    
+    def create_issue(self, title: str, body: str):
+        return self._post(
+            self.rest_url("issues"),
+            {
+                'title': title,
+                'body': body
+            }
+        )
+
+
+
+
+
+

--- a/Lib/gftools/github.py
+++ b/Lib/gftools/github.py
@@ -52,17 +52,17 @@ class GitHubClient:
         return base_url
 
     def get_blob(self, file_sha):
-        url = self._rest_repo_url + f'/git/blobs/{file_sha}'
+        url = self.rest_url(f'git/blobs/{file_sha}')
         headers = {
             'Accept': 'application/vnd.github.v3.raw',
-            'Authorization': f'bearer {github_api_token}'
+            'Authorization': f'bearer {self.gh_token}'
         }
         response = requests.get(url, headers=headers)
         response.raise_for_status()
         return response
     
     def open_prs(self, pr_head: str, pr_base_branch: str) -> typing.List:
-        return self._get(self.rest_url("pulls", state="open"))
+        return self._get(self.rest_url("pulls", state="open", head=pr_head, base=pr_base_branch))
     
     def create_pr(self, title: str, body: str, head: str, base: str):
         return self._post(

--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -147,7 +147,7 @@ def get_gh_gf_family_entry(family_name):
   family_name_normal = _family_name_normal(family_name)
   variables = _get_query_variables('google','fonts', family_name_normal)
 
-  result = _run_gh_graphql_query(GITHUB_GRAPHQL_GET_FAMILY_ENTRY, variables)
+  result = GitHubClient("google", "fonts")._run_graphql(GITHUB_GRAPHQL_GET_FAMILY_ENTRY, variables)
   return result
 
 def _git_tree_iterate(path, tree, topdown):

--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -39,6 +39,7 @@ import functools
 from hashlib import sha1
 from fontTools.ttLib import TTFont # type: ignore
 from gftools.util import google_fonts as fonts
+from gftools.github import GitHubClient
 
 # ignore type because mypy error: Module 'google.protobuf' has no
 # attribute 'text_format'
@@ -62,13 +63,6 @@ with open(resource_filename('gftools', 'template.upstream.yaml')) as f:
   # without adding them to the call to format (KeyError).
   upstream_yaml_template = upstream_yaml_template.replace('{CATEGORIES}', ', '.join(CATEGORIES))
 
-
-
-# GITHUB_REPO_HTTPS_URL = 'https://github.com/{gh_repo_name_with_owner}.git'.format
-GITHUB_REPO_SSH_URL = 'git@github.com:{repo_name_with_owner}.git'.format
-
-GITHUB_GRAPHQL_API = 'https://api.github.com/graphql'
-GITHUB_V3_REST_API = 'https://api.github.com'
 
 GIT_NEW_BRANCH_PREFIX = 'gftools_packager_'
 # Using object(expression:$rev), we query all three license folders
@@ -142,29 +136,6 @@ def _get_query_variables(repo_owner, repo_name, family_name, reference='refs/hea
     'uflDir': f'{reference}:ufl/{family_name}'
   }
 
-def _get_github_api_token() -> str:
-  # $ export GH_TOKEN={the GitHub API token}
-  return os.environ['GH_TOKEN']
-
-def _post_github(url: str, payload: typing.Dict):
-  github_api_token = _get_github_api_token()
-  headers = {'Authorization': f'bearer {github_api_token}'}
-  response = requests.post(url, json=payload, headers=headers)
-  if response.status_code == requests.codes.unprocessable:
-    # has a helpful response.json with an 'errors' key.
-    pass
-  else:
-    response.raise_for_status()
-  json = response.json()
-  if 'errors' in json:
-    errors = pprint.pformat(json['errors'], indent=2)
-    raise Exception(f'GitHub POST query failed to url {url}:\n {errors}')
-  return json
-
-def _run_gh_graphql_query(query, variables):
-  payload = {'query': query, 'variables': variables}
-  return _post_github(GITHUB_GRAPHQL_API, payload)
-
 def _family_name_normal(family_name: str) -> str:
   return family_name.lower()\
       .replace(' ', '')\
@@ -200,21 +171,8 @@ def _git_tree_iterate(path, tree, topdown):
 def _git_tree_walk(path, tree, topdown=True):
   yield from _git_tree_iterate(path.split(os.sep), tree[path], topdown)
 
-def get_github_blob(repo_owner, repo_name, file_sha):
-  github_api_token = _get_github_api_token()
-  url = f'{GITHUB_V3_REST_API}/repos/{repo_owner}/{repo_name}/git/blobs/{file_sha}'
-  headers = {
-    'Accept': 'application/vnd.github.v3.raw',
-    'Authorization': f'bearer {github_api_token}'
-  }
-  response = requests.get(url, headers=headers)
-  # print(f'response headers: {pprint.pformat(response.headers, indent=2)}')
-  # raises requests.exceptions.HTTPError
-  response.raise_for_status()
-  return response
-
 def get_github_gf_blob(file_sha):
-  return get_github_blob('google', 'fonts', file_sha)
+  return GitHubClient('google', 'fonts').get_blob(file_sha)
 
 def _shallow_clone_git(target_dir, git_url, branch_or_tag='main'):
   """
@@ -1198,53 +1156,8 @@ def _push(repo: pygit2.Repository, url: str, local_branch_name: str,
   #if callbacks.rejected_push_message is not None:
   #  raise Exception(callbacks.rejected_push_message)
 
-def get_github_open_pull_requests(repo_owner: str, repo_name: str,
-                pr_head: str, pr_base_branch: str) -> typing.Union[typing.List]:
-  url = (f'{GITHUB_V3_REST_API}/repos/{repo_owner}/{repo_name}/pulls?state=open'
-         f'&head={urllib.parse.quote(pr_head)}'
-         f'&base={urllib.parse.quote(pr_base_branch)}')
-  github_api_token = _get_github_api_token()
-  headers = {'Authorization': f'bearer {github_api_token}'}
+GITHUB_REPO_SSH_URL = 'git@github.com:{repo_name_with_owner}.git'.format
 
-  response = requests.get(url, headers=headers)
-  # print(f'response headers: {pprint.pformat(response.headers, indent=2)}')
-  # raises requests.exceptions.HTTPError
-  response.raise_for_status()
-  json = response.json()
-  if 'errors' in json:
-    errors = pprint.pformat(json['errors'], indent=2)
-    raise Exception(f'GitHub REST query failed:\n {errors}')
-  return json
-
-def create_github_pull_request(repo_owner: str, repo_name: str, pr_head: str,
-                               pr_base_branch: str, title: str, body: str):
-  url = f'{GITHUB_V3_REST_API}/repos/{repo_owner}/{repo_name}/pulls'
-  payload = {
-    'title': title,
-    'body': body,
-    'head': pr_head,
-    'base': pr_base_branch,
-    'maintainer_can_modify': True
-  }
-  return _post_github(url, payload)
-
-def create_github_issue_comment(repo_owner: str, repo_name: str,
-                                issue_number: int, pr_comment_body: str):
-  url = (f'{GITHUB_V3_REST_API}/repos/{repo_owner}/{repo_name}/issues'
-          f'/{issue_number}/comments')
-  payload = {
-    'body': pr_comment_body
-  }
-  return _post_github(url, payload)
-
-def create_github_issue(repo_owner: str, repo_name: str,
-                        pr_title: str, pr_body: str):
-  url = (f'{GITHUB_V3_REST_API}/repos/{repo_owner}/{repo_name}/issues')
-  payload = {
-    'title': pr_title,
-    'body': pr_body
-  }
-  return _post_github(url, payload)
 
 def _make_pr(repo: pygit2.Repository, local_branch_name: str,
                                   pr_upstream: str, push_upstream: str,
@@ -1284,20 +1197,18 @@ def _make_pr(repo: pygit2.Repository, local_branch_name: str,
     #_updateUpstream(prRemoteName, prRemoteRef))
     #// NOTE: at this point the PUSH was already successful, so the branch
     #// of the PR exists or if it existed it has changed.
-  open_prs = get_github_open_pull_requests(pr_owner, pr_repo, pr_head,
-                                           pr_base_branch)
+  client = GitHubClient(pr_owner, pr_repo)
+  open_prs = client.open_prs(pr_head, pr_base_branch)
 
   if not len(open_prs):
     # No open PRs, creating …
-    result = create_github_pull_request(pr_owner, pr_repo, pr_head,
-                                pr_base_branch, pr_title, pr_message_body)
+    result = client.create_pr(pr_title, pr_message_body, pr_head, pr_base_branch)
     print(f'Created a PR #{result["number"]} {result["html_url"]}')
   else:
     # found open PR
     pr_issue_number = open_prs[0]['number']
     pr_comment_body = f'Updated\n\n## {pr_title}\n\n---\n{pr_message_body}'
-    result = create_github_issue_comment(pr_owner, pr_repo, pr_issue_number,
-                                                        pr_comment_body)
+    result = client.create_issue_comment(pr_issue_number, pr_comment_body)
     print(f'Created a comment in PR #{pr_issue_number} {result["html_url"]}')
 
 def _get_root_commit(repo: pygit2.Repository, base_remote_branch:str,

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -43,10 +43,7 @@ except ModuleNotFoundError:
     raise ModuleNotFoundError(("gftools was installed without the QA "
         "dependencies. To install the dependencies, see the ReadMe, "
         "https://github.com/googlefonts/gftools#installation"))
-from gftools.packager import (
-    create_github_issue_comment,
-    create_github_issue
-)
+from gftools.github import GitHubClient
 
 __version__ = "2.1.3"
 logger = logging.getLogger(__name__)
@@ -265,17 +262,15 @@ class FontQA:
                 "Cannot Post Github message because no Fontbakery report exists"
             )
             return
+        
+        client = GitHubClient(repo_owner, repo_name)
 
         with open(fontbakery_report) as doc:
             msg = doc.read()
             if issue_number:
-                create_github_issue_comment(
-                    repo_owner, repo_name, issue_number, msg
-                )
+                client.create_issue_comment(issue_number, msg)
             else:
-                create_github_issue(
-                    repo_owner, repo_name, "Google Font QA report", msg
-                )
+                client.create_issue("Google Font QA report", msg)
 
 
 def family_name_from_fonts(fonts):


### PR DESCRIPTION
The packager module is very big, and contains lots of code, not all of which is related to packaging; in addition, the GitHub-y bits of it are also used by gftools-qa. I'm hoping to use them for something else too, but they need disentangling first.

I've tested that gftools qa still works after this, but not the packager bits.