### PR TITLE
Allow gftools-qa to download fonts from a URL

### DIFF
--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -197,6 +197,12 @@ def download_files_in_github_dir(
     return results
 
 
+def download_files_from_archive(url, dst):
+    zip_io = download_file(url)
+    with ZipFile(zip_io) as zip_file:
+        return fonts_from_zip(zip_file, dst)
+
+
 def download_file(url, dst_path=None):
     """Download a file from a url. If no dst_path is specified, store the file
     as a BytesIO object"""

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -29,6 +29,7 @@ from gftools.utils import (
     download_family_from_Google_Fonts,
     download_files_in_github_pr,
     download_files_in_github_dir,
+    download_files_from_archive,
     Google_Fonts_has_family,
     mkdir,
 )
@@ -87,6 +88,8 @@ def main():
         help="Get previous fonts from a Github pull request")
     font_before_input_group.add_argument("-ghb", "--github-dir-before",
         help="Get previous fonts from a Github dir")
+    font_before_input_group.add_argument("-arb", "--archive-before",
+        help="Get previous fonts from a zip file URL")
     font_before_input_group.add_argument(
         "-gfb",
         "--googlefonts-before",
@@ -196,7 +199,7 @@ def main():
 
     # Retrieve fonts_before and store in out dir
     fonts_before = None
-    if any([args.fonts_before, args.pull_request_before, args.github_dir_before]) or \
+    if any([args.fonts_before, args.pull_request_before, args.github_dir_before, args.archive_before]) or \
            (args.googlefonts_before and family_on_gf):
         fonts_before_dir = os.path.join(args.out, "fonts_before")
         mkdir(fonts_before_dir, overwrite=False)
@@ -212,6 +215,10 @@ def main():
     elif args.github_dir_before:
         fonts_before = download_files_in_github_dir(
             args.github_dir_before, fonts_before_dir
+        )
+    elif args.archive_before:
+        fonts_before = download_files_from_archive(
+            args.archive_before, fonts_before_dir
         )
     elif args.googlefonts_before and family_on_gf:
         fonts_before = download_family_from_Google_Fonts(

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -75,6 +75,8 @@ def main():
         help="Get fonts from a Github directory")
     font_input_group.add_argument("-gf", "--googlefonts",
         help="Get fonts from Google Fonts")
+    font_before_input_group.add_argument("-ar", "--archive",
+        help="Get fonts from a zip file URL")
 
     font_before_group = parser.add_argument_group(title="Fonts before input")
     font_before_input_group = font_before_group.add_mutually_exclusive_group(
@@ -185,6 +187,8 @@ def main():
         if not fonts:
             logger.info("No fonts found in github dir. Skipping")
             return
+    elif args.archive:
+        fonts = download_files_from_archive(args.archive, fonts_dir)
     elif args.googlefonts:
         fonts = download_family_from_Google_Fonts(args.googlefonts, fonts_dir)
 

--- a/bin/gftools-qa.py
+++ b/bin/gftools-qa.py
@@ -75,7 +75,7 @@ def main():
         help="Get fonts from a Github directory")
     font_input_group.add_argument("-gf", "--googlefonts",
         help="Get fonts from Google Fonts")
-    font_before_input_group.add_argument("-ar", "--archive",
+    font_input_group.add_argument("-ar", "--archive",
         help="Get fonts from a zip file URL")
 
     font_before_group = parser.add_argument_group(title="Fonts before input")


### PR DESCRIPTION
Now we are using GitHub release more, it becomes useful to QA a font against the previous release. e.g.

```
$ bin/gftools-qa.py -arb https://github.com/notofonts/limbu/releases/download/NotoSansLimbu-v2.002/limbu-2.02.zip -f fonts/ttf/Limbu-Regular.ttf --diffenator
```

This implements the `-arb` argument to gftools-qa.