### PR TITLE
Add some scripts to be used in GH Actions

### DIFF
--- a/Lib/gftools/actions/__init__.py
+++ b/Lib/gftools/actions/__init__.py
@@ -1,0 +1,7 @@
+"""Scripts used for font repository automation by GitHub Actions
+
+This contains utility scripts used within GitHub Actions. Putting them
+here allows us to ensure that this code doesn't live in individual
+font repositories, and that the GH Actions can always access the most
+up-to-date versions of the scripts by installing gftools as part of the
+action."""

--- a/Lib/gftools/actions/checkgooglefonts.py
+++ b/Lib/gftools/actions/checkgooglefonts.py
@@ -1,0 +1,15 @@
+"""Test whether the font should be PRed to GF, inform GitHub if so.
+"""
+import yaml
+import os
+from sys import exit
+
+
+if __name__ == "__main__":
+    config = yaml.load(open(os.path.join("sources", "config.yaml")), Loader=yaml.FullLoader)
+    if "googleFonts" in config and config["googleFonts"]:
+        print("This font should be submitted to Google Fonts")
+        print(f"::set-output name=is_gf::true")
+    else:
+        print("This font should not be submitted to Google Fonts")
+        print(f"::set-output name=is_gf::false")

--- a/Lib/gftools/actions/checkversionbump.py
+++ b/Lib/gftools/actions/checkversionbump.py
@@ -1,0 +1,101 @@
+"""Test whether a new release of a font is needed, inform GitHub if so.
+
+This looks for changes to the font sources which alter the font version. If
+the version in the font source is greater than the version number found in
+the last git tag, then the new version number (to be used as a git tag)
+is reported to GitHub actions via the set-output mechanism.
+
+This is expected to be run within a git repository:
+
+    % python3 -m gftools.actions.checkversionbump
+    Current version is:  v1.001
+    There were no git tags.
+    Current version is  <bumpversion.Version:major=1, minor=1>
+    Old version was  v1.000
+    Result was untagged, new tag v1.001
+    ::set-output name=result::untagged
+    ::set-output name=newtag::v1.001
+
+"""
+import yaml
+import os
+import re
+from sys import exit
+from bumpfontversion.ufohandler import UFOHandler
+from bumpfontversion.glyphshandler import GlyphsHandler
+import pygit2
+import tempfile
+
+
+def get_version(path):
+    for handler in [UFOHandler(), GlyphsHandler()]:
+        if not handler.applies_to(path):
+            continue
+        return handler.current_version(path)
+
+
+def get_git_tags():
+    repo = pygit2.Repository(os.path.join(os.getcwd(), ".git"))
+    regex = re.compile("^refs/tags/v")
+    tags = [r.replace("refs/tags/", "") for r in repo.references if regex.match(r)]
+    return tags
+
+
+def format_tag(version):
+    v = int(version["major"].value) + (int(version["minor"].value) / 1000)
+    return "v%.03f" % v
+
+
+def version_has_ever_changed(file, version):
+    repo = pygit2.Repository(os.path.join(os.getcwd(), ".git"))
+    last = repo[repo.head.target]
+    print("Current version is ", version)
+    for commit in repo.walk(last.id, pygit2.GIT_SORT_TIME):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            repo.checkout_tree(commit, directory=tmpdirname)
+            if os.path.isfile(os.path.join(tmpdirname, "sources", file)):
+                old_version = format_tag(
+                    get_version(os.path.join(tmpdirname, "sources", file))
+                )
+                if old_version != format_tag(version):
+                    print("Old version was ", old_version)
+                    return True
+    return False
+
+
+if __name__ == "__main__":
+    config = yaml.load(open(os.path.join("sources", "config.yaml")), Loader=yaml.FullLoader)
+    sources = config["sources"]
+
+    current_version = None
+
+    for source in sources:
+        this_version = get_version(os.path.join("sources", source))
+        if current_version and current_version != this_version:
+            print(
+                "Version mismatch: {} in {} != {}".format(
+                    format_tag(current_version), source, format_tag(this_version)
+                )
+            )
+            exit(1)
+        current_version = this_version
+
+    tags = get_git_tags()
+    print("Current version is: ", format_tag(current_version))
+    if tags:
+        print("There were git tags, current version not amongst them: ", tags)
+        needs_release = current_version not in tags
+    else:
+        print("There were no git tags.")
+        needs_release = version_has_ever_changed(sources[0], current_version)
+
+    if needs_release:
+        result = "untagged"
+        newtag = format_tag(current_version)
+    else:
+        result = "ok"
+        newtag = ""
+
+    print(f"Result was {result}, new tag {newtag}")
+    print(f"::set-output name=result::{result}")
+    print(f"::set-output name=newtag::{newtag}")

