### PR TITLE
[Builder] Make the schema inheritable

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -130,6 +130,8 @@ import tempfile
 
 
 class GFBuilder:
+    schema = schema
+
     def __init__(self, configfile=None, config=None):
         if configfile:
             self.config = self.load_config(configfile)
@@ -145,7 +147,7 @@ class GFBuilder:
         with open(configfile) as f:
             unprocessed_yaml = f.read()
         try:
-            return load(unprocessed_yaml, schema).data
+            return load(unprocessed_yaml, self.schema).data
         except YAMLValidationError as e:
             if "unexpected key not in schema" in e.problem:
                 bad_key = str(e.problem)


### PR DESCRIPTION
I'm extending the builder for the Noto project; not an upstreamable extension - the idea is to fetch other Noto sources and merging subsets from them into the UFO while building. To do this, I need to extend the YAML schema to allow me to define the subsets in the config file. Currently I can't do that without major surgery. With this two-liner, the schema becomes inheritable.