### PR TITLE
Add a category option to the builder config

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -96,6 +96,7 @@ required, all others have sensible defaults:
 * ``flattenComponents``: Whether to flatten components on export. Defaults to ``true``.
 * ``decomposeTransformedComponents``: Whether to decompose transformed components on export. Defaults to ``true``.
 * ``googleFonts``: Whether this font is destined for release on Google Fonts. Used by GitHub Actions. Defaults to ``false``.
+* ``category``: If this font is destined for release on Google Fonts, a list of the categories it should be catalogued under. Used by GitHub Actions. Must be set if ``googleFonts`` is set.
 
 """
 

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -9,7 +9,8 @@ from strictyaml import (
                         Float,
                         Seq,
                         Optional,
-                        Bool
+                        Bool,
+                        UniqueSeq
                         )
 from gftools.packager import CATEGORIES
 

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -10,7 +10,8 @@ from strictyaml import (
                         Seq,
                         Optional,
                         Bool,
-                        UniqueSeq
+                        UniqueSeq,
+                        Enum
                         )
 from gftools.packager import CATEGORIES
 

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -11,6 +11,7 @@ from strictyaml import (
                         Optional,
                         Bool
                         )
+from gftools.packager import CATEGORIES
 
 
 stat_schema = Seq(
@@ -76,5 +77,6 @@ schema = Map(
         Optional("decomposeTransformedComponents"): Bool(),
         Optional("ttfaUseScript"): Bool(),
         Optional("googleFonts"): Bool(),
+        Optional("category"): UniqueSeq(Enum(CATEGORIES)),
     }
 )


### PR DESCRIPTION
Currently people using the packager type in certain values manually at the command line. Which is fine - except in the context of continuous deployment and unattended builds. If we store this information in the config.yaml file we can get hold of it later.