--- a/Lib/gftools/actions/notobuilder.py
+++ b/Lib/gftools/actions/notobuilder.py
@@ -1,0 +1,187 @@
+"""Build a Noto font from one or more source files.
+
+By default, places unhinted TTF, hinted TTF, OTF and (if possible) variable
+fonts into the ``fonts/`` directory; merges in requested subsets at the UFO
+level and places *those* fonts in the ``fonts/full/`` directory.
+
+Example:
+
+    python3 -m gftools.actions.notobuilder src/config.yaml
+"""
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+from strictyaml import (
+    Map,
+    Str,
+    HexInt,
+    Seq,
+    Optional,
+)
+
+from fontTools import designspaceLib
+from glyphsets.codepoints import CodepointsInSubset
+import ufoLib2
+
+from gftools.builder import GFBuilder
+from gftools.builder.autohint import autohint
+from gftools.builder.schema import schema
+from gftools.ufomerge import merge_ufos
+
+# Add our keys to schema
+subsets_schema = Seq(
+    Map(
+        {
+            "from": Str(),
+            Optional("name"): Str(),
+            Optional("ranges"): Seq(Map({"start": HexInt(), "end": HexInt()})),
+        }
+    )
+)
+_newschema = schema._validator
+_newschema[Optional("includeSubsets")] = subsets_schema
+
+
+class NotoBuilder(GFBuilder):
+    schema = Map(_newschema)
+
+    def __init__(self, config):
+        self.config = self.load_config(config)
+        if os.path.dirname(config):
+            os.chdir(os.path.dirname(config))
+        self.config["vfDir"] = "../fonts/unhinted/variable-ttf"
+        self.config["otDir"] = "../fonts/unhinted/otf"
+        self.config["ttDir"] = "../fonts/unhinted/ttf"
+        self.outputs = set()
+        self.logger = logging.getLogger("GFBuilder")
+        self.fill_config_defaults()
+
+    def get_family_name(self, source=None):
+        if not source:
+            source = self.config["sources"][0]
+        source, _ = os.path.splitext(os.path.basename(source))
+        fname = re.sub(r"([a-z])([A-Z])", r"\1 \2", source)
+        fname = re.sub("-?MM$", "", fname)
+        return fname
+
+    def post_process_ttf(self, filename):
+        super().post_process_ttf(filename)
+        self.outputs.add(filename)
+        hinted_dir = self.config["ttDir"].replace("unhinted", "hinted")
+        os.makedirs(hinted_dir, exist_ok=True)
+        hinted = filename.replace("unhinted", "hinted")
+        try:
+            autohint(filename, hinted, add_script=True)
+            self.outputs.add(hinted)
+        except Exception as e:
+            self.logger.error("Couldn't autohint %s: %s" % (filename, e))
+
+    def post_process(self, filename):
+        super().post_process(filename)
+        self.outputs.add(filename)
+
+    def build_variable(self):
+        try:
+            super().build_variable()
+        except Exception as e:
+            self.logger.error("Couldn't build variable font: %s" % e)
+
+    def glyphs_to_ufo(self, source, directory=None):
+        source = Path(source)
+        if directory is None:
+            directory = source.resolve().parent
+        self.run_fontmake(
+            str(source.resolve()),
+            {
+                "format": ["ufo"],
+                "output_dir": directory,
+                "master_dir": directory,
+                "designspace_path": Path(directory)
+                / source.with_suffix(".designspace").name,
+            },
+        )
+        return str(Path(directory) / source.with_suffix(".designspace").name)
+
+    def build(self):
+        # First convert to Designspace/UFO
+        for ix, source in enumerate(self.config["sources"]):
+            if source.endswith(".glyphs"):
+                self.config["sources"][ix] = self.glyphs_to_ufo(source)
+
+        # Do a basic build first
+        super().build()
+
+        # Merge UFOs
+        if not "includeSubsets" in self.config:
+            return
+
+        for key in ["vfDir", "otDir", "ttDir"]:
+            self.config[key] = self.config[key].replace("unhinted", "full")
+
+        for ds_file in self.config["sources"]:
+            ds = designspaceLib.DesignSpaceDocument.fromfile(ds_file)
+            for subset in self.config["includeSubsets"]:
+                if len(ds.sources) == 1:
+                    self.add_subset(ds.sources[0], subset, mapping="Regular")
+                else:
+                    for master in ds.sources:
+                        self.add_subset(ds.sources[0], subset)
+
+        super().build()
+
+    def add_subset(self, ds_source, subset, mapping=None):
+        if mapping is None:
+            raise NotImplementedError
+        if "name" in subset:
+            # Resolve to glyphset
+            unicodes = CodepointsInSubset(subset["name"])
+        else:
+            unicodes = []
+            for r in subset["ranges"]:
+                for cp in range(r["start"], r["end"] + 1):
+                    unicodes.append(cp)
+        source_ufo = self.obtain_noto_ufo(subset["from"], mapping)
+        target_ufo = ufoLib2.Font.open(ds_source.path)
+        merge_ufos(
+            target_ufo, source_ufo, codepoints=unicodes, existing_handling="skip",
+        )
+        target_ufo.save(ds_source.path, overwrite=True)
+
+    def obtain_noto_ufo(self, font_name, mapping):
+        if font_name == "Noto Sans":
+            path = "../subset-files/noto-sans/sources/NotoSans-MM.glyphs"
+        if font_name == "Noto Sans Devanagari":
+            path = "../subset-files/devanagari/sources/NotoSansDevanagari.glyphs"
+
+        if path.endswith(".glyphs"):
+            # Check if UFO already exists
+            path = self.glyphs_to_ufo(path)
+        source_ds = designspaceLib.DesignSpaceDocument.fromfile(path)
+        regs = [
+            source.path
+            for source in source_ds.sources
+            if source.name.endswith("Regular")
+        ]
+        if not regs:
+            regs = [source_ds.sources[0].path]
+        return ufoLib2.Font.open(regs[0])
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build a Noto font")
+    parser.add_argument("config", metavar="YAML", help="config files")
+    parser.add_argument("--verbose", "-v", action="store_true", help="verbose logging")
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+    builder = NotoBuilder(args.config)
+    builder.build()
+    print("Produced the following files:")
+    for o in builder.outputs:
+        print("* " + o)

