### PR TITLE
Fixing missing axisregistry items

### DIFF
--- a/bin/gftools-add-font.py
+++ b/bin/gftools-add-font.py
@@ -55,11 +55,13 @@ from gflanguages import LoadLanguages
 import gftools.fonts_public_pb2 as fonts_pb2
 from gftools.util import google_fonts as fonts
 from gftools.utils import cmp
-from gftools.axisreg import axis_registry
+from axisregistry import AxisRegistry
 from glyphsets.codepoints import SubsetsInFont
 from absl import app
 from google.protobuf import text_format
 from pkg_resources import resource_filename
+
+axis_registry = AxisRegistry()
 
 FLAGS = flags.FLAGS
 

--- a/bin/gftools-ufo-fix-instances.py
+++ b/bin/gftools-ufo-fix-instances.py
@@ -10,9 +10,10 @@ gftools ufo-fix-instances family.designspace
 from fontTools.designspaceLib import DesignSpaceDocument, InstanceDescriptor
 from copy import deepcopy
 from gftools.fix import WEIGHT_VALUES
-from gftools.axisreg import axis_registry as axis_reg
+from axisregistry import AxisRegistry
 import sys
 
+axis_reg = AxisRegistry()
 
 def build_instances(ds):
     """Generate Designspace instances which are gf spec complaint"""


### PR DESCRIPTION
It appears that when the axisreg code was split out (see #515 #516 ), a couple of instances of axisreg were missed, causing gftools packager to now fail.

This PR corrects the two that I found. 