--- a/Lib/gftools/actions/qa2issue.py
+++ b/Lib/gftools/actions/qa2issue.py
@@ -1,0 +1,48 @@
+"""Post the contents of a QA run either to a new GitHub issue or as a comment
+to an existing one.
+
+When a font is automatically tested, we want to alert the user with a more
+helpful (and visible) message than just a failure in the action log; but at
+the same time we don't want to spam them by opening new issues every commit.
+
+This script takes a file and a version, and checks whether there is a GitHub
+issue labelled qa-``version``. If not, it creates an issue with the text
+provided, and labels it accordingly; if there is, it adds the text as a new comment.
+"""
+import argparse
+import subprocess
+from gftools.github import GitHubClient
+
+if __name__ == "__main__":
+    url_split = subprocess.check_output(["git", "remote", "get-url", "origin"]).decode("utf8").strip().split("/")
+    client = GitHubClient(url_split[3], url_split[4])
+
+    parser = argparse.ArgumentParser(description='Create or update github issue')
+    parser.add_argument('--template', help='the issue name',
+        default="Fontbakery QA Report for Version {}")
+    parser.add_argument('version', help='the proposed version')
+    parser.add_argument('file', help='file containing MarkDown content')
+    args = parser.parse_args()
+
+    label = f"qa-{args.version}"
+
+    try:
+        client._post(client.rest_url("labels"), {"name": label})
+    except Exception as e:
+        if "already_exists" not in str(e):
+            raise
+
+    text = open(args.file).read()
+
+    open_issues = client._get(client.rest_url("issues", labels=label))
+    if open_issues:
+        issue_id = open_issues[0]["number"]
+        response = client.create_issue_comment(issue_id, text)
+    else:
+        title = args.template.format(args.version)
+        response = client.create_issue(title, text)
+        number = response["number"]
+        client._post(client.rest_url(f"issues/{number}/labels"), {"labels": [label]})
+    see_url = response["html_url"]
+
+    print(f"::error file=sources/config.yaml,title=Fontbakery check failed::See {see_url}")

--- a/Lib/gftools/actions/updateupstream.py
+++ b/Lib/gftools/actions/updateupstream.py
@@ -1,0 +1,123 @@
+"""Generates an upstream.yaml from a config.yaml and a GitHub release URL
+
+"""
+import argparse
+import os
+from tempfile import TemporaryDirectory
+import yaml
+import zipfile
+
+import gftools.packager
+from gftools.builder import GFBuilder
+from strictyaml import as_document
+from gftools.utils import download_file
+from fontTools.ttLib import TTFont
+
+
+parser = argparse.ArgumentParser(description="Process some integers.")
+parser.add_argument("url", help="URL of GitHub release")
+
+
+def get_family_name(config):
+    if "familyName" in config:
+        return config["familyName"]
+    return GFBuilder(config).get_family_name()
+
+
+def generate_upstream(config, url):
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        raise ValueError("Not being run from a GitHub action?")
+
+    upstream = {
+        "name": get_family_name(config),
+        "repository_url": os.environ["GITHUB_SERVER_URL"] + "/" + repo + ".git",
+        "archive": url,
+        "branch": "main",
+        "category": [
+            "SANS_SERIF"
+        ],  # One man's rigged demo is another man's proof of concept
+        "build": "",
+        "files": {},
+        "designer": "Will be filled in",
+    }
+    return upstream
+
+
+def update_file_list(upstream):
+    print("Downloading release archive...")
+    upstream["files"] = {}
+    with TemporaryDirectory() as tmp:
+        archive_path = os.path.join(tmp, "archive.zip")
+        download_file(upstream["archive"], archive_path)
+        license_found = False
+        description_found = False
+        a_font = None
+        with zipfile.ZipFile(archive_path, "r") as zip_ref:
+            zip_ref.extractall(tmp)
+        for root, _, files in os.walk(tmp):
+            for file in files:
+                fullpath = os.path.join(root, file)
+                relpath = os.path.relpath(fullpath, tmp)
+                print(relpath)
+                if file == "OFL.txt":
+                    license_found = True
+                    upstream["files"][relpath] = file
+                elif file == "DESCRIPTION.en_us.html":
+                    description_found = True
+                    upstream["files"][relpath] = file
+                elif file.endswith("ttf"):
+                    if config.get("buildVariable", True):
+                        # Only add the file if it is the variable font
+                        if "[" in file:
+                            upstream["files"][relpath] = file
+                            a_font = fullpath
+                    else:
+                        # Add statics
+                        upstream["files"][relpath] = file
+                        a_font = fullpath
+        if not license_found:
+            raise ValueError(
+                "No license file was found. Ensure OFL.txt is added the the release"
+            )
+        if not description_found:
+            raise ValueError(
+                "No description file was found. Ensure DESCRIPTION.en_us.html is added the the release"
+            )
+        if not a_font:
+            raise ValueError("No font files were found. Is the release broken?")
+
+        upstream["designer"] = TTFont(a_font)["name"].getDebugName(9)
+
+
+if __name__ == "__main__":
+    config = yaml.load(
+        open(os.path.join("sources", "config.yaml")), Loader=yaml.FullLoader
+    )
+    args = parser.parse_args()
+
+    if os.path.isfile("upstream.yaml"):
+        try:
+            upstream = gftools.packager._upstream_conf_from_file(
+                "upstream.yaml", yes=True, quiet=True
+            )
+        except Exception as e:
+            raise ValueError("Something went wrong parsing upstream.yaml: " + str(e))
+    else:
+        try:
+            upstream = as_document(
+                generate_upstream(config, args.url),
+                gftools.packager.upstream_yaml_schema,
+            )
+        except Exception as e:
+            raise ValueError(
+                "Something went wrong generating upstream.yaml (bug in updateupstream): "
+                + str(e)
+            )
+
+    # Add archive URL
+    upstream["archive"] = args.url
+    update_file_list(upstream)
+
+    with open("upstream.yaml", "w") as upstream_yaml_file:
+        upstream_yaml_file.write(upstream.as_yaml())

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -95,6 +95,7 @@ required, all others have sensible defaults:
 * ``familyName``: Family name for variable fonts. Defaults to family name of first source file.
 * ``flattenComponents``: Whether to flatten components on export. Defaults to ``true``.
 * ``decomposeTransformedComponents``: Whether to decompose transformed components on export. Defaults to ``true``.
+* ``googleFonts``: Whether this font is destined for release on Google Fonts. Used by GitHub Actions. Defaults to ``false``.
 
 """
 

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -75,5 +75,6 @@ schema = Map(
         Optional("flattenComponents"): Bool(),
         Optional("decomposeTransformedComponents"): Bool(),
         Optional("ttfaUseScript"): Bool(),
+        Optional("googleFonts"): Bool(),
     }
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ skia-pathops
 jinja2
 hyperglot
 fontFeatures>=1.6.2
+bumpfontversion

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     author_email='dave@lab6.com',
     package_dir={'': 'Lib'},
     packages=['gftools',
+              'gftools.actions',
               'gftools.util',
               'gftools.builder'],
     package_data={'gftools.util': ["GlyphsInfo/*.xml", "UnicodeSections/*.json"],
@@ -103,5 +104,6 @@ setup(
         'jinja2',
         'hyperglot',
         'fontFeatures',
+        'bumpfontversion',
     ]
     )


### PR DESCRIPTION
The idea here is that there are certain (complex) steps we need to perform as part of GitHub actions in the googlefonts-project-template repo. If those steps lived in the googlefonts-project-template repo itself, we would lose control over the ability to maintain them, as they would be forked into all of the downstream repos. But if the code to perform those steps is part of gftools, then we can roll out updates just by doing another gftools release. The GitHub actions don't use the venv (because that's used for font building and is frozen, so that won't get updates either); instead they explicitly grab the latest version of gftools and run the actions outside the venv. So they're always up to date as of when the Action is run.

The scripts I've added are:

* `checkgooglefonts`: Very simple - reads the `config.yaml` and sets a GH Actions workflow context if `config["googleFonts"]` is true (i.e. if this font is intended to be onboarded to GF.)
* `checkversionbump`: This one is not so simple. It checks whether the version of the font in the font source files is greater than the last tagged release; i.e. if the font has been bumped since the last release was created, and therefore if a new release is needed. It sets GH Actions workflow contexts to indicate if a new release is needed and if so what version number / tag it should be.
* `notobuilder`: This is a subclass of gftools builder which I'm planning to use as part of the Noto build process. It's not plugged into anything yet; that's the next piece of the puzzle but I wanted to get the onboarding stuff working first.
* `qa2issue`: This takes a fontbakery report *and a version number*. It then looks on Github for an issue related to the version; if there is not one, it creates one, and if there is one, it adds the report as a comment. This ensures that each font version gets one single QA issue, so that the user does not get spammed with new issues for each commit.
* `updateupstream`: This updates an upstream.yaml from a GitHub release, generating one if there isn't one in the repo already.

Note that this introduces a new schema key to `config.yaml`