### PR TITLE
builder: ensure fontmake args are reset when generating fonts from each source file

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -455,10 +455,7 @@ class GFBuilder:
                 "output_dir": directory,
                 "optimize_cff": CFFOptimization.SUBROUTINIZE,
             }
-            if source.endswith("ufo"):
-                if "interpolate" in args:
-                    del args["interpolate"]
-            else:
+            if not source.endswith("ufo"):
                 args["interpolate"] = True
             self.logger.info("Creating static fonts from %s" % source)
             for fontfile in self.run_fontmake(source, args):

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -279,9 +279,9 @@ class GFBuilder:
 
     def build_variable(self):
         self.mkdir(self.config["vfDir"], clean=True)
-        args = {"output": ["variable"], "family_name": self.config["familyName"]}
         ttFonts = []
         for source in self.config["sources"]:
+            args = {"output": ["variable"], "family_name": self.config["familyName"]}
             if not source.endswith(".designspace") and not source.endswith("glyphs"):
                 continue
             self.logger.info("Creating variable fonts from %s" % source)
@@ -449,12 +449,12 @@ class GFBuilder:
 
     def build_a_static_format(self, format, directory, postprocessor):
         self.mkdir(directory, clean=True)
-        args = {
-            "output": [format],
-            "output_dir": directory,
-            "optimize_cff": CFFOptimization.SUBROUTINIZE,
-        }
         for source in self.config["sources"]:
+            args = {
+                "output": [format],
+                "output_dir": directory,
+                "optimize_cff": CFFOptimization.SUBROUTINIZE,
+            }
             if source.endswith("ufo"):
                 if "interpolate" in args:
                     del args["interpolate"]

--- a/Lib/gftools/tests/test_usage.py
+++ b/Lib/gftools/tests/test_usage.py
@@ -50,6 +50,7 @@ class TestGFToolsScripts(unittest.TestCase):
         self.example_vf_font = os.path.join("data", "test", 'Lora-Roman-VF.ttf')
         self.example_vf_stat = os.path.join("data", "test", 'lora_stat.yaml')
         self.example_builder_config = os.path.join("data", "test", 'builder_test.yaml')
+        self.example_builder_config_2_sources = os.path.join("data", "test", "Libre-Bodoni", "sources", "config.yaml")
         self.src_vtt_font = os.path.join("data", "test", "Inconsolata[wdth,wght].ttf")
         self.gf_family_dir = os.path.join('data', 'test', 'mock_googlefonts', 'ofl', 'abel')
         self.nam_file = os.path.join('data', 'test', 'arabic_unique-glyphs.nam')
@@ -237,6 +238,9 @@ class TestGFToolsScripts(unittest.TestCase):
 
     def test_builder(self):
         self.check_script(['python', self.get_path('builder'), self.example_builder_config])
+    
+    def test_builder_2_sources(self):
+        self.check_script(["python", self.get_path("builder"), self.example_builder_config_2_sources])
 
 
 if __name__ == '__main__':

--- a/data/test/Libre-Bodoni/AUTHORS.txt
+++ b/data/test/Libre-Bodoni/AUTHORS.txt
@@ -1,0 +1,9 @@
+# This is the official list of project authors for copyright purposes. 
+# This file is distinct from the CONTRIBUTORS.txt file. 
+# See the latter for an explanation. 
+# 
+# Names should be added to this file as: 
+# Name or Organization <email address> 
+
+Pablo Impallari <@impallaritype>
+Rodrigo Fuenzalida <hello@rfuenzalida.com>

--- a/data/test/Libre-Bodoni/CONTRIBUTORS.txt
+++ b/data/test/Libre-Bodoni/CONTRIBUTORS.txt
@@ -1,0 +1,13 @@
+# This is the list of people who have contributed to this project,
+# and includes those not listed in AUTHORS.txt because they are not
+# copyright authors. For example, company employees may be listed
+# here because their company holds the copyright and is listed there.
+#
+# When adding J Random Contributor's name to this file, either J's
+# name or J's organization's name should be added to AUTHORS.txt
+#
+# Names should be added to this file as:
+# Name <email address>
+
+Pablo Impallari <@impallaritype>
+Rodrigo Fuenzalida <hello@rfuenzalida.com>

--- a/data/test/Libre-Bodoni/FONTLOG.txt
+++ b/data/test/Libre-Bodoni/FONTLOG.txt
@@ -1,0 +1,48 @@
+FONTLOG for the Libre Bodoni fonts
+
+This file provides detailed information on the Libre Bodoni Font Software.
+This information should be distributed along with the Libre Bodoni fonts and any derivative works.
+
+Basic Font Information:
+The Libre Bodoni fonts are based on the 19th century Morris Fuller Benton's ATF design, but specifically adapted for today's web requirements.
+
+They are a perfect choice for everything related to elegance, style, luxury and fashion.
+
+Libre Bodoni currently features four styles: Regular, Italic, Bold and Bold Italic.
+
+Join the project at Github
+Documentation can be found at www.impallari.com
+To contribute to the project contact Pablo Impallari at impallari@gmail.com
+
+ChangeLog
+
+16 August 2016 (Pablo Impallari, Rodrigo Fuenzalida) Libre Bodoni v2.000
+- Initial glyphs migration
+
+23 Jul 2015 (Pablo Impallari, Rodrigo Fuenzalida) Libre Bodoni v1.001
+- Removed RFN
+
+21 May 2015 (Pablo Impallari, Rodrigo Fuenzalida) Libre Bodoni v1.000
+- Initial Release
+
+17 Sept 2014 (Pablo Impallari, Rodrigo Fuenzalida) Libre Bodoni v0.001
+- Initial Sketchs
+
+Acknowledgements
+
+If you make modifications be sure to add your name (N), 
+email (E), web-address (if you have one) (W) and 
+description (D). This list is in alphabetical order.
+
+N: Pablo Impallari
+E: impallari@gmail.com
+W: http://www.impallari.com
+D: Designer
+
+N: Rodrigo Fuenzalida
+E: hello@rfuenzalida.com
+W: http://www.rfuenzalida.com
+D: Designer
+
+
+

--- a/data/test/Libre-Bodoni/OFL.txt
+++ b/data/test/Libre-Bodoni/OFL.txt
@@ -1,0 +1,93 @@
+Copyright 2012 The Libre Bodoni Project Authors (https://github.com/googlefonts/Libre-Bodoni/)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/data/test/Libre-Bodoni/README.md
+++ b/data/test/Libre-Bodoni/README.md
@@ -1,0 +1,27 @@
+Libre Bodoni Fonts
+======================
+
+## Current Status
+- Version 1.001 is the latest stable version.
+- Version 2.002 is an ongoing migration to Glyphs and Vietnamese extension, but is still a work in progress.
+
+## Description
+
+The Libre Bodoni fonts are based on the 19th century Morris Fuller Benton's ATF design, but specifically adapted for today's web requirements.
+
+They are a perfect choice for everything related to elegance, style, luxury and fashion.
+
+Libre Bodoni currently features four styles: Regular, Italic, Bold and Bold Italic.
+
+## License
+
+- Libre Bodoni is licensed under the SIL Open Font License v1.1 (<http://scripts.sil.org/OFL>)
+- To view the copyright and specific terms and conditions please refer to [OFL.txt](https://github.com/impallari/Libre-Bodoni/blob/master/OFL.txt)
+
+## Language Coverage
+
+The Libre Bodoni Fonts covers all 104 Latin Languages: Afar, Afrikaans, Albanian, Azerbaijani, Basque, Belarusian, Bislama, Bosnian, Breton, Catalan, Chamorro, Chichewa, Comorian, Croatian, Czech, Danish, Dutch, English, Esperanto, Estonian, Faroese, Fijian, Filipino/Tagalog, Finnish, Flemish, French, Gaelic (Irish / Manx / Scottish), Gagauz, German, Gikuyu, Gilbertese/Kiribati, Greenlandic, Guarani, Haitian_Creole, Hawaiian, Hungarian, Icelandic, Igo/Igbo, Indonesian, Irish, Italian, Javanese, Kashubian, Kinyarwanda, Kirundi, Latin, Latvian, Lithuanian, Luba/Ciluba/Kasai, Luxembourgish, Malagasy, Malay, Maltese, Maori, Marquesan, Marshallese, Moldovan/Moldovian/Romanian, Montenegrin, Nauruan, Ndebele, Norwegian, Oromo, Palauan/Belauan, Polish, Portuguese, Quechua, Romanian, Romansh, Sami, Samoan, Sango, Serbian, Sesotho, Setswana/Sitswana/Tswana, Seychellois_Creole, SiSwati/Swati/Swazi, Silesian, Slovak, Slovenian, Somali, Sorbian, Sotho, Spanish, Swahili, Swedish, Tahitian, Tetum, Tok_Pisin, Tongan, Tsonga, Tswana, Tuareg/Berber, Turkish, Turkmen, Tuvaluan, Uzbek/Usbek, Wallisian, Walloon, Welsh, Xhosa, Yoruba, Zulu.
+
+## Authors
+
+[Pablo Impallari](http://www.impallari.com) and [Rodrigo Fuenzalida](http://www.rfuenzalida.com)

--- a/data/test/Libre-Bodoni/requirements.txt
+++ b/data/test/Libre-Bodoni/requirements.txt
@@ -1,0 +1,1 @@
+gftools

--- a/data/test/Libre-Bodoni/sources/LibreBodoni-Italic.glyphs
+++ b/data/test/Libre-Bodoni/sources/LibreBodoni-Italic.glyphs
@@ -1,0 +1,48412 @@
+{
+.appVersion = "3108";
+.formatVersion = 3;
+DisplayStrings = (
+"ǻ"
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = panose;
+value = (
+2,
+7,
+5,
+3,
+7,
+6,
+0,
+0,
+0,
+3
+);
+},
+{
+name = "Axis Mappings";
+value = {
+wght = {
+400 = 400;
+500 = 550;
+700 = 700;
+};
+};
+},
+{
+name = fsType;
+value = (
+);
+},
+{
+name = "Use Line Breaks";
+value = 1;
+},
+{
+name = "Use Typo Metrics";
+value = 1;
+},
+{
+name = "Variable Font Origin";
+value = "426C3F01-D24D-4224-A47E-56DA036E4742";
+}
+);
+date = "2016-08-16 11:28:02 +0000";
+familyName = "Libre Bodoni";
+features = (
+{
+code = "sub f f i by f_f_i;
+	sub f f l by f_f_l;
+  sub f f by f_f;
+  sub f i by f_i;
+  sub f l by f_l;
+";
+tag = liga;
+},
+{
+code = "sub [zero one two three four five six seven eight nine] [A a]' by [ordfeminine ordfeminine];
+	sub [zero one two three four five six seven eight nine] [O o]' by [ordmasculine ordmasculine];
+	sub [zero one two three four five six seven eight nine] period [A a]' by [ordfeminine ordfeminine];
+	sub [zero one two three four five six seven eight nine] period [O o]' by [ordmasculine ordmasculine];
+";
+tag = ordn;
+},
+{
+code = "sub one [slash fraction] two by onehalf;
+	sub one [slash fraction] three by onethird;
+	sub one [slash fraction] four by onequarter;
+	sub one [slash fraction] eight by oneeighth;
+	sub two [slash fraction] three by twothirds;
+	sub three [slash fraction] four by threequarters;
+	sub three [slash fraction] eight by threeeighths;
+	sub five [slash fraction] eight by fiveeighths;
+	sub seven [slash fraction] eight by seveneighths;
+";
+tag = frac;
+},
+{
+code = "sub zero by zerosuperior;
+	sub one by onesuperior;
+	sub two by twosuperior;
+	sub three by threesuperior;
+	sub four by foursuperior;
+	sub five by fivesuperior;
+	sub six by sixsuperior;
+	sub seven by sevensuperior;
+	sub eight by eightsuperior;
+	sub nine by ninesuperior;
+";
+tag = sups;
+},
+{
+code = "sub zero by zeroinferior;
+	sub one by oneinferior;
+	sub two by twoinferior;
+	sub three by threeinferior;
+	sub four by fourinferior;
+	sub five by fiveinferior;
+	sub six by sixinferior;
+	sub seven by seveninferior;
+	sub eight by eightinferior;
+	sub nine by nineinferior;
+";
+tag = sinf;
+},
+{
+code = "sub zero by zero.numerator;
+	sub one by one.numerator;
+	sub two by two.numerator;
+	sub three by three.numerator;
+	sub four by four.numerator;
+	sub five by five.numerator;
+	sub six by six.numerator;
+	sub seven by seven.numerator;
+	sub eight by eight.numerator;
+	sub nine by nine.numerator;
+";
+tag = numr;
+},
+{
+code = "sub zero by zero.denominator;
+	sub one by one.denominator;
+	sub two by two.denominator;
+	sub three by three.denominator;
+	sub four by four.denominator;
+	sub five by five.denominator;
+	sub six by six.denominator;
+	sub seven by seven.denominator;
+	sub eight by eight.denominator;
+	sub nine by nine.denominator;
+";
+tag = dnom;
+}
+);
+fontMaster = (
+{
+axesValues = (
+400
+);
+customParameters = (
+{
+name = typoAscender;
+value = 924;
+},
+{
+name = typoDescender;
+value = -326;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = hheaAscender;
+value = 924;
+},
+{
+name = hheaDescender;
+value = -326;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1184;
+},
+{
+name = winDescent;
+value = 326;
+}
+);
+id = "426C3F01-D24D-4224-A47E-56DA036E4742";
+metricValues = (
+{
+over = 12;
+pos = 754;
+},
+{
+over = 12;
+pos = 754;
+},
+{
+over = 12;
+pos = 450;
+},
+{
+over = -12;
+},
+{
+over = -12;
+pos = -314;
+},
+{
+pos = 13;
+}
+);
+name = Italic;
+stemValues = (
+30,
+110
+);
+},
+{
+axesValues = (
+700
+);
+customParameters = (
+{
+name = typoAscender;
+value = 924;
+},
+{
+name = typoDescender;
+value = -326;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = hheaAscender;
+value = 924;
+},
+{
+name = hheaDescender;
+value = -326;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1184;
+},
+{
+name = winDescent;
+value = 326;
+}
+);
+iconName = Bold;
+id = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+metricValues = (
+{
+over = 12;
+pos = 754;
+},
+{
+over = 12;
+pos = 754;
+},
+{
+over = 12;
+pos = 450;
+},
+{
+over = -12;
+},
+{
+over = -12;
+pos = -314;
+},
+{
+pos = 13;
+}
+);
+name = "Bold Italic";
+stemValues = (
+35,
+138
+);
+}
+);
+glyphs = (
+{
+glyphname = A;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 13:42:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (241,0);
+},
+{
+name = ogonek;
+pos = (474,10);
+},
+{
+name = top;
+pos = (508,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(21,20,l),
+(384,551,l),
+(493,764,l),
+(-18,20,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,0,l),
+(123,25,l),
+(-91,25,l),
+(-91,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(538,0,l),
+(538,25,l),
+(269,25,l),
+(269,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(434,247,l),
+(434,275,l),
+(165,275,l),
+(165,247,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(459,10,l),
+(514,764,l),
+(493,764,l),
+(381,547,l),
+(385,547,l),
+(336,10,l)
+);
+}
+);
+width = 585;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (259,0);
+},
+{
+name = ogonek;
+pos = (507,10);
+},
+{
+name = top;
+pos = (516,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(22,20,l),
+(385,551,l),
+(502,768,l),
+(-20,20,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(124,30,l),
+(-66,30,l),
+(-66,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(569,0,l),
+(569,30,l),
+(250,30,l),
+(250,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,212,l),
+(415,245,l),
+(146,245,l),
+(146,212,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(490,10,l),
+(545,768,l),
+(494,768,l),
+(382,547,l),
+(386,547,l),
+(337,10,l)
+);
+}
+);
+width = 621;
+}
+);
+unicode = 65;
+},
+{
+glyphname = Aacute;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (149,304);
+ref = acutecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (111,304);
+ref = acutecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 193;
+},
+{
+glyphname = Abreve;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (134,304);
+ref = brevecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (135,304);
+ref = brevecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 258;
+},
+{
+glyphname = Abreveacute;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (149,304);
+ref = brevecomb_acutecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (159,304);
+ref = brevecomb_acutecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7854;
+},
+{
+glyphname = Abrevedotbelow;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+ref = dotbelowcomb;
+},
+{
+pos = (134,304);
+ref = brevecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (9,0);
+ref = dotbelowcomb;
+},
+{
+pos = (135,304);
+ref = brevecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7862;
+},
+{
+glyphname = Abrevegrave;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (135,304);
+ref = brevecomb_gravecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (146,304);
+ref = brevecomb_gravecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7856;
+},
+{
+glyphname = Abrevehookabove;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (131,304);
+ref = brevecomb_hookabovecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (166,304);
+ref = brevecomb_hookabovecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7858;
+},
+{
+glyphname = Abrevetilde;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (134,304);
+ref = brevecomb_tildecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (136,304);
+ref = brevecomb_tildecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7860;
+},
+{
+glyphname = Acircumflex;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (136,304);
+ref = circumflexcomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (171,304);
+ref = circumflexcomb;
+}
+);
+width = 621;
+}
+);
+unicode = 194;
+},
+{
+glyphname = Acircumflexacute;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (140,304);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (149,304);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7844;
+},
+{
+glyphname = Acircumflexdotbelow;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+ref = dotbelowcomb;
+},
+{
+pos = (136,304);
+ref = circumflexcomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (9,0);
+ref = dotbelowcomb;
+},
+{
+pos = (171,304);
+ref = circumflexcomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7852;
+},
+{
+glyphname = Acircumflexgrave;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (144,304);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (153,304);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7846;
+},
+{
+glyphname = Acircumflexhookabove;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (138,304);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (150,304);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7848;
+},
+{
+glyphname = Acircumflextilde;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (140,304);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (147,304);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7850;
+},
+{
+glyphname = Adblgrave;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (36,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (77,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 621;
+}
+);
+unicode = 512;
+},
+{
+glyphname = Adieresis;
+kernLeft = A;
+kernRight = A;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (204,0);
+ref = dieresis.case;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (210,0);
+ref = dieresis.case;
+}
+);
+width = 621;
+}
+);
+unicode = 196;
+},
+{
+glyphname = Adotbelow;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+ref = dotbelowcomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (9,0);
+ref = dotbelowcomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7840;
+},
+{
+glyphname = Agrave;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (160,304);
+ref = gravecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (200,304);
+ref = gravecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 192;
+},
+{
+glyphname = Ahookabove;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (185,304);
+ref = hookabovecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (184,304);
+ref = hookabovecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 7842;
+},
+{
+glyphname = Ainvertedbreve;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:16:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (197,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (193,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 621;
+}
+);
+unicode = 514;
+},
+{
+glyphname = Amacron;
+kernLeft = A;
+kernRight = A;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = macron.case;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (181,0);
+ref = macron.case;
+}
+);
+width = 621;
+}
+);
+unicode = 256;
+},
+{
+glyphname = Aogonek;
+kernLeft = A;
+kernRight = A;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (424,-12);
+ref = ogonek;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (360,0);
+ref = ogonek;
+}
+);
+width = 621;
+}
+);
+unicode = 260;
+},
+{
+glyphname = Aring;
+kernLeft = A;
+kernRight = A;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (258,0);
+ref = ring.case;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (266,0);
+ref = ring.case;
+}
+);
+width = 621;
+}
+);
+unicode = 197;
+},
+{
+glyphname = Aringacute;
+kernLeft = A;
+kernRight = A;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (261,-48);
+ref = ring.case;
+},
+{
+alignment = -1;
+pos = (370,55);
+ref = acute.case;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = A;
+},
+{
+alignment = -1;
+pos = (259,-46);
+ref = ring.case;
+},
+{
+alignment = -1;
+pos = (392,40);
+ref = acute.case;
+}
+);
+width = 621;
+}
+);
+unicode = 506;
+},
+{
+glyphname = Atilde;
+kernLeft = A;
+kernRight = A;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (149,304);
+ref = tildecomb;
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = A;
+},
+{
+pos = (151,304);
+ref = tildecomb;
+}
+);
+width = 621;
+}
+);
+unicode = 195;
+},
+{
+glyphname = AE;
+kernLeft = AE;
+kernRight = E;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-1,20,l),
+(486,734,l),
+(455,741,l),
+(-40,20,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(101,0,l),
+(101,25,l),
+(-113,25,l),
+(-113,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,247,l),
+(412,275,l),
+(143,275,l),
+(143,247,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(837,0,l),
+(897,232,l),
+(867,232,l),
+(791,64,o),
+(729,25,o),
+(640,25,cs),
+(247,25,l),
+(247,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(456,0,l),
+(624,754,l),
+(507,754,l),
+(343,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(706,226,l),
+(765,534,l),
+(740,534,l),
+(709,430,o),
+(674,403,o),
+(594,403,cs),
+(491,403,l),
+(491,378,l),
+(578,378,ls),
+(661,378,o),
+(676,351,o),
+(676,226,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(929,553,l),
+(957,754,l),
+(338,754,l),
+(338,729,l),
+(728,729,ls),
+(870,729,o),
+(899,692,o),
+(899,553,c)
+);
+}
+);
+width = 946;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-14,20,l),
+(542,734,l),
+(505,741,l),
+(-56,20,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(88,0,l),
+(88,30,l),
+(-102,30,l),
+(-102,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(439,212,l),
+(439,245,l),
+(130,245,l),
+(130,212,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(905,0,l),
+(965,232,l),
+(925,232,l),
+(849,68,o),
+(787,30,o),
+(698,30,cs),
+(295,30,l),
+(295,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(534,0,l),
+(702,754,l),
+(551,754,l),
+(387,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(786,227,l),
+(851,535,l),
+(816,535,l),
+(786,441,o),
+(737,404,o),
+(670,404,cs),
+(567,404,l),
+(567,374,l),
+(654,374,ls),
+(714,374,o),
+(752,348,o),
+(752,227,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(997,548,l),
+(1033,754,l),
+(396,754,l),
+(396,724,l),
+(796,724,ls),
+(920,724,o),
+(957,687,o),
+(957,548,c)
+);
+}
+);
+width = 998;
+}
+);
+unicode = 198;
+},
+{
+glyphname = AEacute;
+kernLeft = AE;
+kernRight = E;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = AE;
+},
+{
+alignment = -1;
+pos = (374,0);
+ref = acute.case;
+}
+);
+width = 967;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = AE;
+},
+{
+alignment = -1;
+pos = (451,0);
+ref = acute.case;
+}
+);
+width = 998;
+}
+);
+unicode = 508;
+},
+{
+glyphname = B;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (285,0);
+},
+{
+name = top;
+pos = (459,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(374,0,ls),
+(540,0,o),
+(632,85,o),
+(632,198,cs),
+(632,285,o),
+(565,373,o),
+(454,391,c),
+(425,398,o),
+(379,404,o),
+(363,404,cs),
+(231,404,l),
+(231,378,l),
+(378,378,l),
+(458,378,o),
+(503,337,o),
+(503,236,cs),
+(503,107,o),
+(430,25,o),
+(346,25,cs),
+(-7,25,l),
+(-7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,0,l),
+(360,754,l),
+(243,754,l),
+(79,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,378,ls),
+(546,378,o),
+(680,464,o),
+(680,586,cs),
+(680,684,o),
+(593,754,o),
+(423,754,cs),
+(144,754,l),
+(144,729,l),
+(423,729,ls),
+(526,729,o),
+(553,690,o),
+(553,609,cs),
+(553,490,o),
+(494,403,o),
+(399,403,cs),
+(201,403,l),
+(201,378,l)
+);
+}
+);
+width = 674;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (295,0);
+},
+{
+name = top;
+pos = (469,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,0,ls),
+(519,0,o),
+(644,82,o),
+(644,224,cs),
+(644,310,o),
+(598,363,o),
+(485,389,c),
+(447,401,o),
+(423,409,o),
+(391,409,cs),
+(198,409,l),
+(198,379,l),
+(379,379,ls),
+(453,379,o),
+(471,331,o),
+(471,256,cs),
+(471,104,o),
+(398,31,o),
+(291,31,cs),
+(-28,31,l),
+(-28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(366,754,l),
+(215,754,l),
+(51,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(331,379,ls),
+(558,379,o),
+(684,455,o),
+(684,584,cs),
+(684,684,o),
+(607,754,o),
+(431,754,cs),
+(110,754,l),
+(110,724,l),
+(419,724,ls),
+(498,724,o),
+(518,689,o),
+(518,615,cs),
+(518,489,o),
+(461,409,o),
+(359,409,cs),
+(167,409,l),
+(167,379,l)
+);
+}
+);
+width = 694;
+}
+);
+unicode = 66;
+},
+{
+glyphname = C;
+kernLeft = C;
+kernRight = C;
+lastChange = "2016-08-22 13:47:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (295,0);
+},
+{
+name = top;
+pos = (469,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(420,-13,o),
+(484,12,o),
+(539,49,c),
+(569,0,l),
+(594,0,l),
+(647,206,l),
+(622,206,l),
+(532,56,o),
+(435,19,o),
+(355,19,cs),
+(266,19,o),
+(217,64,o),
+(217,207,cs),
+(217,389,o),
+(297,736,o),
+(489,736,cs),
+(578,736,o),
+(648,662,o),
+(648,541,c),
+(673,541,l),
+(720,754,l),
+(695,754,l),
+(646,702,l),
+(601,746,o),
+(557,765,o),
+(496,765,cs),
+(275,765,o),
+(79,515,o),
+(79,288,cs),
+(79,127,o),
+(177,-13,o),
+(348,-13,cs)
+);
+}
+);
+width = 693;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (289,0);
+},
+{
+name = top;
+pos = (463,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(414,-13,o),
+(474,8,o),
+(529,34,c),
+(559,0,l),
+(589,0,l),
+(642,206,l),
+(612,206,l),
+(523,59,o),
+(424,24,o),
+(357,24,cs),
+(282,24,o),
+(241,68,o),
+(241,200,cs),
+(241,390,o),
+(327,731,o),
+(495,731,cs),
+(576,731,o),
+(643,652,o),
+(643,521,c),
+(673,521,l),
+(720,754,l),
+(685,754,l),
+(641,707,l),
+(599,748,o),
+(557,765,o),
+(501,765,cs),
+(289,765,o),
+(64,517,o),
+(64,283,cs),
+(64,128,o),
+(162,-13,o),
+(344,-13,cs)
+);
+}
+);
+width = 681;
+}
+);
+unicode = 67;
+},
+{
+glyphname = Cacute;
+kernLeft = C;
+kernRight = C;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (326,0);
+ref = acute.case;
+}
+);
+width = 693;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (318,0);
+ref = acute.case;
+}
+);
+width = 681;
+}
+);
+unicode = 262;
+},
+{
+glyphname = Ccaron;
+kernLeft = C;
+kernRight = C;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (187,0);
+ref = caron.case;
+}
+);
+width = 693;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (201,0);
+ref = caron.case;
+}
+);
+width = 681;
+}
+);
+unicode = 268;
+},
+{
+glyphname = Ccedilla;
+kernLeft = C;
+kernRight = C;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (275,-4);
+ref = cedilla;
+}
+);
+width = 693;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (274,0);
+ref = cedilla;
+}
+);
+width = 681;
+}
+);
+unicode = 199;
+},
+{
+glyphname = Ccircumflex;
+kernLeft = C;
+kernRight = C;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (189,0);
+ref = circumflex.case;
+}
+);
+width = 693;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (200,0);
+ref = circumflex.case;
+}
+);
+width = 681;
+}
+);
+unicode = 264;
+},
+{
+glyphname = Cdotaccent;
+kernLeft = C;
+kernRight = C;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (306,0);
+ref = dotaccent.case;
+}
+);
+width = 693;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = C;
+},
+{
+alignment = -1;
+pos = (278,0);
+ref = dotaccent.case;
+}
+);
+width = 681;
+}
+);
+unicode = 266;
+},
+{
+glyphname = D;
+kernLeft = D;
+kernRight = D;
+lastChange = "2016-08-22 13:48:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (330,0);
+},
+{
+name = center;
+pos = (417,377);
+},
+{
+name = top;
+pos = (504,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,0,ls),
+(564,0,o),
+(745,189,o),
+(745,438,cs),
+(745,634,o),
+(623,754,o),
+(416,754,cs),
+(137,754,l),
+(137,729,l),
+(416,729,ls),
+(553,729,o),
+(617,667,o),
+(617,498,cs),
+(617,223,o),
+(485,27,o),
+(300,27,cs),
+(-14,27,l),
+(-14,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(185,0,l),
+(353,754,l),
+(236,754,l),
+(72,0,l)
+);
+}
+);
+width = 764;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (333,0);
+},
+{
+name = center;
+pos = (420,377);
+},
+{
+name = top;
+pos = (507,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,0,ls),
+(571,0,o),
+(748,209,o),
+(748,438,cs),
+(748,634,o),
+(643,754,o),
+(436,754,cs),
+(100,754,l),
+(100,724,l),
+(429,724,ls),
+(574,724,o),
+(590,631,o),
+(590,518,cs),
+(590,215,o),
+(474,32,o),
+(296,32,cs),
+(-41,32,l),
+(-41,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(195,0,l),
+(363,754,l),
+(212,754,l),
+(48,0,l)
+);
+}
+);
+width = 770;
+}
+);
+unicode = 68;
+},
+{
+glyphname = DZ;
+kernLeft = D;
+kernRight = Z;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = D;
+},
+{
+pos = (764,0);
+ref = Z;
+}
+);
+width = 1413;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = D;
+},
+{
+pos = (770,0);
+ref = Z;
+}
+);
+width = 1439;
+}
+);
+unicode = 497;
+},
+{
+glyphname = DZcaron;
+kernLeft = D;
+kernRight = Z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = D;
+},
+{
+alignment = -1;
+pos = (764,0);
+ref = Z;
+},
+{
+alignment = -1;
+pos = (919,0);
+ref = caron.case;
+}
+);
+width = 1413;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = D;
+},
+{
+alignment = -1;
+pos = (770,0);
+ref = Z;
+},
+{
+alignment = -1;
+pos = (944,0);
+ref = caron.case;
+}
+);
+width = 1439;
+}
+);
+unicode = 452;
+},
+{
+glyphname = Eth;
+kernRight = D;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,367,l),
+(381,402,l),
+(16,402,l),
+(16,367,l)
+);
+},
+{
+ref = D;
+}
+);
+width = 764;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(404,362,l),
+(404,402,l),
+(39,402,l),
+(39,362,l)
+);
+},
+{
+ref = D;
+}
+);
+width = 770;
+}
+);
+unicode = 208;
+},
+{
+glyphname = Dcaron;
+kernLeft = D;
+kernRight = D;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = D;
+},
+{
+alignment = -1;
+pos = (143,0);
+ref = caron.case;
+}
+);
+width = 764;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = D;
+},
+{
+alignment = -1;
+pos = (170,0);
+ref = caron.case;
+}
+);
+width = 770;
+}
+);
+unicode = 270;
+},
+{
+glyphname = Dcroat;
+kernRight = D;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Eth;
+}
+);
+width = 764;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Eth;
+}
+);
+width = 770;
+}
+);
+unicode = 272;
+},
+{
+glyphname = Ddotbelow;
+kernLeft = D;
+kernRight = D;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = D;
+},
+{
+alignment = -1;
+pos = (286,0);
+ref = dotbelow;
+}
+);
+width = 764;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = D;
+},
+{
+alignment = -1;
+pos = (268,0);
+ref = dotbelow;
+}
+);
+width = 770;
+}
+);
+unicode = 7692;
+},
+{
+glyphname = Dz;
+kernLeft = D;
+kernRight = z;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = D;
+},
+{
+pos = (764,0);
+ref = z;
+}
+);
+width = 1238;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = D;
+},
+{
+pos = (770,0);
+ref = z;
+}
+);
+width = 1264;
+}
+);
+unicode = 498;
+},
+{
+glyphname = Dzcaron;
+kernLeft = D;
+kernRight = z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = D;
+},
+{
+alignment = -1;
+pos = (764,0);
+ref = z;
+},
+{
+alignment = -1;
+pos = (831,0);
+ref = caron;
+}
+);
+width = 1238;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = D;
+},
+{
+alignment = -1;
+pos = (770,0);
+ref = z;
+},
+{
+alignment = -1;
+pos = (805,0);
+ref = caron;
+}
+);
+width = 1264;
+}
+);
+unicode = 453;
+},
+{
+glyphname = E;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (279,0);
+},
+{
+name = ogonek;
+pos = (544,10);
+},
+{
+name = top;
+pos = (453,754);
+},
+{
+name = topleft;
+pos = (142,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(340,754,l),
+(223,754,l),
+(59,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(553,0,l),
+(613,232,l),
+(583,232,l),
+(507,64,o),
+(445,25,o),
+(356,25,cs),
+(-37,25,l),
+(-37,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,226,l),
+(481,534,l),
+(456,534,l),
+(425,430,o),
+(390,403,o),
+(310,403,cs),
+(207,403,l),
+(207,378,l),
+(294,378,ls),
+(377,378,o),
+(392,351,o),
+(392,226,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(645,553,l),
+(673,754,l),
+(114,754,l),
+(114,729,l),
+(444,729,ls),
+(586,729,o),
+(615,692,o),
+(615,553,c)
+);
+}
+);
+width = 662;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (293,0);
+},
+{
+name = ogonek;
+pos = (569,10);
+},
+{
+name = top;
+pos = (467,754);
+},
+{
+name = topleft;
+pos = (142,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,0,l),
+(394,754,l),
+(243,754,l),
+(79,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(597,0,l),
+(657,232,l),
+(617,232,l),
+(541,68,o),
+(479,30,o),
+(390,30,cs),
+(-13,30,l),
+(-13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(478,227,l),
+(543,535,l),
+(508,535,l),
+(478,441,o),
+(429,404,o),
+(362,404,cs),
+(259,404,l),
+(259,374,l),
+(346,374,ls),
+(406,374,o),
+(444,348,o),
+(444,227,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(689,548,l),
+(725,754,l),
+(128,754,l),
+(128,724,l),
+(488,724,ls),
+(612,724,o),
+(649,687,o),
+(649,548,c)
+);
+}
+);
+width = 690;
+}
+);
+unicode = 69;
+},
+{
+glyphname = Eacute;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (94,304);
+ref = acutecomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (62,304);
+ref = acutecomb;
+}
+);
+width = 690;
+}
+);
+unicode = 201;
+},
+{
+glyphname = Ebreve;
+kernLeft = E;
+kernRight = E;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (104,0);
+ref = breve.case;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (145,0);
+ref = breve.case;
+}
+);
+width = 690;
+}
+);
+unicode = 276;
+},
+{
+glyphname = Ecaron;
+kernLeft = E;
+kernRight = E;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (111,0);
+ref = caron.case;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (125,0);
+ref = caron.case;
+}
+);
+width = 690;
+}
+);
+unicode = 282;
+},
+{
+glyphname = Ecircumflex;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (81,304);
+ref = circumflexcomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (122,304);
+ref = circumflexcomb;
+}
+);
+width = 690;
+}
+);
+unicode = 202;
+},
+{
+glyphname = Ecircumflexacute;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (85,304);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (100,304);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 690;
+}
+);
+unicode = 7870;
+},
+{
+glyphname = Ecircumflexdotbelow;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (38,0);
+ref = dotbelowcomb;
+},
+{
+pos = (81,304);
+ref = circumflexcomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (43,0);
+ref = dotbelowcomb;
+},
+{
+pos = (122,304);
+ref = circumflexcomb;
+}
+);
+width = 690;
+}
+);
+unicode = 7878;
+},
+{
+glyphname = Ecircumflexgrave;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (89,304);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (104,304);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 690;
+}
+);
+unicode = 7872;
+},
+{
+glyphname = Ecircumflexhookabove;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (83,304);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (101,304);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 690;
+}
+);
+unicode = 7874;
+},
+{
+glyphname = Ecircumflextilde;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (85,304);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (98,304);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 690;
+}
+);
+unicode = 7876;
+},
+{
+glyphname = Edblgrave;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (-1,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (24,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 690;
+}
+);
+unicode = 516;
+},
+{
+glyphname = Edieresis;
+kernLeft = E;
+kernRight = E;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (119,0);
+ref = dieresis.case;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (158,0);
+ref = dieresis.case;
+}
+);
+width = 690;
+}
+);
+unicode = 203;
+},
+{
+glyphname = Edotaccent;
+kernLeft = E;
+kernRight = E;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (226,0);
+ref = dotaccent.case;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (215,0);
+ref = dotaccent.case;
+}
+);
+width = 690;
+}
+);
+unicode = 278;
+},
+{
+glyphname = Edotbelow;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (38,0);
+ref = dotbelowcomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (43,0);
+ref = dotbelowcomb;
+}
+);
+width = 690;
+}
+);
+unicode = 7864;
+},
+{
+glyphname = Egrave;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (105,304);
+ref = gravecomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (151,304);
+ref = gravecomb;
+}
+);
+width = 690;
+}
+);
+unicode = 200;
+},
+{
+glyphname = Ehookabove;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (130,304);
+ref = hookabovecomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (135,304);
+ref = hookabovecomb;
+}
+);
+width = 690;
+}
+);
+unicode = 7866;
+},
+{
+glyphname = Einvertedbreve;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (119,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (145,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 690;
+}
+);
+unicode = 518;
+},
+{
+glyphname = Emacron;
+kernLeft = E;
+kernRight = E;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (111,0);
+ref = macron.case;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (142,0);
+ref = macron.case;
+}
+);
+width = 690;
+}
+);
+unicode = 274;
+},
+{
+glyphname = Eogonek;
+kernLeft = E;
+kernRight = E;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (366,0);
+ref = ogonek;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = E;
+},
+{
+alignment = -1;
+pos = (390,0);
+ref = ogonek;
+}
+);
+width = 690;
+}
+);
+unicode = 280;
+},
+{
+glyphname = Etilde;
+kernLeft = E;
+kernRight = E;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (94,304);
+ref = tildecomb;
+}
+);
+width = 662;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = E;
+},
+{
+pos = (102,304);
+ref = tildecomb;
+}
+);
+width = 690;
+}
+);
+unicode = 7868;
+},
+{
+glyphname = F;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (266,0);
+},
+{
+name = top;
+pos = (440,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,0,l),
+(379,754,l),
+(262,754,l),
+(98,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,0,l),
+(321,25,l),
+(2,25,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,224,l),
+(506,528,l),
+(481,528,l),
+(450,428,o),
+(415,401,o),
+(338,401,cs),
+(235,401,l),
+(235,376,l),
+(322,376,ls),
+(405,376,o),
+(420,349,o),
+(420,224,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(681,529,l),
+(712,754,l),
+(153,754,l),
+(153,729,l),
+(483,729,ls),
+(622,729,o),
+(651,692,o),
+(651,529,c)
+);
+}
+);
+width = 635;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (278,0);
+},
+{
+name = top;
+pos = (452,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,0,l),
+(382,754,l),
+(231,754,l),
+(67,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(349,0,l),
+(349,31,l),
+(-20,31,l),
+(-20,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(466,227,l),
+(531,535,l),
+(496,535,l),
+(466,441,o),
+(417,404,o),
+(350,404,cs),
+(247,404,l),
+(247,374,l),
+(334,374,ls),
+(394,374,o),
+(432,348,o),
+(432,227,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(677,548,l),
+(713,754,l),
+(116,754,l),
+(116,724,l),
+(476,724,ls),
+(600,724,o),
+(637,687,o),
+(637,548,c)
+);
+}
+);
+width = 659;
+}
+);
+unicode = 70;
+},
+{
+glyphname = G;
+kernLeft = G;
+kernRight = G;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (323,0);
+},
+{
+name = top;
+pos = (497,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,-13,o),
+(652,69,o),
+(702,256,c),
+(547,256,l),
+(515,76,o),
+(469,19,o),
+(363,19,cs),
+(271,19,o),
+(222,62,o),
+(222,205,cs),
+(222,390,o),
+(304,736,o),
+(505,736,cs),
+(598,736,o),
+(673,662,o),
+(673,541,c),
+(698,541,l),
+(745,754,l),
+(720,754,l),
+(671,702,l),
+(618,751,o),
+(569,765,o),
+(509,765,cs),
+(259,765,o),
+(84,519,o),
+(84,314,cs),
+(84,188,o),
+(149,-13,o),
+(375,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(778,253,l),
+(778,278,l),
+(441,278,l),
+(441,253,l)
+);
+}
+);
+width = 749;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (329,0);
+},
+{
+name = top;
+pos = (503,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,-13,o),
+(644,73,o),
+(698,243,c),
+(522,243,l),
+(494,65,o),
+(430,24,o),
+(363,24,cs),
+(290,24,o),
+(248,73,o),
+(248,207,cs),
+(248,399,o),
+(335,731,o),
+(502,731,cs),
+(585,731,o),
+(651,650,o),
+(651,521,c),
+(681,521,l),
+(728,754,l),
+(693,754,l),
+(649,707,l),
+(607,748,o),
+(565,765,o),
+(509,765,cs),
+(297,765,o),
+(72,525,o),
+(72,287,cs),
+(72,134,o),
+(165,-13,o),
+(364,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(773,237,l),
+(773,267,l),
+(423,267,l),
+(423,237,l)
+);
+}
+);
+width = 762;
+}
+);
+unicode = 71;
+},
+{
+glyphname = Gacute;
+kernLeft = G;
+kernRight = G;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = G;
+},
+{
+alignment = -1;
+pos = (236,0);
+ref = acute.case;
+}
+);
+width = 749;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = G;
+},
+{
+alignment = -1;
+pos = (240,0);
+ref = acute.case;
+}
+);
+width = 762;
+}
+);
+unicode = 500;
+},
+{
+glyphname = Gbreve;
+kernLeft = G;
+kernRight = G;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = G;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = breve.case;
+}
+);
+width = 749;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = G;
+},
+{
+alignment = -1;
+pos = (172,0);
+ref = breve.case;
+}
+);
+width = 762;
+}
+);
+unicode = 286;
+},
+{
+glyphname = Gcircumflex;
+kernLeft = G;
+kernRight = G;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = G;
+},
+{
+alignment = -1;
+pos = (214,0);
+ref = circumflex.case;
+}
+);
+width = 749;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = G;
+},
+{
+alignment = -1;
+pos = (183,1);
+ref = circumflex.case;
+}
+);
+width = 762;
+}
+);
+unicode = 284;
+},
+{
+glyphname = Gcommaaccent;
+kernLeft = G;
+kernRight = G;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = G;
+},
+{
+pos = (330,0);
+ref = commaaccentcomb;
+}
+);
+width = 749;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = G;
+},
+{
+pos = (316,0);
+ref = commaaccentcomb;
+}
+);
+width = 762;
+}
+);
+unicode = 290;
+},
+{
+glyphname = Gdotaccent;
+kernLeft = G;
+kernRight = G;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = G;
+},
+{
+alignment = -1;
+pos = (312,0);
+ref = dotaccent.case;
+}
+);
+width = 749;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = G;
+},
+{
+alignment = -1;
+pos = (266,0);
+ref = dotaccent.case;
+}
+);
+width = 762;
+}
+);
+unicode = 288;
+},
+{
+glyphname = H;
+kernLeft = H;
+kernRight = H;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (342,0);
+},
+{
+name = center;
+pos = (429,377);
+},
+{
+name = top;
+pos = (516,754);
+},
+{
+name = topleft;
+pos = (142,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(625,0,l),
+(793,754,l),
+(676,754,l),
+(512,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,0,l),
+(288,25,l),
+(-1,25,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(727,0,l),
+(727,25,l),
+(431,25,l),
+(431,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(188,0,l),
+(356,754,l),
+(239,754,l),
+(75,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(631,377,l),
+(631,405,l),
+(192,405,l),
+(192,377,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(441,729,l),
+(441,754,l),
+(152,754,l),
+(152,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(876,729,l),
+(876,754,l),
+(580,754,l),
+(580,729,l)
+);
+}
+);
+width = 787;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (352,0);
+},
+{
+name = center;
+pos = (439,377);
+},
+{
+name = top;
+pos = (526,754);
+},
+{
+name = topleft;
+pos = (142,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(630,0,l),
+(798,754,l),
+(647,754,l),
+(483,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(336,31,l),
+(-13,31,l),
+(-13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(745,0,l),
+(745,31,l),
+(396,31,l),
+(396,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,0,l),
+(389,754,l),
+(238,754,l),
+(74,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(608,365,l),
+(608,395,l),
+(269,395,l),
+(269,365,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,724,l),
+(477,754,l),
+(138,754,l),
+(138,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(886,724,l),
+(886,754,l),
+(547,754,l),
+(547,724,l)
+);
+}
+);
+width = 807;
+}
+);
+unicode = 72;
+},
+{
+glyphname = Hbar;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(857,548,l),
+(857,578,l),
+(88,578,l),
+(88,548,l)
+);
+},
+{
+ref = H;
+}
+);
+width = 787;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(869,538,l),
+(869,578,l),
+(100,578,l),
+(100,538,l)
+);
+},
+{
+ref = H;
+}
+);
+width = 807;
+}
+);
+unicode = 294;
+},
+{
+glyphname = Hcircumflex;
+kernLeft = H;
+kernRight = H;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = H;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = circumflex.case;
+}
+);
+width = 787;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = H;
+},
+{
+alignment = -1;
+pos = (230,0);
+ref = circumflex.case;
+}
+);
+width = 807;
+}
+);
+unicode = 292;
+},
+{
+glyphname = Hdotbelow;
+kernLeft = H;
+kernRight = H;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = H;
+},
+{
+alignment = -1;
+pos = (317,0);
+ref = dotbelow;
+}
+);
+width = 787;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = H;
+},
+{
+alignment = -1;
+pos = (327,0);
+ref = dotbelow;
+}
+);
+width = 807;
+}
+);
+unicode = 7716;
+},
+{
+glyphname = I;
+kernLeft = I;
+kernRight = I;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (128,0);
+},
+{
+name = ogonek;
+pos = (272,10);
+},
+{
+name = top;
+pos = (302,754);
+},
+{
+name = topleft;
+pos = (142,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,0,l),
+(361,754,l),
+(244,754,l),
+(80,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,0,l),
+(303,25,l),
+(-6,25,l),
+(-6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,729,l),
+(444,754,l),
+(145,754,l),
+(145,729,l)
+);
+}
+);
+width = 360;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (143,0);
+},
+{
+name = ogonek;
+pos = (299,10);
+},
+{
+name = top;
+pos = (317,754);
+},
+{
+name = topleft;
+pos = (142,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(207,0,l),
+(375,754,l),
+(224,754,l),
+(60,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,0,l),
+(302,31,l),
+(-7,31,l),
+(-7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(443,724,l),
+(443,754,l),
+(144,754,l),
+(144,724,l)
+);
+}
+);
+width = 390;
+}
+);
+unicode = 73;
+},
+{
+glyphname = IJ;
+kernLeft = I;
+kernRight = J;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (360,0);
+ref = J;
+}
+);
+width = 728;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (390,0);
+ref = J;
+}
+);
+width = 830;
+}
+);
+unicode = 306;
+},
+{
+glyphname = Iacute;
+kernLeft = I;
+kernRight = I;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-57,304);
+ref = acutecomb;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-88,304);
+ref = acutecomb;
+}
+);
+width = 390;
+}
+);
+unicode = 205;
+},
+{
+glyphname = Ibreve;
+kernLeft = I;
+kernRight = I;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (8,0);
+ref = breve.case;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (-6,0);
+ref = breve.case;
+}
+);
+width = 390;
+}
+);
+unicode = 300;
+},
+{
+glyphname = Icircumflex;
+kernLeft = I;
+kernRight = I;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (9,0);
+ref = circumflex.case;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (8,0);
+ref = circumflex.case;
+}
+);
+width = 390;
+}
+);
+unicode = 206;
+},
+{
+glyphname = Idblgrave;
+kernLeft = I;
+kernRight = I;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-108,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-119,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 390;
+}
+);
+unicode = 520;
+},
+{
+glyphname = Idieresis;
+kernLeft = I;
+kernRight = I;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (12,0);
+ref = dieresis.case;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (14,0);
+ref = dieresis.case;
+}
+);
+width = 390;
+}
+);
+unicode = 207;
+},
+{
+glyphname = Idotaccent;
+kernLeft = I;
+kernRight = I;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (88,0);
+ref = dotaccent.case;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (70,0);
+ref = dotaccent.case;
+}
+);
+width = 390;
+}
+);
+unicode = 304;
+},
+{
+glyphname = Idotbelow;
+kernLeft = I;
+kernRight = I;
+lastChange = "2016-08-22 14:06:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-113,0);
+ref = dotbelowcomb;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-107,0);
+ref = dotbelowcomb;
+}
+);
+width = 390;
+}
+);
+unicode = 7882;
+},
+{
+glyphname = Igrave;
+kernLeft = I;
+kernRight = I;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-46,304);
+ref = gravecomb;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (1,304);
+ref = gravecomb;
+}
+);
+width = 390;
+}
+);
+unicode = 204;
+},
+{
+glyphname = Ihookabove;
+kernLeft = I;
+kernRight = I;
+lastChange = "2016-08-22 14:17:04 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-21,304);
+ref = hookabovecomb;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-15,304);
+ref = hookabovecomb;
+}
+);
+width = 390;
+}
+);
+unicode = 7880;
+},
+{
+glyphname = Iinvertedbreve;
+kernLeft = I;
+kernRight = I;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (12,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-9,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 390;
+}
+);
+unicode = 522;
+},
+{
+glyphname = Imacron;
+kernLeft = I;
+kernRight = I;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (4,0);
+ref = macron.case;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (4,0);
+ref = macron.case;
+}
+);
+width = 390;
+}
+);
+unicode = 298;
+},
+{
+glyphname = Iogonek;
+kernLeft = I;
+kernRight = I;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (95,0);
+ref = ogonek;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = I;
+},
+{
+alignment = -1;
+pos = (71,0);
+ref = ogonek;
+}
+);
+width = 390;
+}
+);
+unicode = 302;
+},
+{
+glyphname = Itilde;
+kernLeft = I;
+kernRight = I;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-57,304);
+ref = tildecomb;
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = I;
+},
+{
+pos = (-48,304);
+ref = tildecomb;
+}
+);
+width = 390;
+}
+);
+unicode = 296;
+},
+{
+glyphname = J;
+kernLeft = J;
+kernRight = J;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (132,0);
+},
+{
+name = top;
+pos = (306,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,-101,o),
+(211,-36,o),
+(253,152,cs),
+(387,754,l),
+(270,754,l),
+(121,71,ls),
+(91,-67,o),
+(55,-71,o),
+(37,-71,cs),
+(14,-71,o),
+(1,-65,o),
+(1,-50,cs),
+(1,-31,o),
+(23,-21,o),
+(23,7,cs),
+(23,33,o),
+(4,60,o),
+(-31,60,cs),
+(-65,60,o),
+(-92,34,o),
+(-92,-8,cs),
+(-92,-60,o),
+(-50,-101,o),
+(30,-101,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(470,729,l),
+(470,754,l),
+(181,754,l),
+(181,729,l)
+);
+}
+);
+width = 368;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (168,0);
+},
+{
+name = top;
+pos = (342,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,-119,o),
+(257,-46,o),
+(296,142,cs),
+(423,754,l),
+(272,754,l),
+(114,34,ls),
+(93,-64,o),
+(73,-83,o),
+(45,-83,cs),
+(27,-83,o),
+(19,-75,o),
+(19,-65,cs),
+(19,-48,o),
+(47,-31,o),
+(47,12,cs),
+(47,59,o),
+(13,84,o),
+(-24,84,cs),
+(-73,84,o),
+(-101,39,o),
+(-101,-3,cs),
+(-101,-61,o),
+(-49,-119,o),
+(41,-119,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(491,724,l),
+(491,754,l),
+(162,754,l),
+(162,724,l)
+);
+}
+);
+width = 440;
+}
+);
+unicode = 74;
+},
+{
+glyphname = Jcircumflex;
+kernLeft = J;
+kernRight = J;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = J;
+},
+{
+alignment = -1;
+pos = (26,0);
+ref = circumflex.case;
+}
+);
+width = 368;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = J;
+},
+{
+alignment = -1;
+pos = (22,0);
+ref = circumflex.case;
+}
+);
+width = 440;
+}
+);
+unicode = 308;
+},
+{
+glyphname = K;
+kernLeft = K;
+kernRight = K;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (311,0);
+},
+{
+name = top;
+pos = (485,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,0,l),
+(382,754,l),
+(265,754,l),
+(101,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(324,0,l),
+(324,25,l),
+(15,25,l),
+(15,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(764,0,l),
+(764,25,l),
+(418,25,l),
+(418,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(673,9,l),
+(421,461,l),
+(322,395,l),
+(541,9,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(475,729,l),
+(475,754,l),
+(156,754,l),
+(156,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(365,395,l),
+(730,734,l),
+(687,734,l),
+(322,395,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(833,729,l),
+(833,754,l),
+(568,754,l),
+(568,729,l)
+);
+}
+);
+width = 726;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (317,0);
+},
+{
+name = top;
+pos = (491,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,0,l),
+(389,754,l),
+(238,754,l),
+(74,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(316,0,l),
+(316,31,l),
+(7,31,l),
+(7,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(750,0,l),
+(750,30,l),
+(394,30,l),
+(394,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(674,9,l),
+(457,472,l),
+(328,395,l),
+(497,9,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(457,724,l),
+(457,754,l),
+(158,754,l),
+(158,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,395,l),
+(765,734,l),
+(713,734,l),
+(328,395,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(816,724,l),
+(816,754,l),
+(551,754,l),
+(551,724,l)
+);
+}
+);
+width = 738;
+}
+);
+unicode = 75;
+},
+{
+glyphname = Kcommaaccent;
+kernLeft = K;
+kernRight = K;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = K;
+},
+{
+pos = (315,0);
+ref = commaaccentcomb;
+}
+);
+width = 726;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = K;
+},
+{
+pos = (297,0);
+ref = commaaccentcomb;
+}
+);
+width = 738;
+}
+);
+unicode = 310;
+},
+{
+glyphname = L;
+kernLeft = L;
+kernRight = L;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (247,0);
+},
+{
+name = center;
+pos = (334,377);
+},
+{
+name = top;
+pos = (421,754);
+},
+{
+name = topright;
+pos = (700,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(167,0,l),
+(335,754,l),
+(218,754,l),
+(54,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(536,0,l),
+(596,232,l),
+(566,232,l),
+(490,64,o),
+(428,25,o),
+(339,25,cs),
+(-22,25,l),
+(-22,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(418,729,l),
+(418,754,l),
+(129,754,l),
+(129,729,l)
+);
+}
+);
+width = 598;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (261,0);
+},
+{
+name = center;
+pos = (348,377);
+},
+{
+name = top;
+pos = (435,754);
+},
+{
+name = topright;
+pos = (728,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,0,l),
+(378,754,l),
+(227,754,l),
+(63,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(561,0,l),
+(621,232,l),
+(581,232,l),
+(505,78,o),
+(423,30,o),
+(344,30,cs),
+(-29,30,l),
+(-29,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,724,l),
+(486,754,l),
+(107,754,l),
+(107,724,l)
+);
+}
+);
+width = 626;
+}
+);
+unicode = 76;
+},
+{
+glyphname = LJ;
+kernLeft = L;
+kernRight = J;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (598,0);
+ref = J;
+}
+);
+width = 966;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (626,0);
+ref = J;
+}
+);
+width = 1066;
+}
+);
+unicode = 455;
+},
+{
+glyphname = Lacute;
+kernLeft = L;
+kernRight = L;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = L;
+},
+{
+alignment = -1;
+pos = (110,0);
+ref = acute.case;
+}
+);
+width = 598;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = L;
+},
+{
+alignment = -1;
+pos = (122,0);
+ref = acute.case;
+}
+);
+width = 626;
+}
+);
+unicode = 313;
+},
+{
+glyphname = Lcaron;
+kernLeft = L;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (374,152);
+ref = quoteright;
+}
+);
+width = 598;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (415,152);
+ref = quoteright;
+}
+);
+width = 626;
+}
+);
+unicode = 317;
+},
+{
+glyphname = Lcommaaccent;
+kernLeft = L;
+kernRight = L;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (209,0);
+ref = commaaccentcomb;
+}
+);
+width = 598;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (255,0);
+ref = commaaccentcomb;
+}
+);
+width = 626;
+}
+);
+unicode = 315;
+},
+{
+glyphname = Ldot;
+kernLeft = L;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (371,143);
+ref = periodcentered;
+}
+);
+width = 598;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (401,143);
+ref = periodcentered;
+}
+);
+width = 626;
+}
+);
+unicode = 319;
+},
+{
+glyphname = Lj;
+kernLeft = L;
+kernRight = j;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (598,0);
+ref = j;
+}
+);
+width = 889;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = L;
+},
+{
+pos = (626,0);
+ref = j;
+}
+);
+width = 913;
+}
+);
+unicode = 456;
+},
+{
+glyphname = Lslash;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,463,l),
+(399,503,l),
+(12,277,l),
+(12,237,l)
+);
+},
+{
+ref = L;
+}
+);
+width = 598;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,453,l),
+(463,503,l),
+(29,277,l),
+(18,227,l)
+);
+},
+{
+ref = L;
+}
+);
+width = 626;
+}
+);
+unicode = 321;
+},
+{
+glyphname = M;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (388,0);
+},
+{
+name = top;
+pos = (562,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(798,754,l),
+(759,754,l),
+(458,227,l),
+(368,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,0,l),
+(236,25,l),
+(14,25,l),
+(14,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(131,0,l),
+(295,754,l),
+(265,754,l),
+(101,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(825,0,l),
+(825,25,l),
+(509,25,l),
+(509,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(368,0,l),
+(458,227,l),
+(454,227,l),
+(408,754,l),
+(284,754,l),
+(284,705,l),
+(288,705,l),
+(347,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(408,729,l),
+(408,754,l),
+(166,754,l),
+(166,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(708,0,l),
+(876,754,l),
+(759,754,l),
+(595,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(975,729,l),
+(975,754,l),
+(759,754,l),
+(759,729,l)
+);
+}
+);
+width = 879;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (402,0);
+},
+{
+name = top;
+pos = (576,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(796,754,l),
+(747,754,l),
+(480,272,l),
+(366,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,0,l),
+(234,30,l),
+(12,30,l),
+(12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,0,l),
+(293,754,l),
+(253,754,l),
+(89,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(854,0,l),
+(854,31,l),
+(505,31,l),
+(505,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(366,0,l),
+(480,272,l),
+(476,272,l),
+(420,754,l),
+(282,754,l),
+(265,626,l),
+(269,626,l),
+(345,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,724,l),
+(420,754,l),
+(164,754,l),
+(164,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(739,0,l),
+(907,754,l),
+(756,754,l),
+(592,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(995,724,l),
+(995,754,l),
+(786,754,l),
+(786,724,l)
+);
+}
+);
+width = 907;
+}
+);
+unicode = 77;
+},
+{
+glyphname = N;
+kernLeft = N;
+kernRight = N;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (333,0);
+},
+{
+name = top;
+pos = (507,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(580,-13,l),
+(613,228,l),
+(609,228,l),
+(399,754,l),
+(275,754,l),
+(275,705,l),
+(279,705,l),
+(560,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,0,l),
+(237,25,l),
+(-5,25,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(286,754,l),
+(256,754,l),
+(92,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,729,l),
+(399,754,l),
+(147,754,l),
+(147,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(590,-13,l),
+(757,754,l),
+(727,754,l),
+(560,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(854,729,l),
+(854,754,l),
+(612,754,l),
+(612,729,l)
+);
+}
+);
+width = 769;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (323,0);
+},
+{
+name = top;
+pos = (497,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,-13,l),
+(619,267,l),
+(615,267,l),
+(384,754,l),
+(270,754,l),
+(251,637,l),
+(255,637,l),
+(555,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,30,l),
+(-15,30,l),
+(-15,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,0,l),
+(276,754,l),
+(236,754,l),
+(72,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,724,l),
+(384,754,l),
+(127,754,l),
+(127,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(586,-13,l),
+(753,754,l),
+(713,754,l),
+(564,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(830,724,l),
+(830,754,l),
+(612,754,l),
+(612,724,l)
+);
+}
+);
+width = 749;
+}
+);
+unicode = 78;
+},
+{
+glyphname = NJ;
+kernLeft = N;
+kernRight = J;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = N;
+},
+{
+pos = (769,0);
+ref = J;
+}
+);
+width = 1137;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = N;
+},
+{
+pos = (749,0);
+ref = J;
+}
+);
+width = 1189;
+}
+);
+unicode = 458;
+},
+{
+glyphname = Nacute;
+kernLeft = N;
+kernRight = N;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = N;
+},
+{
+alignment = -1;
+pos = (238,0);
+ref = acute.case;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = N;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = acute.case;
+}
+);
+width = 749;
+}
+);
+unicode = 323;
+},
+{
+glyphname = Ncaron;
+kernLeft = N;
+kernRight = N;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = N;
+},
+{
+alignment = -1;
+pos = (193,0);
+ref = caron.case;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = N;
+},
+{
+alignment = -1;
+pos = (195,0);
+ref = caron.case;
+}
+);
+width = 749;
+}
+);
+unicode = 327;
+},
+{
+glyphname = Ncommaaccent;
+kernLeft = N;
+kernRight = N;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = N;
+},
+{
+pos = (312,0);
+ref = commaaccentcomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = N;
+},
+{
+pos = (299,0);
+ref = commaaccentcomb;
+}
+);
+width = 749;
+}
+);
+unicode = 325;
+},
+{
+glyphname = Ndotaccent;
+kernLeft = N;
+kernRight = N;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = N;
+},
+{
+alignment = -1;
+pos = (294,0);
+ref = dotaccent.case;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = N;
+},
+{
+alignment = -1;
+pos = (271,0);
+ref = dotaccent.case;
+}
+);
+width = 749;
+}
+);
+unicode = 7748;
+},
+{
+glyphname = Eng;
+kernLeft = N;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,-158,o),
+(572,-81,o),
+(598,35,cs),
+(753,737,l),
+(723,737,l),
+(567,19,ls),
+(537,-117,o),
+(495,-129,o),
+(472,-129,cs),
+(454,-129,o),
+(445,-122,o),
+(445,-107,cs),
+(445,-83,o),
+(467,-73,o),
+(467,-48,cs),
+(467,-24,o),
+(448,3,o),
+(413,3,cs),
+(379,3,o),
+(352,-23,o),
+(352,-64,cs),
+(352,-118,o),
+(397,-158,o),
+(456,-158,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,0,l),
+(237,25,l),
+(-5,25,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(286,754,l),
+(256,754,l),
+(92,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(593,47,l),
+(625,286,l),
+(621,286,l),
+(399,754,l),
+(275,754,l),
+(275,705,l),
+(279,705,l),
+(573,47,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,729,l),
+(399,754,l),
+(147,754,l),
+(147,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(854,729,l),
+(854,754,l),
+(612,754,l),
+(612,729,l)
+);
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(532,-157,o),
+(573,-81,o),
+(594,16,cs),
+(751,737,l),
+(711,737,l),
+(548,-4,ls),
+(528,-93,o),
+(498,-114,o),
+(471,-114,cs),
+(450,-114,o),
+(443,-105,o),
+(443,-95,cs),
+(443,-68,o),
+(481,-77,o),
+(481,-26,cs),
+(481,21,o),
+(447,46,o),
+(410,46,cs),
+(361,46,o),
+(333,1,o),
+(333,-41,cs),
+(333,-95,o),
+(378,-157,o),
+(451,-157,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,30,l),
+(-15,30,l),
+(-15,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,0,l),
+(276,754,l),
+(236,754,l),
+(72,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(587,39,l),
+(623,337,l),
+(619,337,l),
+(384,754,l),
+(270,754,l),
+(251,637,l),
+(255,637,l),
+(567,39,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(384,724,l),
+(384,754,l),
+(127,754,l),
+(127,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(830,724,l),
+(830,754,l),
+(612,754,l),
+(612,724,l)
+);
+}
+);
+width = 751;
+}
+);
+unicode = 330;
+},
+{
+glyphname = Nj;
+kernLeft = N;
+kernRight = j;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = N;
+},
+{
+pos = (769,0);
+ref = j;
+}
+);
+width = 1060;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = N;
+},
+{
+pos = (749,0);
+ref = j;
+}
+);
+width = 1036;
+}
+);
+unicode = 459;
+},
+{
+glyphname = Ntilde;
+kernLeft = N;
+kernRight = N;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = N;
+},
+{
+alignment = -1;
+pos = (172,0);
+ref = tilde.case;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = N;
+},
+{
+alignment = -1;
+pos = (182,0);
+ref = tilde.case;
+}
+);
+width = 749;
+}
+);
+unicode = 209;
+},
+{
+glyphname = O;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:09:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (333,0);
+},
+{
+name = center;
+pos = (420,377);
+},
+{
+name = ogonek;
+pos = (640,10);
+},
+{
+name = top;
+pos = (533,754);
+},
+{
+name = topleft;
+pos = (142,754);
+},
+{
+name = topright;
+pos = (666,703);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,-11,o),
+(781,278,o),
+(781,475,cs),
+(781,617,o),
+(686,763,o),
+(518,763,cs),
+(300,763,o),
+(72,516,o),
+(72,280,cs),
+(72,131,o),
+(163,-11,o),
+(343,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,19,o),
+(210,89,o),
+(210,208,cs),
+(210,390,o),
+(298,736,o),
+(520,736,cs),
+(588,736,o),
+(651,704,o),
+(651,547,cs),
+(651,377,o),
+(578,19,o),
+(349,19,cs)
+);
+}
+);
+width = 769;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (343,0);
+},
+{
+name = center;
+pos = (430,377);
+},
+{
+name = ogonek;
+pos = (658,10);
+},
+{
+name = top;
+pos = (517,754);
+},
+{
+name = topleft;
+pos = (142,754);
+},
+{
+name = topright;
+pos = (658,701);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(589,-11,o),
+(798,227,o),
+(798,454,cs),
+(798,630,o),
+(672,763,o),
+(500,763,cs),
+(272,763,o),
+(65,529,o),
+(65,304,cs),
+(65,129,o),
+(190,-11,o),
+(363,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,21,o),
+(238,89,o),
+(238,194,cs),
+(238,384,o),
+(298,731,o),
+(503,731,cs),
+(613,731,o),
+(624,630,o),
+(624,551,cs),
+(624,369,o),
+(565,21,o),
+(357,21,cs)
+);
+}
+);
+width = 789;
+}
+);
+unicode = 79;
+},
+{
+glyphname = Oacute;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:10:02 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (174,304);
+ref = acutecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (112,304);
+ref = acutecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 211;
+},
+{
+glyphname = Obreve;
+kernLeft = O;
+kernRight = O;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (208,0);
+ref = breve.case;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (191,0);
+ref = breve.case;
+}
+);
+width = 789;
+}
+);
+unicode = 334;
+},
+{
+glyphname = Ocircumflex;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:10:02 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (161,304);
+ref = circumflexcomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (172,304);
+ref = circumflexcomb;
+}
+);
+width = 789;
+}
+);
+unicode = 212;
+},
+{
+glyphname = Ocircumflexacute;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (165,304);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (150,304);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7888;
+},
+{
+glyphname = Ocircumflexdotbelow;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (92,0);
+ref = dotbelowcomb;
+},
+{
+pos = (161,304);
+ref = circumflexcomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (93,0);
+ref = dotbelowcomb;
+},
+{
+pos = (172,304);
+ref = circumflexcomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7896;
+},
+{
+glyphname = Ocircumflexgrave;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (169,304);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (154,304);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7890;
+},
+{
+glyphname = Ocircumflexhookabove;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (163,304);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (151,304);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7892;
+},
+{
+glyphname = Ocircumflextilde;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (165,304);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (148,304);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7894;
+},
+{
+glyphname = Odblgrave;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (155,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (107,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 789;
+}
+);
+unicode = 524;
+},
+{
+glyphname = Odieresis;
+kernLeft = O;
+kernRight = O;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (225,0);
+ref = dieresis.case;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = dieresis.case;
+}
+);
+width = 789;
+}
+);
+unicode = 214;
+},
+{
+glyphname = Odotbelow;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (92,0);
+ref = dotbelowcomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (93,0);
+ref = dotbelowcomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7884;
+},
+{
+glyphname = Ograve;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (185,304);
+ref = gravecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (201,304);
+ref = gravecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 210;
+},
+{
+glyphname = Ohookabove;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (210,304);
+ref = hookabovecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (185,304);
+ref = hookabovecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7886;
+},
+{
+glyphname = Ohorn;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (361,253);
+ref = horncomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (345,251);
+ref = horncomb;
+}
+);
+width = 789;
+}
+);
+unicode = 416;
+},
+{
+glyphname = Ohornacute;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (174,304);
+ref = acutecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (112,304);
+ref = acutecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7898;
+},
+{
+glyphname = Ohorndotbelow;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (92,0);
+ref = dotbelowcomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (93,0);
+ref = dotbelowcomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7906;
+},
+{
+glyphname = Ohorngrave;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (185,304);
+ref = gravecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (201,304);
+ref = gravecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7900;
+},
+{
+glyphname = Ohornhookabove;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (210,304);
+ref = hookabovecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (185,304);
+ref = hookabovecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7902;
+},
+{
+glyphname = Ohorntilde;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (174,304);
+ref = tildecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Ohorn;
+},
+{
+pos = (152,304);
+ref = tildecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 7904;
+},
+{
+glyphname = Ohungarumlaut;
+kernLeft = O;
+kernRight = O;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (181,0);
+ref = hungarumlaut.case;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (128,0);
+ref = hungarumlaut.case;
+}
+);
+width = 789;
+}
+);
+unicode = 336;
+},
+{
+glyphname = Oinvertedbreve;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (233,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (198,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 789;
+}
+);
+unicode = 526;
+},
+{
+glyphname = Omacron;
+kernLeft = O;
+kernRight = O;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (201,0);
+ref = macron.case;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (189,0);
+ref = macron.case;
+}
+);
+width = 789;
+}
+);
+unicode = 332;
+},
+{
+glyphname = Oogonek;
+kernLeft = O;
+kernRight = O;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (298,0);
+ref = ogonek;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = O;
+},
+{
+alignment = -1;
+pos = (273,0);
+ref = ogonek;
+}
+);
+width = 789;
+}
+);
+unicode = 490;
+},
+{
+glyphname = Oslash;
+lastChange = "2016-08-22 14:17:28 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(81,-53,l),
+(169,49,l),
+(212,12,o),
+(270,-11,o),
+(343,-11,cs),
+(599,-11,o),
+(781,278,o),
+(781,475,cs),
+(781,548,o),
+(756,622,o),
+(709,676,c),
+(819,804,l),
+(781,804,l),
+(689,697,l),
+(646,737,o),
+(588,763,o),
+(518,763,cs),
+(300,763,o),
+(72,516,o),
+(72,280,cs),
+(72,201,o),
+(97,123,o),
+(148,68,c),
+(44,-53,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,19,o),
+(240,52,o),
+(222,111,c),
+(647,605,l),
+(689,367,o),
+(547,19,o),
+(349,19,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,164,o),
+(210,185,o),
+(210,208,cs),
+(210,390,o),
+(298,736,o),
+(520,736,cs),
+(571,736,o),
+(620,717,o),
+(640,640,c),
+(214,145,l)
+);
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(112,-53,l),
+(193,42,l),
+(240,8,o),
+(298,-11,o),
+(363,-11,cs),
+(589,-11,o),
+(798,227,o),
+(798,454,cs),
+(798,534,o),
+(771,606,o),
+(726,660,c),
+(850,804,l),
+(792,804,l),
+(695,692,l),
+(644,737,o),
+(576,763,o),
+(500,763,cs),
+(272,763,o),
+(65,529,o),
+(65,304,cs),
+(65,210,o),
+(100,127,o),
+(160,70,c),
+(54,-53,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(297,21,o),
+(264,50,o),
+(249,106,c),
+(624,541,l),
+(622,357,o),
+(561,21,o),
+(357,21,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,168,o),
+(238,191,o),
+(238,194,cs),
+(238,384,o),
+(298,731,o),
+(503,731,cs),
+(588,731,o),
+(614,670,o),
+(621,606,c),
+(239,162,l)
+);
+}
+);
+width = 789;
+}
+);
+unicode = 216;
+},
+{
+glyphname = Oslashacute;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = Oslash;
+},
+{
+alignment = -1;
+pos = (301,0);
+ref = acute.case;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = Oslash;
+},
+{
+alignment = -1;
+pos = (236,0);
+ref = acute.case;
+}
+);
+width = 789;
+}
+);
+unicode = 510;
+},
+{
+glyphname = Otilde;
+kernLeft = O;
+kernRight = O;
+lastChange = "2016-08-22 14:10:02 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (174,304);
+ref = tildecomb;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = O;
+},
+{
+pos = (152,304);
+ref = tildecomb;
+}
+);
+width = 789;
+}
+);
+unicode = 213;
+},
+{
+glyphname = OE;
+kernLeft = O;
+kernRight = E;
+lastChange = "2016-08-22 11:02:24 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(575,0,o),
+(735,279,o),
+(735,472,cs),
+(735,613,o),
+(644,754,o),
+(503,754,cs),
+(292,754,o),
+(72,516,o),
+(72,284,cs),
+(72,140,o),
+(170,0,o),
+(343,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(259,30,o),
+(210,75,o),
+(210,204,cs),
+(210,389,o),
+(295,727,o),
+(508,727,cs),
+(572,727,o),
+(631,695,o),
+(631,551,cs),
+(631,373,o),
+(551,30,o),
+(336,30,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(1024,0,l),
+(1084,232,l),
+(1054,232,l),
+(978,64,o),
+(916,25,o),
+(827,25,cs),
+(572,25,l),
+(571,124,l),
+(471,49,l),
+(352,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(643,0,l),
+(811,754,l),
+(694,754,l),
+(530,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(893,226,l),
+(952,534,l),
+(927,534,l),
+(896,430,o),
+(861,403,o),
+(781,403,cs),
+(678,403,l),
+(678,378,l),
+(765,378,ls),
+(848,378,o),
+(863,351,o),
+(863,226,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(1116,553,l),
+(1144,754,l),
+(503,754,l),
+(573,723,l),
+(672,631,l),
+(729,729,l),
+(915,729,ls),
+(1057,729,o),
+(1086,692,o),
+(1086,553,c)
+);
+}
+);
+width = 1133;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,0,o),
+(742,241,o),
+(742,466,cs),
+(742,619,o),
+(651,754,o),
+(507,754,cs),
+(285,754,o),
+(65,511,o),
+(65,286,cs),
+(65,135,o),
+(170,0,o),
+(337,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,32,o),
+(233,66,o),
+(233,170,cs),
+(233,323,o),
+(303,722,o),
+(511,722,cs),
+(594,722,o),
+(609,662,o),
+(609,591,cs),
+(609,430,o),
+(538,32,o),
+(331,32,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(1021,0,l),
+(1081,232,l),
+(1041,232,l),
+(965,68,o),
+(903,30,o),
+(814,30,cs),
+(572,30,l),
+(515,100,l),
+(436,30,l),
+(351,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(650,0,l),
+(818,754,l),
+(667,754,l),
+(503,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(902,227,l),
+(967,535,l),
+(932,535,l),
+(902,441,o),
+(853,404,o),
+(786,404,cs),
+(683,404,l),
+(683,374,l),
+(770,374,ls),
+(830,374,o),
+(868,348,o),
+(868,227,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(1113,548,l),
+(1149,754,l),
+(512,754,l),
+(602,724,l),
+(656,643,l),
+(705,724,l),
+(912,724,ls),
+(1036,724,o),
+(1073,687,o),
+(1073,548,c)
+);
+}
+);
+width = 1114;
+}
+);
+unicode = 338;
+},
+{
+glyphname = P;
+kernLeft = P;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (270,0);
+},
+{
+name = top;
+pos = (444,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,348,ls),
+(538,348,o),
+(676,437,o),
+(676,569,cs),
+(676,675,o),
+(586,754,o),
+(417,754,cs),
+(126,754,l),
+(126,729,l),
+(405,729,ls),
+(517,729,o),
+(540,694,o),
+(540,601,cs),
+(540,449,o),
+(478,373,o),
+(342,373,cs),
+(183,373,l),
+(183,348,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(294,0,l),
+(294,25,l),
+(-25,25,l),
+(-25,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(174,0,l),
+(342,754,l),
+(225,754,l),
+(61,0,l)
+);
+}
+);
+width = 643;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (290,0);
+},
+{
+name = top;
+pos = (464,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,348,ls),
+(581,348,o),
+(715,436,o),
+(715,571,cs),
+(715,684,o),
+(622,754,o),
+(442,754,cs),
+(121,754,l),
+(121,724,l),
+(430,724,ls),
+(529,724,o),
+(549,690,o),
+(549,604,cs),
+(549,448,o),
+(484,373,o),
+(370,373,cs),
+(178,373,l),
+(178,348,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,0,l),
+(304,31,l),
+(-5,31,l),
+(-5,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(209,0,l),
+(377,754,l),
+(226,754,l),
+(62,0,l)
+);
+}
+);
+width = 683;
+}
+);
+unicode = 80;
+},
+{
+glyphname = Thorn;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,0,l),
+(339,754,l),
+(222,754,l),
+(58,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(291,0,l),
+(291,25,l),
+(-28,25,l),
+(-28,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(304,178,ls),
+(495,178,o),
+(633,267,o),
+(633,399,cs),
+(633,505,o),
+(543,584,o),
+(374,584,cs),
+(213,584,l),
+(213,559,l),
+(362,559,ls),
+(474,559,o),
+(497,524,o),
+(497,431,cs),
+(497,279,o),
+(435,203,o),
+(299,203,cs),
+(140,203,l),
+(140,178,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,729,l),
+(445,754,l),
+(116,754,l),
+(116,729,l)
+);
+}
+);
+width = 622;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,0,l),
+(372,754,l),
+(221,754,l),
+(57,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,0,l),
+(299,31,l),
+(-10,31,l),
+(-10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(303,175,ls),
+(542,175,o),
+(676,263,o),
+(676,398,cs),
+(676,511,o),
+(583,581,o),
+(403,581,cs),
+(222,581,l),
+(222,551,l),
+(391,551,ls),
+(490,551,o),
+(510,517,o),
+(510,431,cs),
+(510,275,o),
+(445,200,o),
+(331,200,cs),
+(139,200,l),
+(139,175,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(453,723,l),
+(453,754,l),
+(144,754,l),
+(144,723,l)
+);
+}
+);
+width = 642;
+}
+);
+unicode = 222;
+},
+{
+glyphname = Q;
+kernLeft = O;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (333,0);
+},
+{
+name = top;
+pos = (507,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(599,-11,o),
+(781,278,o),
+(781,475,cs),
+(781,617,o),
+(686,763,o),
+(518,763,cs),
+(300,763,o),
+(72,516,o),
+(72,280,cs),
+(72,131,o),
+(163,-11,o),
+(343,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(539,-242,o),
+(577,-239,o),
+(618,-232,c),
+(611,-202,l),
+(585,-208,o),
+(561,-210,o),
+(541,-210,cs),
+(455,-210,o),
+(404,-172,o),
+(404,-85,cs),
+(404,-48,o),
+(413,-18,o),
+(431,12,c),
+(265,6,l),
+(263,-10,o),
+(262,-26,o),
+(262,-40,cs),
+(262,-173,o),
+(350,-242,o),
+(506,-242,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,19,o),
+(210,89,o),
+(210,208,cs),
+(210,390,o),
+(298,736,o),
+(520,736,cs),
+(588,736,o),
+(651,704,o),
+(651,547,cs),
+(651,377,o),
+(578,19,o),
+(349,19,cs)
+);
+}
+);
+width = 769;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (343,0);
+},
+{
+name = top;
+pos = (517,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(583,-11,o),
+(810,236,o),
+(810,466,cs),
+(810,623,o),
+(701,763,o),
+(525,763,cs),
+(295,763,o),
+(68,516,o),
+(68,286,cs),
+(68,129,o),
+(177,-11,o),
+(353,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(524,-242,o),
+(562,-239,o),
+(603,-232,c),
+(596,-192,l),
+(570,-198,o),
+(546,-200,o),
+(526,-200,cs),
+(452,-200,o),
+(409,-165,o),
+(409,-85,cs),
+(409,-48,o),
+(411,-18,o),
+(416,12,c),
+(251,15,l),
+(249,-1,o),
+(247,-26,o),
+(247,-40,cs),
+(247,-173,o),
+(335,-242,o),
+(491,-242,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,21,o),
+(236,57,o),
+(236,170,cs),
+(236,326,o),
+(310,731,o),
+(529,731,cs),
+(624,731,o),
+(642,666,o),
+(642,591,cs),
+(642,427,o),
+(567,21,o),
+(349,21,cs)
+);
+}
+);
+width = 789;
+}
+);
+unicode = 81;
+},
+{
+glyphname = R;
+kernLeft = P;
+kernRight = R;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (300,0);
+},
+{
+name = top;
+pos = (474,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,0,l),
+(366,754,l),
+(249,754,l),
+(85,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,0,l),
+(318,25,l),
+(-1,25,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(688,-10,o),
+(708,4,o),
+(727,25,c),
+(711,39,l),
+(699,27,o),
+(686,23,o),
+(665,23,cs),
+(605,23,o),
+(603,56,o),
+(600,138,cs),
+(594,283,o),
+(576,335,o),
+(438,389,c),
+(438,393,l),
+(315,390,l),
+(398,390,o),
+(451,345,o),
+(458,233,cs),
+(463,154,o),
+(446,-10,o),
+(633,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(371,391,ls),
+(580,391,o),
+(700,469,o),
+(700,585,cs),
+(700,685,o),
+(610,754,o),
+(441,754,cs),
+(150,754,l),
+(150,729,l),
+(429,729,ls),
+(542,729,o),
+(564,700,o),
+(564,620,cs),
+(564,487,o),
+(502,416,o),
+(392,416,cs),
+(207,416,l),
+(207,391,l)
+);
+}
+);
+width = 703;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (484,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,0,l),
+(381,754,l),
+(230,754,l),
+(66,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(308,0,l),
+(308,31,l),
+(-1,31,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(668,-11,o),
+(708,4,o),
+(732,25,c),
+(716,54,l),
+(699,44,o),
+(684,38,o),
+(666,38,cs),
+(614,38,o),
+(620,93,o),
+(615,161,cs),
+(607,287,o),
+(576,352,o),
+(457,387,c),
+(457,391,l),
+(334,385,l),
+(436,385,o),
+(440,310,o),
+(443,233,cs),
+(448,110,o),
+(453,-11,o),
+(612,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(346,385,ls),
+(586,385,o),
+(719,454,o),
+(719,578,cs),
+(719,681,o),
+(626,754,o),
+(446,754,cs),
+(125,754,l),
+(125,724,l),
+(434,724,ls),
+(529,724,o),
+(553,690,o),
+(553,614,cs),
+(553,491,o),
+(488,415,o),
+(374,415,cs),
+(182,415,l),
+(182,385,l)
+);
+}
+);
+width = 723;
+}
+);
+unicode = 82;
+},
+{
+glyphname = Racute;
+kernLeft = P;
+kernRight = R;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = R;
+},
+{
+alignment = -1;
+pos = (181,0);
+ref = acute.case;
+}
+);
+width = 703;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = R;
+},
+{
+alignment = -1;
+pos = (194,0);
+ref = acute.case;
+}
+);
+width = 723;
+}
+);
+unicode = 340;
+},
+{
+glyphname = Rcaron;
+kernLeft = P;
+kernRight = R;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = R;
+},
+{
+alignment = -1;
+pos = (125,0);
+ref = caron.case;
+}
+);
+width = 703;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = R;
+},
+{
+alignment = -1;
+pos = (139,0);
+ref = caron.case;
+}
+);
+width = 723;
+}
+);
+unicode = 344;
+},
+{
+glyphname = Rcommaaccent;
+kernLeft = P;
+kernRight = R;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = R;
+},
+{
+pos = (318,0);
+ref = commaaccentcomb;
+}
+);
+width = 703;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = R;
+},
+{
+pos = (294,0);
+ref = commaaccentcomb;
+}
+);
+width = 723;
+}
+);
+unicode = 342;
+},
+{
+glyphname = Rdblgrave;
+kernLeft = P;
+kernRight = R;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = R;
+},
+{
+pos = (14,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 703;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = R;
+},
+{
+pos = (57,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 723;
+}
+);
+unicode = 528;
+},
+{
+glyphname = Rdotbelow;
+kernLeft = P;
+kernRight = R;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = R;
+},
+{
+alignment = -1;
+pos = (316,0);
+ref = dotbelow;
+}
+);
+width = 703;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = R;
+},
+{
+alignment = -1;
+pos = (287,0);
+ref = dotbelow;
+}
+);
+width = 723;
+}
+);
+unicode = 7770;
+},
+{
+glyphname = Rinvertedbreve;
+kernLeft = P;
+kernRight = R;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = R;
+},
+{
+pos = (142,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 703;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = R;
+},
+{
+pos = (129,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 723;
+}
+);
+unicode = 530;
+},
+{
+glyphname = S;
+kernLeft = S;
+kernRight = S;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (237,0);
+},
+{
+name = top;
+pos = (411,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(419,-13,o),
+(535,93,o),
+(535,247,cs),
+(535,492,o),
+(212,464,o),
+(212,617,cs),
+(212,695,o),
+(301,738,o),
+(374,738,cs),
+(473,738,o),
+(530,664,o),
+(530,555,c),
+(555,555,l),
+(595,754,l),
+(570,754,l),
+(528,708,l),
+(497,740,o),
+(449,763,o),
+(377,763,cs),
+(223,763,o),
+(149,658,o),
+(149,543,cs),
+(149,317,o),
+(466,349,o),
+(466,177,cs),
+(466,102,o),
+(399,12,o),
+(275,12,cs),
+(169,12,o),
+(106,79,o),
+(87,213,c),
+(62,213,l),
+(17,0,l),
+(42,0,l),
+(99,54,l),
+(137,14,o),
+(192,-13,o),
+(268,-13,cs)
+);
+}
+);
+width = 577;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (239,0);
+},
+{
+name = top;
+pos = (413,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(430,-13,o),
+(545,97,o),
+(545,253,cs),
+(545,514,o),
+(221,467,o),
+(221,618,cs),
+(221,677,o),
+(270,728,o),
+(355,728,cs),
+(447,728,o),
+(523,669,o),
+(523,555,c),
+(553,555,l),
+(587,754,l),
+(562,754,l),
+(522,708,l),
+(488,740,o),
+(431,763,o),
+(366,763,cs),
+(217,763,o),
+(124,643,o),
+(124,515,cs),
+(124,277,o),
+(444,318,o),
+(444,161,cs),
+(444,94,o),
+(385,22,o),
+(274,22,cs),
+(169,22,o),
+(106,86,o),
+(82,213,c),
+(52,213,l),
+(15,0,l),
+(50,0,l),
+(100,49,l),
+(141,12,o),
+(199,-13,o),
+(274,-13,cs)
+);
+}
+);
+width = 581;
+}
+);
+unicode = 83;
+},
+{
+glyphname = Sacute;
+kernLeft = S;
+kernRight = S;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (126,0);
+ref = acute.case;
+}
+);
+width = 577;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (140,0);
+ref = acute.case;
+}
+);
+width = 581;
+}
+);
+unicode = 346;
+},
+{
+glyphname = Scaron;
+kernLeft = S;
+kernRight = S;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (86,0);
+ref = caron.case;
+}
+);
+width = 577;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (60,0);
+ref = caron.case;
+}
+);
+width = 581;
+}
+);
+unicode = 352;
+},
+{
+glyphname = Scedilla;
+kernLeft = S;
+kernRight = S;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (171,-8);
+ref = cedilla;
+}
+);
+width = 577;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (209,-9);
+ref = cedilla;
+}
+);
+width = 581;
+}
+);
+unicode = 350;
+},
+{
+glyphname = Scircumflex;
+kernLeft = S;
+kernRight = S;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (89,0);
+ref = circumflex.case;
+}
+);
+width = 577;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (84,0);
+ref = circumflex.case;
+}
+);
+width = 581;
+}
+);
+unicode = 348;
+},
+{
+glyphname = Scommaaccent;
+kernLeft = S;
+kernRight = S;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = S;
+},
+{
+pos = (203,0);
+ref = commaaccentcomb;
+}
+);
+width = 577;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = S;
+},
+{
+pos = (235,0);
+ref = commaaccentcomb;
+}
+);
+width = 581;
+}
+);
+unicode = 536;
+},
+{
+glyphname = Sdotbelow;
+kernLeft = S;
+kernRight = S;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (230,0);
+ref = dotbelow;
+}
+);
+width = 577;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = S;
+},
+{
+alignment = -1;
+pos = (260,0);
+ref = dotbelow;
+}
+);
+width = 581;
+}
+);
+unicode = 7778;
+},
+{
+glyphname = Schwa;
+lastChange = "2016-08-22 13:49:19 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(529,-13,o),
+(731,225,o),
+(731,462,cs),
+(731,619,o),
+(642,763,o),
+(473,763,cs),
+(343,763,o),
+(218,678,o),
+(123,544,c),
+(157,521,l),
+(237,643,o),
+(356,729,o),
+(470,729,cs),
+(560,729,o),
+(600,675,o),
+(600,538,cs),
+(600,323,o),
+(502,20,o),
+(315,20,cs),
+(249,20,o),
+(211,57,o),
+(211,157,cs),
+(211,286,o),
+(275,388,o),
+(466,388,cs),
+(508,388,o),
+(551,383,o),
+(592,371,c),
+(595,408,l),
+(574,413,o),
+(473,426,o),
+(400,426,cs),
+(204,426,o),
+(65,331,o),
+(65,189,cs),
+(65,61,o),
+(177,-13,o),
+(303,-13,cs)
+);
+}
+);
+width = 729;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(533,-11,o),
+(745,223,o),
+(745,453,cs),
+(745,613,o),
+(642,763,o),
+(449,763,cs),
+(301,763,o),
+(179,675,o),
+(101,532,c),
+(142,500,l),
+(235,654,o),
+(327,697,o),
+(437,697,cs),
+(538,697,o),
+(577,661,o),
+(577,527,cs),
+(577,306,o),
+(472,23,o),
+(307,23,cs),
+(236,23,o),
+(203,76,o),
+(203,160,cs),
+(203,282,o),
+(274,380,o),
+(441,380,cs),
+(528,380,o),
+(567,380,o),
+(605,363,c),
+(613,421,l),
+(595,425,o),
+(473,440,o),
+(390,440,cs),
+(156,440,o),
+(34,318,o),
+(34,191,cs),
+(34,69,o),
+(148,-11,o),
+(290,-11,cs)
+);
+}
+);
+width = 749;
+}
+);
+unicode = 399;
+},
+{
+glyphname = T;
+kernLeft = T;
+kernRight = T;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (289,0);
+},
+{
+name = center;
+pos = (376,377);
+},
+{
+name = top;
+pos = (463,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,0,l),
+(521,754,l),
+(404,754,l),
+(240,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,0,l),
+(473,25,l),
+(134,25,l),
+(134,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(118,513,l),
+(177,661,o),
+(266,729,o),
+(344,729,cs),
+(565,729,ls),
+(679,729,o),
+(701,684,o),
+(701,513,c),
+(731,513,l),
+(764,754,l),
+(160,754,l),
+(88,513,l)
+);
+}
+);
+width = 681;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (299,0);
+},
+{
+name = center;
+pos = (386,377);
+},
+{
+name = top;
+pos = (473,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,0,l),
+(545,754,l),
+(394,754,l),
+(230,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(512,0,l),
+(512,31,l),
+(133,31,l),
+(133,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(123,513,l),
+(180,658,o),
+(267,724,o),
+(344,724,cs),
+(565,724,ls),
+(683,724,o),
+(706,680,o),
+(706,513,c),
+(741,513,l),
+(774,754,l),
+(160,754,l),
+(88,513,l)
+);
+}
+);
+width = 701;
+}
+);
+unicode = 84;
+},
+{
+glyphname = Tbar;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(605,416,l),
+(605,451,l),
+(190,451,l),
+(190,416,l)
+);
+},
+{
+ref = T;
+}
+);
+width = 681;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(603,406,l),
+(603,451,l),
+(188,451,l),
+(188,406,l)
+);
+},
+{
+ref = T;
+}
+);
+width = 701;
+}
+);
+unicode = 358;
+},
+{
+glyphname = Tcaron;
+kernLeft = T;
+kernRight = T;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = T;
+},
+{
+alignment = -1;
+pos = (138,0);
+ref = caron.case;
+}
+);
+width = 681;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = T;
+},
+{
+alignment = -1;
+pos = (173,1);
+ref = caron.case;
+}
+);
+width = 701;
+}
+);
+unicode = 356;
+},
+{
+glyphname = Tcedilla;
+kernLeft = T;
+kernRight = T;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = T;
+},
+{
+alignment = -1;
+pos = (212,0);
+ref = cedilla;
+}
+);
+width = 681;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = T;
+},
+{
+alignment = -1;
+pos = (232,0);
+ref = cedilla;
+}
+);
+width = 701;
+}
+);
+unicode = 354;
+},
+{
+glyphname = Tcommaaccent;
+kernLeft = T;
+kernRight = T;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = T;
+},
+{
+pos = (260,0);
+ref = commaaccentcomb;
+}
+);
+width = 681;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = T;
+},
+{
+pos = (274,0);
+ref = commaaccentcomb;
+}
+);
+width = 701;
+}
+);
+unicode = 538;
+},
+{
+glyphname = Tdotbelow;
+kernLeft = T;
+kernRight = T;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = T;
+},
+{
+alignment = -1;
+pos = (260,0);
+ref = dotbelow;
+}
+);
+width = 681;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = T;
+},
+{
+alignment = -1;
+pos = (288,0);
+ref = dotbelow;
+}
+);
+width = 701;
+}
+);
+unicode = 7788;
+},
+{
+glyphname = U;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:07:27 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (314,0);
+},
+{
+name = ogonek;
+pos = (607,10);
+},
+{
+name = top;
+pos = (488,754);
+},
+{
+name = topright;
+pos = (806,701);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,-13,o),
+(603,92,o),
+(633,231,cs),
+(745,754,l),
+(715,754,l),
+(598,205,ls),
+(573,86,o),
+(493,17,o),
+(387,17,cs),
+(294,17,o),
+(237,70,o),
+(237,167,cs),
+(237,192,o),
+(241,227,o),
+(250,266,cs),
+(361,754,l),
+(244,754,l),
+(137,266,ls),
+(130,233,o),
+(126,203,o),
+(126,176,cs),
+(126,51,o),
+(214,-13,o),
+(357,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(448,729,l),
+(448,754,l),
+(125,754,l),
+(125,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(842,729,l),
+(842,754,l),
+(600,754,l),
+(600,729,l)
+);
+}
+);
+width = 732;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (324,0);
+},
+{
+name = ogonek;
+pos = (625,10);
+},
+{
+name = top;
+pos = (498,754);
+},
+{
+name = topright;
+pos = (820,701);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-11,o),
+(610,69,o),
+(644,226,cs),
+(758,754,l),
+(718,754,l),
+(604,226,ls),
+(575,90,o),
+(491,31,o),
+(398,31,cs),
+(315,31,o),
+(260,79,o),
+(260,168,cs),
+(260,185,o),
+(262,206,o),
+(267,226,cs),
+(385,754,l),
+(234,754,l),
+(120,226,ls),
+(116,206,o),
+(114,187,o),
+(114,170,cs),
+(114,64,o),
+(196,-11,o),
+(365,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,724,l),
+(473,754,l),
+(114,754,l),
+(114,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(838,724,l),
+(838,754,l),
+(611,754,l),
+(611,724,l)
+);
+}
+);
+width = 752;
+}
+);
+unicode = 85;
+},
+{
+glyphname = Uacute;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (129,304);
+ref = acutecomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (93,304);
+ref = acutecomb;
+}
+);
+width = 752;
+}
+);
+unicode = 218;
+},
+{
+glyphname = Ubreve;
+kernLeft = U;
+kernRight = U;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (201,0);
+ref = breve.case;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = breve.case;
+}
+);
+width = 752;
+}
+);
+unicode = 364;
+},
+{
+glyphname = Ucircumflex;
+kernLeft = U;
+kernRight = U;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (205,0);
+ref = circumflex.case;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (207,0);
+ref = circumflex.case;
+}
+);
+width = 752;
+}
+);
+unicode = 219;
+},
+{
+glyphname = Udblgrave;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (79,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (148,0);
+ref = dblgravecomb.cap;
+}
+);
+width = 752;
+}
+);
+unicode = 532;
+},
+{
+glyphname = Udieresis;
+kernLeft = U;
+kernRight = U;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (206,0);
+ref = dieresis.case;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (245,0);
+ref = dieresis.case;
+}
+);
+width = 752;
+}
+);
+unicode = 220;
+},
+{
+glyphname = Udotbelow;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (73,0);
+ref = dotbelowcomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (74,0);
+ref = dotbelowcomb;
+}
+);
+width = 752;
+}
+);
+unicode = 7908;
+},
+{
+glyphname = Ugrave;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (140,304);
+ref = gravecomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (182,304);
+ref = gravecomb;
+}
+);
+width = 752;
+}
+);
+unicode = 217;
+},
+{
+glyphname = Uhookabove;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (165,304);
+ref = hookabovecomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (166,304);
+ref = hookabovecomb;
+}
+);
+width = 752;
+}
+);
+unicode = 7910;
+},
+{
+glyphname = Uhorn;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (314,0);
+},
+{
+name = ogonek;
+pos = (607,10);
+},
+{
+name = top;
+pos = (488,754);
+},
+{
+name = topright;
+pos = (806,701);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(540,-13,o),
+(603,92,o),
+(633,231,cs),
+(745,754,l),
+(715,754,l),
+(598,205,ls),
+(573,86,o),
+(493,17,o),
+(387,17,cs),
+(294,17,o),
+(237,70,o),
+(237,167,cs),
+(237,192,o),
+(241,227,o),
+(250,266,cs),
+(361,754,l),
+(244,754,l),
+(137,266,ls),
+(130,233,o),
+(126,203,o),
+(126,176,cs),
+(126,51,o),
+(214,-13,o),
+(357,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(448,729,l),
+(448,754,l),
+(125,754,l),
+(125,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(733,729,l),
+(733,754,l),
+(600,754,l),
+(600,729,l)
+);
+},
+{
+pos = (501,251);
+ref = horncomb;
+}
+);
+width = 732;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (324,0);
+},
+{
+name = ogonek;
+pos = (625,10);
+},
+{
+name = top;
+pos = (498,754);
+},
+{
+name = topright;
+pos = (820,701);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(539,-11,o),
+(610,69,o),
+(644,226,cs),
+(758,754,l),
+(718,754,l),
+(604,226,ls),
+(575,90,o),
+(491,31,o),
+(398,31,cs),
+(315,31,o),
+(260,79,o),
+(260,168,cs),
+(260,185,o),
+(262,206,o),
+(267,226,cs),
+(385,754,l),
+(234,754,l),
+(120,226,ls),
+(116,206,o),
+(114,187,o),
+(114,170,cs),
+(114,64,o),
+(196,-11,o),
+(365,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,724,l),
+(473,754,l),
+(114,754,l),
+(114,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(744,724,l),
+(744,754,l),
+(611,754,l),
+(611,724,l)
+);
+},
+{
+pos = (507,251);
+ref = horncomb;
+}
+);
+width = 752;
+}
+);
+unicode = 431;
+},
+{
+glyphname = Uhornacute;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (129,304);
+ref = acutecomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (93,304);
+ref = acutecomb;
+}
+);
+width = 752;
+}
+);
+unicode = 7912;
+},
+{
+glyphname = Uhorndotbelow;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (73,0);
+ref = dotbelowcomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (74,0);
+ref = dotbelowcomb;
+}
+);
+width = 752;
+}
+);
+unicode = 7920;
+},
+{
+glyphname = Uhorngrave;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (140,304);
+ref = gravecomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (182,304);
+ref = gravecomb;
+}
+);
+width = 752;
+}
+);
+unicode = 7914;
+},
+{
+glyphname = Uhornhookabove;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (165,304);
+ref = hookabovecomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (166,304);
+ref = hookabovecomb;
+}
+);
+width = 752;
+}
+);
+unicode = 7916;
+},
+{
+glyphname = Uhorntilde;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (129,304);
+ref = tildecomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Uhorn;
+},
+{
+pos = (133,304);
+ref = tildecomb;
+}
+);
+width = 752;
+}
+);
+unicode = 7918;
+},
+{
+glyphname = Uhungarumlaut;
+kernLeft = U;
+kernRight = U;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (181,0);
+ref = hungarumlaut.case;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (151,0);
+ref = hungarumlaut.case;
+}
+);
+width = 752;
+}
+);
+unicode = 368;
+},
+{
+glyphname = Uinvertedbreve;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (232,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (228,0);
+ref = breveinvertedcomb.cap;
+}
+);
+width = 752;
+}
+);
+unicode = 534;
+},
+{
+glyphname = Umacron;
+kernLeft = U;
+kernRight = U;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (192,0);
+ref = macron.case;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (219,0);
+ref = macron.case;
+}
+);
+width = 752;
+}
+);
+unicode = 362;
+},
+{
+glyphname = Uogonek;
+kernLeft = U;
+kernRight = U;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (295,-17);
+ref = ogonek;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (291,-7);
+ref = ogonek;
+}
+);
+width = 752;
+}
+);
+unicode = 370;
+},
+{
+glyphname = Uring;
+kernLeft = U;
+kernRight = U;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (262,0);
+ref = ring.case;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = U;
+},
+{
+alignment = -1;
+pos = (299,0);
+ref = ring.case;
+}
+);
+width = 752;
+}
+);
+unicode = 366;
+},
+{
+glyphname = Utilde;
+kernLeft = U;
+kernRight = U;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (129,304);
+ref = tildecomb;
+}
+);
+width = 732;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = U;
+},
+{
+pos = (133,304);
+ref = tildecomb;
+}
+);
+width = 752;
+}
+);
+unicode = 360;
+},
+{
+glyphname = V;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (230,0);
+},
+{
+name = top;
+pos = (404,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(158,-10,l),
+(667,734,l),
+(628,734,l),
+(265,203,l),
+(153,-10,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(156,-10,l),
+(268,207,l),
+(264,207,l),
+(313,744,l),
+(190,744,l),
+(135,-10,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,729,l),
+(380,754,l),
+(111,754,l),
+(111,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(740,729,l),
+(740,754,l),
+(526,754,l),
+(526,729,l)
+);
+}
+);
+width = 564;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (256,0);
+},
+{
+name = top;
+pos = (430,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,-13,l),
+(731,734,l),
+(694,734,l),
+(305,220,l),
+(164,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,-13,l),
+(308,224,l),
+(304,224,l),
+(339,744,l),
+(176,744,l),
+(141,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(416,724,l),
+(416,754,l),
+(97,754,l),
+(97,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(802,724,l),
+(802,754,l),
+(582,754,l),
+(582,724,l)
+);
+}
+);
+width = 616;
+}
+);
+unicode = 86;
+},
+{
+glyphname = W;
+kernLeft = W;
+kernRight = W;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (383,0);
+},
+{
+name = top;
+pos = (557,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-10,l),
+(979,734,l),
+(946,734,l),
+(538,196,l),
+(423,-10,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,-10,l),
+(500,458,l),
+(467,458,l),
+(264,198,l),
+(146,-10,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,-10,l),
+(267,202,l),
+(263,202,l),
+(307,744,l),
+(184,744,l),
+(129,-10,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,-10,l),
+(541,200,l),
+(537,200,l),
+(585,744,l),
+(462,744,l),
+(407,-10,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(796,729,l),
+(796,754,l),
+(105,754,l),
+(105,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(733,738,l),
+(700,738,l),
+(497,478,l),
+(531,467,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(1052,729,l),
+(1052,754,l),
+(838,754,l),
+(838,729,l)
+);
+}
+);
+width = 870;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (409,0);
+},
+{
+name = top;
+pos = (583,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,-13,l),
+(1029,734,l),
+(990,734,l),
+(580,210,l),
+(442,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,-13,l),
+(478,388,l),
+(465,424,l),
+(281,206,l),
+(140,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(148,-13,l),
+(284,210,l),
+(280,210,l),
+(315,744,l),
+(152,744,l),
+(117,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,-13,l),
+(580,210,l),
+(576,210,l),
+(611,744,l),
+(448,744,l),
+(413,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(826,724,l),
+(826,754,l),
+(68,754,l),
+(68,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(775,734,l),
+(738,734,l),
+(560,501,l),
+(571,464,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(1083,724,l),
+(1083,754,l),
+(863,754,l),
+(863,724,l)
+);
+}
+);
+width = 922;
+}
+);
+unicode = 87;
+},
+{
+glyphname = Wacute;
+kernLeft = W;
+kernRight = W;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = W;
+},
+{
+alignment = -1;
+pos = (344,0);
+ref = acute.case;
+}
+);
+width = 870;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = W;
+},
+{
+alignment = -1;
+pos = (348,0);
+ref = acute.case;
+}
+);
+width = 922;
+}
+);
+unicode = 7810;
+},
+{
+glyphname = Wcircumflex;
+kernLeft = W;
+kernRight = W;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = W;
+},
+{
+alignment = -1;
+pos = (305,0);
+ref = circumflex.case;
+}
+);
+width = 870;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = W;
+},
+{
+alignment = -1;
+pos = (322,0);
+ref = circumflex.case;
+}
+);
+width = 922;
+}
+);
+unicode = 372;
+},
+{
+glyphname = Wdieresis;
+kernLeft = W;
+kernRight = W;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = W;
+},
+{
+alignment = -1;
+pos = (319,0);
+ref = dieresis.case;
+}
+);
+width = 870;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = W;
+},
+{
+alignment = -1;
+pos = (353,0);
+ref = dieresis.case;
+}
+);
+width = 922;
+}
+);
+unicode = 7812;
+},
+{
+glyphname = Wgrave;
+kernLeft = W;
+kernRight = W;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = W;
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = grave.case;
+}
+);
+width = 870;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = W;
+},
+{
+alignment = -1;
+pos = (308,0);
+ref = grave.case;
+}
+);
+width = 922;
+}
+);
+unicode = 7808;
+},
+{
+glyphname = X;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (250,0);
+},
+{
+name = top;
+pos = (424,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(274,754,l),
+(149,754,l),
+(435,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,0,l),
+(202,25,l),
+(-55,25,l),
+(-55,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(73,20,l),
+(309,323,l),
+(313,323,l),
+(362,389,l),
+(327,389,l),
+(38,20,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(650,0,l),
+(650,25,l),
+(321,25,l),
+(321,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,729,l),
+(381,754,l),
+(62,754,l),
+(62,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(369,395,l),
+(641,734,l),
+(606,734,l),
+(387,462,l),
+(383,462,l),
+(334,395,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(732,729,l),
+(732,754,l),
+(487,754,l),
+(487,729,l)
+);
+}
+);
+width = 603;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (266,0);
+},
+{
+name = top;
+pos = (440,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(577,0,l),
+(295,754,l),
+(130,754,l),
+(416,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,0,l),
+(203,30,l),
+(-54,30,l),
+(-54,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(74,20,l),
+(297,306,l),
+(301,306,l),
+(363,389,l),
+(320,389,l),
+(34,20,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(651,0,l),
+(651,30,l),
+(322,30,l),
+(322,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,724,l),
+(382,754,l),
+(63,754,l),
+(63,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,408,l),
+(642,734,l),
+(607,734,l),
+(401,479,l),
+(397,479,l),
+(345,408,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(733,724,l),
+(733,754,l),
+(488,754,l),
+(488,724,l)
+);
+}
+);
+width = 635;
+}
+);
+unicode = 88;
+},
+{
+glyphname = Y;
+kernLeft = Y;
+kernRight = Y;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (240,0);
+},
+{
+name = top;
+pos = (414,754);
+},
+{
+name = topleft;
+pos = (142,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(393,365,l),
+(249,754,l),
+(124,754,l),
+(284,334,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(372,317,l),
+(664,734,l),
+(629,734,l),
+(388,390,l),
+(384,390,l),
+(337,317,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(317,0,l),
+(401,376,l),
+(284,376,l),
+(204,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(447,0,l),
+(447,25,l),
+(95,25,l),
+(95,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(376,729,l),
+(376,754,l),
+(42,754,l),
+(42,729,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(755,729,l),
+(755,754,l),
+(510,754,l),
+(510,729,l)
+);
+}
+);
+width = 583;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (272,0);
+},
+{
+name = top;
+pos = (446,754);
+},
+{
+name = topleft;
+pos = (142,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,348,l),
+(294,754,l),
+(139,754,l),
+(299,294,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(430,300,l),
+(701,734,l),
+(666,734,l),
+(439,374,l),
+(435,374,l),
+(384,300,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(366,0,l),
+(445,347,l),
+(294,347,l),
+(219,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(491,0,l),
+(491,31,l),
+(112,31,l),
+(112,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(421,724,l),
+(421,754,l),
+(67,754,l),
+(67,724,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(772,724,l),
+(772,754,l),
+(547,754,l),
+(547,724,l)
+);
+}
+);
+width = 647;
+}
+);
+unicode = 89;
+},
+{
+glyphname = Yacute;
+kernLeft = Y;
+kernRight = Y;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (55,304);
+ref = acutecomb;
+}
+);
+width = 583;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (41,304);
+ref = acutecomb;
+}
+);
+width = 647;
+}
+);
+unicode = 221;
+},
+{
+glyphname = Ycircumflex;
+kernLeft = Y;
+kernRight = Y;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = Y;
+},
+{
+alignment = -1;
+pos = (124,0);
+ref = circumflex.case;
+}
+);
+width = 583;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = Y;
+},
+{
+alignment = -1;
+pos = (171,0);
+ref = circumflex.case;
+}
+);
+width = 647;
+}
+);
+unicode = 374;
+},
+{
+glyphname = Ydieresis;
+kernLeft = Y;
+kernRight = Y;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = Y;
+},
+{
+alignment = -1;
+pos = (127,0);
+ref = dieresis.case;
+}
+);
+width = 583;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = Y;
+},
+{
+alignment = -1;
+pos = (196,0);
+ref = dieresis.case;
+}
+);
+width = 647;
+}
+);
+unicode = 376;
+},
+{
+glyphname = Ydotbelow;
+kernLeft = Y;
+kernRight = Y;
+lastChange = "2022-03-23 16:24:45 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (-1,0);
+ref = dotbelowcomb;
+}
+);
+width = 583;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (22,0);
+ref = dotbelowcomb;
+}
+);
+width = 647;
+}
+);
+unicode = 7924;
+},
+{
+glyphname = Ygrave;
+kernLeft = Y;
+kernRight = Y;
+lastChange = "2016-08-22 14:17:47 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (66,304);
+ref = gravecomb;
+}
+);
+width = 583;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (130,304);
+ref = gravecomb;
+}
+);
+width = 647;
+}
+);
+unicode = 7922;
+},
+{
+glyphname = Yhookabove;
+kernLeft = Y;
+kernRight = Y;
+lastChange = "2016-08-22 14:17:47 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (91,304);
+ref = hookabovecomb;
+}
+);
+width = 583;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (114,304);
+ref = hookabovecomb;
+}
+);
+width = 647;
+}
+);
+unicode = 7926;
+},
+{
+glyphname = Ytilde;
+kernLeft = Y;
+kernRight = Y;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (55,304);
+ref = tildecomb;
+}
+);
+width = 583;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = Y;
+},
+{
+pos = (81,304);
+ref = tildecomb;
+}
+);
+width = 647;
+}
+);
+unicode = 7928;
+},
+{
+glyphname = Z;
+kernLeft = Z;
+kernRight = Z;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (273,0);
+},
+{
+name = top;
+pos = (447,754);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,25,l),
+(149,29,l),
+(702,729,l),
+(556,729,l),
+(556,725,l),
+(9,25,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(550,0,l),
+(610,232,l),
+(580,232,l),
+(504,64,o),
+(442,25,o),
+(353,25,cs),
+(9,25,l),
+(9,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(180,542,l),
+(256,694,o),
+(318,729,o),
+(407,729,cs),
+(702,729,l),
+(702,754,l),
+(210,754,l),
+(150,542,l)
+);
+}
+);
+width = 649;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (283,0);
+},
+{
+name = top;
+pos = (457,754);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,30,l),
+(190,35,l),
+(720,724,l),
+(543,724,l),
+(543,720,l),
+(-1,30,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(556,0,l),
+(616,232,l),
+(576,232,l),
+(500,68,o),
+(438,30,o),
+(349,30,cs),
+(-1,30,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(181,533,l),
+(235,664,o),
+(318,724,o),
+(392,724,cs),
+(720,724,l),
+(720,754,l),
+(208,754,l),
+(146,533,l)
+);
+}
+);
+width = 669;
+}
+);
+unicode = 90;
+},
+{
+glyphname = Zacute;
+kernLeft = Z;
+kernRight = Z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = Z;
+},
+{
+alignment = -1;
+pos = (198,0);
+ref = acute.case;
+}
+);
+width = 649;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = Z;
+},
+{
+alignment = -1;
+pos = (219,0);
+ref = acute.case;
+}
+);
+width = 669;
+}
+);
+unicode = 377;
+},
+{
+glyphname = Zcaron;
+kernLeft = Z;
+kernRight = Z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = Z;
+},
+{
+alignment = -1;
+pos = (155,0);
+ref = caron.case;
+}
+);
+width = 649;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = Z;
+},
+{
+alignment = -1;
+pos = (174,0);
+ref = caron.case;
+}
+);
+width = 669;
+}
+);
+unicode = 381;
+},
+{
+glyphname = Zdotaccent;
+kernLeft = Z;
+kernRight = Z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = Z;
+},
+{
+alignment = -1;
+pos = (264,0);
+ref = dotaccent.case;
+}
+);
+width = 649;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = Z;
+},
+{
+alignment = -1;
+pos = (237,0);
+ref = dotaccent.case;
+}
+);
+width = 669;
+}
+);
+unicode = 379;
+},
+{
+glyphname = Zdotbelow;
+kernLeft = Z;
+kernRight = Z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = Z;
+},
+{
+alignment = -1;
+pos = (244,0);
+ref = dotbelow;
+}
+);
+width = 649;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = Z;
+},
+{
+alignment = -1;
+pos = (280,0);
+ref = dotbelow;
+}
+);
+width = 669;
+}
+);
+unicode = 7826;
+},
+{
+glyphname = a;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (225,0);
+},
+{
+name = ogonek;
+pos = (447,10);
+},
+{
+name = top;
+pos = (329,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,-13,o),
+(304,17,o),
+(334,70,c),
+(340,70,l),
+(352,170,l),
+(310,52,o),
+(258,19,o),
+(217,19,cs),
+(176,19,o),
+(154,53,o),
+(154,117,cs),
+(154,218,o),
+(210,433,o),
+(310,433,cs),
+(354,433,o),
+(386,392,o),
+(386,335,cs),
+(386,321,o),
+(384,313,o),
+(383,298,c),
+(404,389,l),
+(398,389,l),
+(384,430,o),
+(359,462,o),
+(298,462,cs),
+(172,462,o),
+(43,328,o),
+(43,173,cs),
+(43,59,o),
+(112,-13,o),
+(197,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(475,-13,o),
+(526,68,o),
+(556,142,c),
+(536,151,l),
+(502,71,o),
+(466,30,o),
+(443,30,cs),
+(432,30,o),
+(426,39,o),
+(426,59,cs),
+(426,77,o),
+(431,106,o),
+(441,147,cs),
+(515,450,l),
+(418,450,l),
+(348,154,ls),
+(341,125,o),
+(338,101,o),
+(338,81,cs),
+(338,8,o),
+(377,-13,o),
+(410,-13,cs)
+);
+}
+);
+width = 554;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (241,0);
+},
+{
+name = ogonek;
+pos = (475,10);
+},
+{
+name = top;
+pos = (345,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(257,-11,o),
+(305,32,o),
+(329,70,c),
+(336,70,l),
+(368,208,l),
+(336,76,o),
+(258,30,o),
+(213,30,cs),
+(183,30,o),
+(171,48,o),
+(171,107,cs),
+(171,256,o),
+(244,423,o),
+(326,423,cs),
+(358,423,o),
+(392,385,o),
+(392,333,cs),
+(392,324,o),
+(390,312,o),
+(389,299,c),
+(412,390,l),
+(405,390,l),
+(384,439,o),
+(354,462,o),
+(305,462,cs),
+(174,462,o),
+(29,320,o),
+(29,166,cs),
+(29,54,o),
+(107,-11,o),
+(192,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(514,-11,o),
+(577,69,o),
+(603,152,c),
+(578,161,l),
+(541,69,o),
+(500,41,o),
+(480,41,cs),
+(473,41,o),
+(468,45,o),
+(468,54,cs),
+(468,58,o),
+(469,70,o),
+(473,87,cs),
+(560,450,l),
+(426,450,l),
+(352,153,ls),
+(339,100,o),
+(336,86,o),
+(336,70,cs),
+(336,15,o),
+(371,-11,o),
+(423,-11,cs)
+);
+}
+);
+width = 586;
+}
+);
+unicode = 97;
+},
+{
+glyphname = aacute;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-30,0);
+ref = acutecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-60,0);
+ref = acutecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 225;
+},
+{
+glyphname = abreve;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-45,0);
+ref = brevecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-36,0);
+ref = brevecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 259;
+},
+{
+glyphname = abreveacute;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-30,0);
+ref = brevecomb_acutecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-12,0);
+ref = brevecomb_acutecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7855;
+},
+{
+glyphname = abrevedotbelow;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-16,0);
+ref = dotbelowcomb;
+},
+{
+pos = (-45,0);
+ref = brevecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-9,0);
+ref = dotbelowcomb;
+},
+{
+pos = (-36,0);
+ref = brevecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7863;
+},
+{
+glyphname = abrevegrave;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-44,0);
+ref = brevecomb_gravecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-25,0);
+ref = brevecomb_gravecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7857;
+},
+{
+glyphname = abrevehookabove;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-48,0);
+ref = brevecomb_hookabovecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-5,0);
+ref = brevecomb_hookabovecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7859;
+},
+{
+glyphname = abrevetilde;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-45,0);
+ref = brevecomb_tildecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-35,0);
+ref = brevecomb_tildecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7861;
+},
+{
+glyphname = acircumflex;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-43,0);
+ref = circumflexcomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+ref = circumflexcomb;
+}
+);
+width = 586;
+}
+);
+unicode = 226;
+},
+{
+glyphname = acircumflexacute;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-39,0);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-22,0);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7845;
+},
+{
+glyphname = acircumflexdotbelow;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-16,0);
+ref = dotbelowcomb;
+},
+{
+pos = (-43,0);
+ref = circumflexcomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-9,0);
+ref = dotbelowcomb;
+},
+{
+ref = circumflexcomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7853;
+},
+{
+glyphname = acircumflexgrave;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-35,0);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-18,0);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7847;
+},
+{
+glyphname = acircumflexhookabove;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-41,0);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-21,0);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7849;
+},
+{
+glyphname = acircumflextilde;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-39,0);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-24,0);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7851;
+},
+{
+glyphname = adblgrave;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (43,0);
+ref = dblgravecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (60,0);
+ref = dblgravecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 513;
+},
+{
+glyphname = adieresis;
+kernLeft = a;
+kernRight = a;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = a;
+},
+{
+alignment = -1;
+pos = (120,0);
+ref = dieresis;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = a;
+},
+{
+alignment = -1;
+pos = (121,0);
+ref = dieresis;
+}
+);
+width = 586;
+}
+);
+unicode = 228;
+},
+{
+glyphname = adotbelow;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-16,0);
+ref = dotbelowcomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-9,0);
+ref = dotbelowcomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7841;
+},
+{
+glyphname = agrave;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-19,0);
+ref = gravecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (29,0);
+ref = gravecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 224;
+},
+{
+glyphname = ahookabove;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (6,0);
+ref = hookabovecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (13,0);
+ref = hookabovecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 7843;
+},
+{
+glyphname = ainvertedbreve;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (107,0);
+ref = breveinvertedcomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (116,0);
+ref = breveinvertedcomb;
+}
+);
+width = 586;
+}
+);
+unicode = 515;
+},
+{
+glyphname = amacron;
+kernLeft = a;
+kernRight = a;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = a;
+},
+{
+alignment = -1;
+pos = (105,0);
+ref = macron;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = a;
+},
+{
+alignment = -1;
+pos = (116,0);
+ref = macron;
+}
+);
+width = 586;
+}
+);
+unicode = 257;
+},
+{
+glyphname = aogonek;
+kernLeft = a;
+kernRight = a;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+alignment = -1;
+pos = (347,0);
+ref = ogonek;
+}
+);
+width = 769;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = a;
+},
+{
+alignment = -1;
+pos = (348,0);
+ref = ogonek;
+}
+);
+width = 586;
+}
+);
+unicode = 261;
+},
+{
+glyphname = aring;
+kernLeft = a;
+kernRight = a;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = a;
+},
+{
+alignment = -1;
+pos = (159,0);
+ref = ring;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = a;
+},
+{
+alignment = -1;
+pos = (188,0);
+ref = ring;
+}
+);
+width = 586;
+}
+);
+unicode = 229;
+},
+{
+glyphname = aringacute;
+kernLeft = a;
+kernRight = a;
+lastChange = "2022-03-23 16:33:43 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = a;
+},
+{
+alignment = -1;
+pos = (163,-77);
+ref = ring;
+},
+{
+alignment = -1;
+pos = (290,161);
+ref = acute;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = a;
+},
+{
+alignment = -1;
+pos = (167,-75);
+ref = ring;
+},
+{
+alignment = -1;
+pos = (308,165);
+ref = acute;
+}
+);
+width = 586;
+}
+);
+unicode = 507;
+},
+{
+glyphname = atilde;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-30,0);
+ref = tildecomb;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = a;
+},
+{
+pos = (-20,0);
+ref = tildecomb;
+}
+);
+width = 586;
+}
+);
+unicode = 227;
+},
+{
+glyphname = ae;
+kernLeft = a;
+kernRight = a;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(632,-13,o),
+(702,31,o),
+(751,119,c),
+(731,133,l),
+(679,47,o),
+(617,17,o),
+(553,17,cs),
+(488,17,o),
+(461,48,o),
+(461,139,cs),
+(461,263,o),
+(512,432,o),
+(615,432,cs),
+(652,432,o),
+(677,410,o),
+(677,355,cs),
+(677,284,o),
+(634,219,o),
+(512,219,cs),
+(485,219,o),
+(462,222,o),
+(439,229,c),
+(434,204,l),
+(447,201,o),
+(507,193,o),
+(552,193,cs),
+(676,193,o),
+(765,254,o),
+(765,341,cs),
+(765,413,o),
+(705,462,o),
+(625,462,cs),
+(487,462,o),
+(362,314,o),
+(362,179,cs),
+(362,84,o),
+(424,-13,o),
+(548,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,-13,o),
+(329,31,o),
+(368,110,c),
+(374,110,l),
+(374,143,l),
+(350,157,l),
+(329,63,o),
+(270,19,o),
+(217,19,cs),
+(176,19,o),
+(154,46,o),
+(154,108,cs),
+(154,209,o),
+(211,433,o),
+(313,433,cs),
+(356,433,o),
+(387,393,o),
+(387,335,cs),
+(387,325,o),
+(387,313,o),
+(385,300,c),
+(407,391,l),
+(401,391,l),
+(387,431,o),
+(360,462,o),
+(301,462,cs),
+(175,462,o),
+(43,320,o),
+(43,164,cs),
+(43,53,o),
+(111,-13,o),
+(197,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(441,147,l),
+(517,450,l),
+(420,450,l),
+(337,102,l)
+);
+}
+);
+width = 777;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(670,-11,o),
+(755,42,o),
+(808,129,c),
+(783,148,l),
+(721,57,o),
+(649,29,o),
+(584,29,cs),
+(539,29,o),
+(511,55,o),
+(511,95,cs),
+(511,196,o),
+(565,432,o),
+(652,432,cs),
+(693,432,o),
+(713,402,o),
+(713,359,cs),
+(713,291,o),
+(670,232,o),
+(574,232,cs),
+(522,232,o),
+(499,232,o),
+(476,242,c),
+(471,207,l),
+(482,204,o),
+(555,196,o),
+(605,196,cs),
+(751,196,o),
+(826,267,o),
+(826,344,cs),
+(826,413,o),
+(756,462,o),
+(665,462,cs),
+(530,462,o),
+(368,319,o),
+(368,176,cs),
+(368,79,o),
+(437,-11,o),
+(569,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,-11,o),
+(343,47,o),
+(377,100,c),
+(384,100,l),
+(376,154,l),
+(368,208,l),
+(336,76,o),
+(258,30,o),
+(213,30,cs),
+(183,30,o),
+(171,48,o),
+(171,107,cs),
+(171,256,o),
+(244,423,o),
+(326,423,cs),
+(358,423,o),
+(392,385,o),
+(392,333,cs),
+(392,324,o),
+(390,312,o),
+(389,299,c),
+(412,390,l),
+(405,390,l),
+(384,439,o),
+(354,462,o),
+(305,462,cs),
+(174,462,o),
+(29,320,o),
+(29,166,cs),
+(29,54,o),
+(107,-11,o),
+(192,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,97,l),
+(560,450,l),
+(426,450,l),
+(352,153,l)
+);
+}
+);
+width = 847;
+}
+);
+unicode = 230;
+},
+{
+glyphname = aeacute;
+kernLeft = a;
+kernRight = a;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = ae;
+},
+{
+alignment = -1;
+pos = (324,0);
+ref = acute;
+}
+);
+width = 777;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = ae;
+},
+{
+alignment = -1;
+pos = (355,0);
+ref = acute;
+}
+);
+width = 847;
+}
+);
+unicode = 509;
+},
+{
+glyphname = b;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (206,0);
+},
+{
+name = top;
+pos = (310,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,-13,o),
+(487,127,o),
+(487,284,cs),
+(487,396,o),
+(417,462,o),
+(337,462,cs),
+(292,462,o),
+(250,441,o),
+(225,416,c),
+(218,416,l),
+(197,328,l),
+(233,397,o),
+(276,430,o),
+(323,430,cs),
+(365,430,o),
+(380,403,o),
+(380,335,cs),
+(380,175,o),
+(297,16,o),
+(207,16,cs),
+(170,16,o),
+(147,42,o),
+(147,90,cs),
+(147,108,o),
+(150,124,o),
+(153,138,cs),
+(301,754,l),
+(194,754,l),
+(64,204,ls),
+(54,163,o),
+(52,147,o),
+(52,131,cs),
+(52,49,o),
+(102,-13,o),
+(201,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,729,l),
+(289,754,l),
+(94,754,l),
+(94,729,l)
+);
+}
+);
+width = 516;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (218,0);
+},
+{
+name = top;
+pos = (322,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-13,o),
+(501,129,o),
+(501,284,cs),
+(501,407,o),
+(414,462,o),
+(342,462,cs),
+(289,462,o),
+(243,431,o),
+(218,389,c),
+(211,389,l),
+(187,291,l),
+(222,380,o),
+(276,425,o),
+(320,425,cs),
+(348,425,o),
+(356,406,o),
+(356,351,cs),
+(356,193,o),
+(291,26,o),
+(206,26,cs),
+(176,26,o),
+(153,46,o),
+(153,93,cs),
+(153,110,o),
+(156,134,o),
+(159,148,cs),
+(298,754,l),
+(171,754,l),
+(40,204,ls),
+(33,173,o),
+(32,146,o),
+(32,135,cs),
+(32,48,o),
+(95,-13,o),
+(200,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(286,724,l),
+(286,754,l),
+(71,754,l),
+(71,724,l)
+);
+}
+);
+width = 540;
+}
+);
+unicode = 98;
+},
+{
+glyphname = c;
+kernLeft = c;
+kernRight = c;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (183,0);
+},
+{
+name = top;
+pos = (287,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,-13,o),
+(379,34,o),
+(424,119,c),
+(404,133,l),
+(355,47,o),
+(296,17,o),
+(240,17,cs),
+(173,17,o),
+(149,60,o),
+(149,134,cs),
+(149,240,o),
+(199,432,o),
+(326,432,cs),
+(348,432,o),
+(377,426,o),
+(377,412,cs),
+(377,398,o),
+(347,395,o),
+(347,359,cs),
+(347,327,o),
+(371,311,o),
+(402,311,cs),
+(436,311,o),
+(460,332,o),
+(460,369,cs),
+(460,425,o),
+(408,462,o),
+(328,462,cs),
+(175,462,o),
+(44,329,o),
+(44,191,cs),
+(44,89,o),
+(115,-13,o),
+(232,-13,cs)
+);
+}
+);
+width = 470;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (188,0);
+},
+{
+name = top;
+pos = (292,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,-11,o),
+(409,42,o),
+(462,129,c),
+(437,148,l),
+(375,57,o),
+(303,29,o),
+(238,29,cs),
+(182,29,o),
+(158,50,o),
+(167,105,cs),
+(212,380,o),
+(257,432,o),
+(312,432,cs),
+(331,432,o),
+(346,426,o),
+(346,407,cs),
+(346,388,o),
+(330,366,o),
+(330,343,cs),
+(330,314,o),
+(354,287,o),
+(399,287,cs),
+(452,287,o),
+(474,323,o),
+(474,357,cs),
+(474,414,o),
+(409,462,o),
+(318,462,cs),
+(162,462,o),
+(22,318,o),
+(22,177,cs),
+(22,78,o),
+(91,-11,o),
+(223,-11,cs)
+);
+}
+);
+width = 479;
+}
+);
+unicode = 99;
+},
+{
+glyphname = cacute;
+kernLeft = c;
+kernRight = c;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = acute;
+}
+);
+width = 470;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (156,0);
+ref = acute;
+}
+);
+width = 479;
+}
+);
+unicode = 263;
+},
+{
+glyphname = ccaron;
+kernLeft = c;
+kernRight = c;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (89,0);
+ref = caron;
+}
+);
+width = 470;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (64,0);
+ref = caron;
+}
+);
+width = 479;
+}
+);
+unicode = 269;
+},
+{
+glyphname = ccedilla;
+kernLeft = c;
+kernRight = c;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (130,0);
+ref = cedilla;
+}
+);
+width = 470;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (144,0);
+ref = cedilla;
+}
+);
+width = 479;
+}
+);
+unicode = 231;
+},
+{
+glyphname = ccircumflex;
+kernLeft = c;
+kernRight = c;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (88,0);
+ref = circumflex;
+}
+);
+width = 470;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (67,0);
+ref = circumflex;
+}
+);
+width = 479;
+}
+);
+unicode = 265;
+},
+{
+glyphname = cdotaccent;
+kernLeft = c;
+kernRight = c;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (190,0);
+ref = dotaccent;
+}
+);
+width = 470;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = c;
+},
+{
+alignment = -1;
+pos = (165,0);
+ref = dotaccent;
+}
+);
+width = 479;
+}
+);
+unicode = 267;
+},
+{
+glyphname = d;
+kernLeft = d;
+kernRight = d;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (228,0);
+},
+{
+name = center;
+pos = (280,225);
+},
+{
+name = top;
+pos = (332,450);
+},
+{
+name = topright;
+pos = (592,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,-13,o),
+(549,68,o),
+(593,157,c),
+(573,166,l),
+(525,73,o),
+(488,38,o),
+(455,38,cs),
+(440,38,o),
+(432,45,o),
+(432,63,cs),
+(432,69,o),
+(433,80,o),
+(437,97,cs),
+(599,754,l),
+(492,754,l),
+(349,153,ls),
+(341,121,o),
+(338,94,o),
+(338,74,cs),
+(338,11,o),
+(368,-13,o),
+(414,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,-13,o),
+(308,23,o),
+(334,70,c),
+(341,70,l),
+(353,170,l),
+(308,40,o),
+(254,19,o),
+(217,19,cs),
+(172,19,o),
+(146,48,o),
+(146,120,cs),
+(146,227,o),
+(203,433,o),
+(304,433,cs),
+(351,433,o),
+(387,389,o),
+(387,333,cs),
+(387,323,o),
+(386,311,o),
+(384,298,c),
+(407,389,l),
+(400,389,l),
+(383,431,o),
+(353,462,o),
+(295,462,cs),
+(173,462,o),
+(32,324,o),
+(32,169,cs),
+(32,54,o),
+(109,-13,o),
+(198,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(587,729,l),
+(587,754,l),
+(392,754,l),
+(392,729,l)
+);
+}
+);
+width = 560;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (253,0);
+},
+{
+name = center;
+pos = (305,225);
+},
+{
+name = top;
+pos = (357,450);
+},
+{
+name = topright;
+pos = (641,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(531,-11,o),
+(594,69,o),
+(620,152,c),
+(595,161,l),
+(558,69,o),
+(517,41,o),
+(497,41,cs),
+(490,41,o),
+(485,45,o),
+(485,54,cs),
+(485,58,o),
+(486,70,o),
+(490,87,cs),
+(648,754,l),
+(514,754,l),
+(369,153,ls),
+(356,100,o),
+(353,86,o),
+(353,70,cs),
+(353,15,o),
+(388,-11,o),
+(440,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,-11,o),
+(320,32,o),
+(346,70,c),
+(353,70,l),
+(385,208,l),
+(351,76,o),
+(267,30,o),
+(220,30,cs),
+(190,30,o),
+(178,48,o),
+(178,107,cs),
+(178,250,o),
+(251,423,o),
+(332,423,cs),
+(370,423,o),
+(409,385,o),
+(409,334,cs),
+(409,322,o),
+(407,313,o),
+(406,298,c),
+(429,389,l),
+(422,389,l),
+(399,439,o),
+(365,462,o),
+(312,462,cs),
+(181,462,o),
+(36,324,o),
+(36,168,cs),
+(36,53,o),
+(114,-11,o),
+(199,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(591,724,l),
+(591,754,l),
+(396,754,l),
+(396,724,l)
+);
+}
+);
+width = 609;
+}
+);
+unicode = 100;
+},
+{
+glyphname = eth;
+lastChange = "2016-08-22 13:49:52 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,-13,o),
+(531,198,o),
+(531,390,cs),
+(531,585,o),
+(415,718,o),
+(257,752,c),
+(242,725,l),
+(369,693,o),
+(421,623,o),
+(421,515,cs),
+(421,489,o),
+(418,458,o),
+(411,426,c),
+(407,425,l),
+(382,449,o),
+(341,464,o),
+(295,464,cs),
+(156,464,o),
+(31,329,o),
+(31,186,cs),
+(31,69,o),
+(114,-13,o),
+(231,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,14,o),
+(152,31,o),
+(152,125,cs),
+(152,254,o),
+(212,434,o),
+(317,434,cs),
+(352,434,o),
+(385,414,o),
+(403,384,c),
+(400,321,o),
+(391,268,o),
+(381,221,cs),
+(349,72,o),
+(314,14,o),
+(230,14,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(593,666,l),
+(584,695,l),
+(257,590,l),
+(267,561,l)
+);
+}
+);
+width = 547;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(447,-11,o),
+(592,191,o),
+(592,393,cs),
+(592,593,o),
+(459,747,o),
+(279,754,c),
+(263,725,l),
+(373,708,o),
+(438,617,o),
+(438,481,cs),
+(438,458,o),
+(436,452,o),
+(435,432,c),
+(431,431,l),
+(408,446,o),
+(370,455,o),
+(328,455,cs),
+(172,455,o),
+(22,328,o),
+(22,179,cs),
+(22,60,o),
+(117,-11,o),
+(241,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,24,o),
+(180,60,o),
+(180,127,cs),
+(180,244,o),
+(249,415,o),
+(352,415,cs),
+(392,415,o),
+(420,390,o),
+(429,364,c),
+(429,308,o),
+(419,264,o),
+(409,223,cs),
+(371,73,o),
+(332,24,o),
+(263,24,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(627,682,l),
+(616,725,l),
+(253,600,l),
+(266,557,l)
+);
+}
+);
+width = 583;
+}
+);
+unicode = 240;
+},
+{
+glyphname = dcaron;
+kernLeft = d;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = d;
+},
+{
+alignment = -1;
+pos = (479,38);
+ref = quoteright;
+}
+);
+width = 651;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = d;
+},
+{
+alignment = -1;
+pos = (522,3);
+ref = quoteright;
+}
+);
+width = 719;
+}
+);
+unicode = 271;
+},
+{
+glyphname = dcroat;
+kernLeft = d;
+lastChange = "2016-08-22 14:14:32 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = d;
+},
+{
+alignment = -1;
+pos = (343,310);
+ref = strokeshortcomb;
+}
+);
+width = 560;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = d;
+},
+{
+alignment = -1;
+pos = (186,365);
+ref = strokeshortcomb;
+}
+);
+width = 609;
+}
+);
+unicode = 273;
+},
+{
+glyphname = ddotbelow;
+kernLeft = d;
+kernRight = d;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = d;
+},
+{
+alignment = -1;
+pos = (189,0);
+ref = dotbelow;
+}
+);
+width = 560;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = d;
+},
+{
+alignment = -1;
+pos = (277,0);
+ref = dotbelow;
+}
+);
+width = 609;
+}
+);
+unicode = 7693;
+},
+{
+glyphname = dz;
+kernLeft = d;
+kernRight = z;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = d;
+},
+{
+pos = (560,0);
+ref = z;
+}
+);
+width = 1034;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = d;
+},
+{
+pos = (609,0);
+ref = z;
+}
+);
+width = 1103;
+}
+);
+unicode = 499;
+},
+{
+glyphname = dzcaron;
+kernLeft = d;
+kernRight = z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = d;
+},
+{
+alignment = -1;
+pos = (560,0);
+ref = z;
+},
+{
+alignment = -1;
+pos = (627,0);
+ref = caron;
+}
+);
+width = 1034;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = d;
+},
+{
+alignment = -1;
+pos = (609,0);
+ref = z;
+},
+{
+alignment = -1;
+pos = (644,0);
+ref = caron;
+}
+);
+width = 1103;
+}
+);
+unicode = 454;
+},
+{
+glyphname = e;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (181,0);
+},
+{
+name = ogonek;
+pos = (367,10);
+},
+{
+name = top;
+pos = (285,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,-13,o),
+(400,42,o),
+(443,119,c),
+(423,133,l),
+(370,45,o),
+(305,17,o),
+(250,17,cs),
+(182,17,o),
+(153,59,o),
+(153,148,cs),
+(153,265,o),
+(204,432,o),
+(304,432,cs),
+(341,432,o),
+(366,410,o),
+(366,357,cs),
+(366,289,o),
+(323,229,o),
+(204,229,cs),
+(177,229,o),
+(154,229,o),
+(131,239,c),
+(126,214,l),
+(139,211,o),
+(199,203,o),
+(245,203,cs),
+(366,203,o),
+(454,259,o),
+(454,344,cs),
+(454,413,o),
+(395,462,o),
+(311,462,cs),
+(171,462,o),
+(33,325,o),
+(33,190,cs),
+(33,86,o),
+(115,-13,o),
+(240,-13,cs)
+);
+}
+);
+width = 466;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (200,0);
+},
+{
+name = ogonek;
+pos = (402,10);
+},
+{
+name = top;
+pos = (304,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(329,-11,o),
+(414,42,o),
+(467,129,c),
+(442,148,l),
+(380,57,o),
+(308,29,o),
+(243,29,cs),
+(187,29,o),
+(163,50,o),
+(172,105,cs),
+(213,383,o),
+(268,432,o),
+(313,432,cs),
+(350,432,o),
+(370,397,o),
+(370,352,cs),
+(370,285,o),
+(327,232,o),
+(233,232,cs),
+(181,232,o),
+(158,232,o),
+(135,242,c),
+(130,207,l),
+(141,204,o),
+(214,196,o),
+(264,196,cs),
+(408,196,o),
+(483,261,o),
+(483,337,cs),
+(483,409,o),
+(414,462,o),
+(322,462,cs),
+(170,462,o),
+(27,319,o),
+(27,177,cs),
+(27,79,o),
+(96,-11,o),
+(228,-11,cs)
+);
+}
+);
+width = 504;
+}
+);
+unicode = 101;
+},
+{
+glyphname = eacute;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-74,0);
+ref = acutecomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-101,0);
+ref = acutecomb;
+}
+);
+width = 504;
+}
+);
+unicode = 233;
+},
+{
+glyphname = ebreve;
+kernLeft = e;
+kernRight = e;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (91,0);
+ref = breve;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (72,0);
+ref = breve;
+}
+);
+width = 504;
+}
+);
+unicode = 277;
+},
+{
+glyphname = ecaron;
+kernLeft = e;
+kernRight = e;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (95,0);
+ref = caron;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (73,0);
+ref = caron;
+}
+);
+width = 504;
+}
+);
+unicode = 283;
+},
+{
+glyphname = ecircumflex;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-87,0);
+ref = circumflexcomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-41,0);
+ref = circumflexcomb;
+}
+);
+width = 504;
+}
+);
+unicode = 234;
+},
+{
+glyphname = ecircumflexacute;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-83,0);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-63,0);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 504;
+}
+);
+unicode = 7871;
+},
+{
+glyphname = ecircumflexdotbelow;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-60,0);
+ref = dotbelowcomb;
+},
+{
+pos = (-87,0);
+ref = circumflexcomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-50,0);
+ref = dotbelowcomb;
+},
+{
+pos = (-41,0);
+ref = circumflexcomb;
+}
+);
+width = 504;
+}
+);
+unicode = 7879;
+},
+{
+glyphname = ecircumflexgrave;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-79,0);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-59,0);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 504;
+}
+);
+unicode = 7873;
+},
+{
+glyphname = ecircumflexhookabove;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-85,0);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-62,0);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 504;
+}
+);
+unicode = 7875;
+},
+{
+glyphname = ecircumflextilde;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-83,0);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-65,0);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 504;
+}
+);
+unicode = 7877;
+},
+{
+glyphname = edblgrave;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (18,0);
+ref = dblgravecomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (9,0);
+ref = dblgravecomb;
+}
+);
+width = 504;
+}
+);
+unicode = 517;
+},
+{
+glyphname = edieresis;
+kernLeft = e;
+kernRight = e;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (107,0);
+ref = dieresis;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (87,0);
+ref = dieresis;
+}
+);
+width = 504;
+}
+);
+unicode = 235;
+},
+{
+glyphname = edotaccent;
+kernLeft = e;
+kernRight = e;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (182,0);
+ref = dotaccent;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (184,0);
+ref = dotaccent;
+}
+);
+width = 504;
+}
+);
+unicode = 279;
+},
+{
+glyphname = edotbelow;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-60,0);
+ref = dotbelowcomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-50,0);
+ref = dotbelowcomb;
+}
+);
+width = 504;
+}
+);
+unicode = 7865;
+},
+{
+glyphname = egrave;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-63,0);
+ref = gravecomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-12,0);
+ref = gravecomb;
+}
+);
+width = 504;
+}
+);
+unicode = 232;
+},
+{
+glyphname = ehookabove;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-38,0);
+ref = hookabovecomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-28,0);
+ref = hookabovecomb;
+}
+);
+width = 504;
+}
+);
+unicode = 7867;
+},
+{
+glyphname = einvertedbreve;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (105,0);
+ref = breveinvertedcomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (72,0);
+ref = breveinvertedcomb;
+}
+);
+width = 504;
+}
+);
+unicode = 519;
+},
+{
+glyphname = emacron;
+kernLeft = e;
+kernRight = e;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (81,0);
+ref = macron;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (62,0);
+ref = macron;
+}
+);
+width = 504;
+}
+);
+unicode = 275;
+},
+{
+glyphname = eogonek;
+kernLeft = e;
+kernRight = e;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (221,0);
+ref = ogonek;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = e;
+},
+{
+alignment = -1;
+pos = (180,0);
+ref = ogonek;
+}
+);
+width = 504;
+}
+);
+unicode = 281;
+},
+{
+glyphname = etilde;
+kernLeft = e;
+kernRight = e;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-74,0);
+ref = tildecomb;
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = e;
+},
+{
+pos = (-61,0);
+ref = tildecomb;
+}
+);
+width = 504;
+}
+);
+unicode = 7869;
+},
+{
+glyphname = schwa;
+lastChange = "2016-08-22 11:22:41 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,-13,o),
+(456,120,o),
+(456,261,cs),
+(456,361,o),
+(387,462,o),
+(254,462,cs),
+(164,462,o),
+(98,415,o),
+(50,330,c),
+(70,316,l),
+(122,402,o),
+(184,432,o),
+(242,432,cs),
+(305,432,o),
+(336,396,o),
+(336,302,cs),
+(336,182,o),
+(285,17,o),
+(185,17,cs),
+(148,17,o),
+(123,39,o),
+(123,92,cs),
+(123,162,o),
+(166,222,o),
+(285,222,cs),
+(312,222,o),
+(335,219,o),
+(358,212,c),
+(363,237,l),
+(350,240,o),
+(290,248,o),
+(244,248,cs),
+(124,248,o),
+(35,192,o),
+(35,106,cs),
+(35,36,o),
+(94,-13,o),
+(178,-13,c)
+);
+}
+);
+width = 486;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,-11,o),
+(501,129,o),
+(501,267,cs),
+(501,367,o),
+(432,462,o),
+(303,462,cs),
+(202,462,o),
+(117,409,o),
+(64,322,c),
+(89,303,l),
+(151,394,o),
+(223,422,o),
+(288,422,cs),
+(343,422,o),
+(365,393,o),
+(356,338,cs),
+(312,69,o),
+(271,19,o),
+(219,19,cs),
+(178,19,o),
+(158,49,o),
+(158,93,cs),
+(158,157,o),
+(201,211,o),
+(295,211,cs),
+(347,211,o),
+(370,211,o),
+(393,201,c),
+(398,236,l),
+(387,239,o),
+(314,247,o),
+(264,247,cs),
+(120,247,o),
+(45,181,o),
+(45,108,cs),
+(45,38,o),
+(115,-11,o),
+(206,-11,cs)
+);
+}
+);
+width = 506;
+}
+);
+unicode = 601;
+},
+{
+glyphname = f;
+kernLeft = f;
+kernRight = f;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (104,0);
+},
+{
+name = top;
+pos = (208,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(3,-324,o),
+(101,-256,o),
+(171,45,cs),
+(277,501,ls),
+(319,682,o),
+(359,736,o),
+(417,736,cs),
+(438,736,o),
+(452,729,o),
+(452,718,cs),
+(452,705,o),
+(431,695,o),
+(431,669,cs),
+(431,645,o),
+(450,625,o),
+(481,625,cs),
+(515,625,o),
+(535,651,o),
+(535,681,cs),
+(535,732,o),
+(482,766,o),
+(424,766,cs),
+(320,766,o),
+(201,656,o),
+(156,440,cs),
+(35,-140,ls),
+(10,-260,o),
+(-26,-294,o),
+(-68,-294,cs),
+(-88,-294,o),
+(-92,-287,o),
+(-92,-276,cs),
+(-92,-267,o),
+(-89,-256,o),
+(-89,-247,cs),
+(-89,-223,o),
+(-108,-203,o),
+(-136,-203,cs),
+(-164,-203,o),
+(-185,-223,o),
+(-185,-251,cs),
+(-185,-293,o),
+(-140,-324,o),
+(-82,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,425,l),
+(383,450,l),
+(62,450,l),
+(62,425,l)
+);
+}
+);
+width = 312;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (108,0);
+},
+{
+name = top;
+pos = (212,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(35,-324,o),
+(153,-177,o),
+(223,175,cs),
+(288,501,ls),
+(322,682,o),
+(361,736,o),
+(408,736,cs),
+(426,736,o),
+(434,728,o),
+(434,718,cs),
+(434,702,o),
+(413,691,o),
+(413,658,cs),
+(413,623,o),
+(438,600,o),
+(476,600,cs),
+(519,600,o),
+(539,629,o),
+(539,667,cs),
+(539,727,o),
+(487,766,o),
+(422,766,cs),
+(314,766,o),
+(183,659,o),
+(136,434,cs),
+(52,33,ls),
+(-11,-268,o),
+(-28,-289,o),
+(-61,-289,cs),
+(-76,-289,o),
+(-84,-285,o),
+(-84,-272,cs),
+(-84,-256,o),
+(-71,-245,o),
+(-71,-224,cs),
+(-71,-198,o),
+(-91,-172,o),
+(-131,-172,cs),
+(-172,-172,o),
+(-193,-199,o),
+(-193,-235,cs),
+(-193,-279,o),
+(-163,-324,o),
+(-92,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,420,l),
+(399,450,l),
+(38,450,l),
+(38,420,l)
+);
+}
+);
+width = 320;
+}
+);
+unicode = 102;
+},
+{
+glyphname = g;
+kernLeft = g;
+kernRight = g;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (207,0);
+},
+{
+name = top;
+pos = (311,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,-326,o),
+(440,-197,o),
+(440,-80,cs),
+(440,-8,o),
+(407,47,o),
+(330,52,cs),
+(172,62,ls),
+(93,67,o),
+(76,78,o),
+(76,105,cs),
+(76,137,o),
+(100,158,o),
+(143,166,c),
+(145,197,l),
+(115,192,o),
+(4,156,o),
+(4,69,cs),
+(4,0,o),
+(75,-30,o),
+(113,-33,cs),
+(336,-51,ls),
+(374,-54,o),
+(400,-77,o),
+(400,-118,cs),
+(400,-188,o),
+(324,-296,o),
+(168,-296,cs),
+(70,-296,o),
+(18,-254,o),
+(18,-178,cs),
+(18,-114,o),
+(54,-62,o),
+(205,-16,c),
+(174,-5,l),
+(-21,-52,o),
+(-56,-118,o),
+(-56,-177,cs),
+(-56,-267,o),
+(25,-326,o),
+(158,-326,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(344,136,o),
+(435,208,o),
+(435,319,cs),
+(435,401,o),
+(385,462,o),
+(292,462,cs),
+(187,462,o),
+(88,385,o),
+(88,281,cs),
+(88,213,o),
+(131,136,o),
+(239,136,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,156,o),
+(183,186,o),
+(183,237,cs),
+(183,336,o),
+(224,442,o),
+(299,442,cs),
+(335,442,o),
+(347,418,o),
+(347,367,cs),
+(347,272,o),
+(305,156,o),
+(231,156,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,362,o),
+(461,409,o),
+(474,409,cs),
+(484,409,o),
+(488,382,o),
+(516,382,cs),
+(541,382,o),
+(553,404,o),
+(553,421,cs),
+(553,443,o),
+(535,462,o),
+(508,462,cs),
+(473,462,o),
+(449,430,o),
+(431,369,c),
+(427,369,l),
+(431,282,l)
+);
+}
+);
+width = 517;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (213,0);
+},
+{
+name = top;
+pos = (317,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(366,-319,o),
+(459,-187,o),
+(459,-70,cs),
+(459,7,o),
+(419,56,o),
+(349,58,cs),
+(169,64,ls),
+(88,67,o),
+(71,81,o),
+(71,108,cs),
+(71,138,o),
+(92,157,o),
+(140,166,c),
+(142,197,l),
+(112,192,o),
+(1,154,o),
+(1,53,cs),
+(1,-23,o),
+(65,-58,o),
+(103,-60,cs),
+(333,-75,ls),
+(380,-78,o),
+(406,-92,o),
+(406,-126,cs),
+(406,-187,o),
+(326,-284,o),
+(169,-284,cs),
+(73,-284,o),
+(27,-248,o),
+(27,-174,cs),
+(27,-107,o),
+(65,-58,o),
+(202,-16,c),
+(171,-5,l),
+(53,-35,o),
+(-59,-86,o),
+(-59,-176,cs),
+(-59,-263,o),
+(22,-319,o),
+(158,-319,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,131,o),
+(476,204,o),
+(476,323,cs),
+(476,403,o),
+(391,462,o),
+(305,462,cs),
+(185,462,o),
+(66,384,o),
+(66,275,cs),
+(66,204,o),
+(116,131,o),
+(243,131,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(198,156,o),
+(188,176,o),
+(188,220,cs),
+(188,308,o),
+(229,437,o),
+(314,437,cs),
+(348,437,o),
+(354,416,o),
+(354,382,cs),
+(354,300,o),
+(319,156,o),
+(231,156,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(485,367,o),
+(495,391,o),
+(506,391,cs),
+(513,391,o),
+(522,380,o),
+(542,380,cs),
+(573,380,o),
+(584,405,o),
+(584,423,cs),
+(584,445,o),
+(569,464,o),
+(539,464,cs),
+(501,464,o),
+(483,432,o),
+(463,374,c),
+(457,374,l),
+(471,287,l)
+);
+}
+);
+width = 529;
+}
+);
+unicode = 103;
+},
+{
+glyphname = gacute;
+kernLeft = g;
+kernRight = g;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = g;
+},
+{
+alignment = -1;
+pos = (216,0);
+ref = acute;
+}
+);
+width = 517;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = g;
+},
+{
+alignment = -1;
+pos = (172,0);
+ref = acute;
+}
+);
+width = 529;
+}
+);
+unicode = 501;
+},
+{
+glyphname = gbreve;
+kernLeft = g;
+kernRight = g;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = g;
+},
+{
+alignment = -1;
+pos = (104,0);
+ref = breve;
+}
+);
+width = 517;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = g;
+},
+{
+alignment = -1;
+pos = (88,0);
+ref = breve;
+}
+);
+width = 529;
+}
+);
+unicode = 287;
+},
+{
+glyphname = gcircumflex;
+kernLeft = g;
+kernRight = g;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = g;
+},
+{
+alignment = -1;
+pos = (113,0);
+ref = circumflex;
+}
+);
+width = 517;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = g;
+},
+{
+alignment = -1;
+pos = (95,0);
+ref = circumflex;
+}
+);
+width = 529;
+}
+);
+unicode = 285;
+},
+{
+glyphname = gcommaaccent;
+kernLeft = g;
+kernRight = g;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = g;
+},
+{
+angle = 180;
+pos = (367,489);
+ref = commaaccentcomb;
+}
+);
+width = 517;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = g;
+},
+{
+angle = 180;
+pos = (357,489);
+ref = commaaccentcomb;
+}
+);
+width = 529;
+}
+);
+unicode = 291;
+},
+{
+glyphname = gdotaccent;
+kernLeft = g;
+kernRight = g;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = g;
+},
+{
+alignment = -1;
+pos = (210,0);
+ref = dotaccent;
+}
+);
+width = 517;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = g;
+},
+{
+alignment = -1;
+pos = (197,0);
+ref = dotaccent;
+}
+);
+width = 529;
+}
+);
+unicode = 289;
+},
+{
+glyphname = h;
+kernLeft = h;
+kernRight = h;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (225,0);
+},
+{
+name = center;
+pos = (277,225);
+},
+{
+name = top;
+pos = (329,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,0,l),
+(304,754,l),
+(197,754,l),
+(19,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,-13,o),
+(523,69,o),
+(562,157,c),
+(542,166,l),
+(500,73,o),
+(467,38,o),
+(438,38,cs),
+(424,38,o),
+(416,46,o),
+(416,63,cs),
+(416,69,o),
+(417,80,o),
+(421,97,cs),
+(482,338,ls),
+(486,355,o),
+(488,370,o),
+(488,382,cs),
+(488,438,o),
+(446,462,o),
+(395,462,cs),
+(321,462,o),
+(254,413,o),
+(214,363,c),
+(207,363,l),
+(179,236,l),
+(209,342,o),
+(289,420,o),
+(349,420,cs),
+(371,420,o),
+(386,410,o),
+(386,387,cs),
+(386,379,o),
+(384,371,o),
+(382,361,cs),
+(316,87,ls),
+(314,78,o),
+(312,67,o),
+(312,56,cs),
+(312,15,o),
+(341,-13,o),
+(388,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,729,l),
+(292,754,l),
+(98,754,l),
+(98,729,l)
+);
+}
+);
+width = 554;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (240,0);
+},
+{
+name = center;
+pos = (292,225);
+},
+{
+name = top;
+pos = (344,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(334,754,l),
+(197,754,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(487,-11,o),
+(550,21,o),
+(596,146,c),
+(571,155,l),
+(535,69,o),
+(497,35,o),
+(472,35,cs),
+(461,35,o),
+(456,42,o),
+(456,55,cs),
+(456,61,o),
+(457,72,o),
+(461,89,cs),
+(523,331,ls),
+(527,348,o),
+(529,362,o),
+(529,375,cs),
+(529,437,o),
+(480,462,o),
+(422,462,cs),
+(339,462,o),
+(282,412,o),
+(242,362,c),
+(235,362,l),
+(202,231,l),
+(234,343,o),
+(329,416,o),
+(373,416,cs),
+(388,416,o),
+(397,408,o),
+(397,393,cs),
+(397,384,o),
+(394,365,o),
+(392,356,cs),
+(328,107,ls),
+(326,98,o),
+(324,88,o),
+(324,75,cs),
+(324,19,o),
+(360,-11,o),
+(422,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,724,l),
+(322,754,l),
+(103,754,l),
+(103,724,l)
+);
+}
+);
+width = 584;
+}
+);
+unicode = 104;
+},
+{
+glyphname = hbar;
+kernRight = h;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(389,576,l),
+(389,611,l),
+(64,611,l),
+(64,576,l)
+);
+},
+{
+ref = h;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(409,581,l),
+(409,621,l),
+(84,621,l),
+(84,581,l)
+);
+},
+{
+ref = h;
+}
+);
+width = 584;
+}
+);
+unicode = 295;
+},
+{
+glyphname = hcircumflex;
+kernLeft = h;
+kernRight = h;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = h;
+},
+{
+alignment = -1;
+pos = (10,0);
+ref = circumflex.case;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = h;
+},
+{
+alignment = -1;
+ref = circumflex.case;
+}
+);
+width = 584;
+}
+);
+unicode = 293;
+},
+{
+glyphname = hdotbelow;
+kernLeft = h;
+kernRight = h;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = h;
+},
+{
+alignment = -1;
+pos = (186,0);
+ref = dotbelow;
+}
+);
+width = 554;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = h;
+},
+{
+alignment = -1;
+pos = (213,0);
+ref = dotbelow;
+}
+);
+width = 584;
+}
+);
+unicode = 7717;
+},
+{
+glyphname = i;
+kernLeft = i;
+kernRight = i;
+lastChange = "2016-08-22 13:50:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (104,0);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,-13,o),
+(271,73,o),
+(310,157,c),
+(290,166,l),
+(244,73,o),
+(208,38,o),
+(176,38,cs),
+(162,38,o),
+(154,45,o),
+(154,63,cs),
+(154,69,o),
+(155,80,o),
+(159,97,cs),
+(248,450,l),
+(141,450,l),
+(54,87,ls),
+(52,78,o),
+(50,67,o),
+(50,56,cs),
+(50,15,o),
+(78,-13,o),
+(127,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,425,l),
+(236,450,l),
+(47,450,l),
+(47,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(265,601,o),
+(295,631,o),
+(295,667,cs),
+(295,703,o),
+(265,733,o),
+(229,733,cs),
+(193,733,o),
+(163,703,o),
+(163,667,cs),
+(163,631,o),
+(193,601,o),
+(229,601,cs)
+);
+}
+);
+width = 312;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (113,0);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,-11,o),
+(298,38,o),
+(335,147,c),
+(310,156,l),
+(269,65,o),
+(225,37,o),
+(203,37,cs),
+(195,37,o),
+(190,41,o),
+(190,54,cs),
+(190,58,o),
+(191,68,o),
+(195,87,cs),
+(279,450,l),
+(145,450,l),
+(71,153,ls),
+(58,100,o),
+(55,86,o),
+(55,70,cs),
+(55,15,o),
+(90,-11,o),
+(142,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,420,l),
+(222,450,l),
+(48,450,l),
+(48,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,577,o),
+(325,612,o),
+(325,656,cs),
+(325,700,o),
+(290,735,o),
+(246,735,cs),
+(202,735,o),
+(167,700,o),
+(167,656,cs),
+(167,612,o),
+(202,577,o),
+(246,577,cs)
+);
+}
+);
+width = 330;
+}
+);
+unicode = 105;
+},
+{
+glyphname = idotless;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (104,0);
+},
+{
+name = ogonek;
+pos = (229,10);
+},
+{
+name = top;
+pos = (208,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(213,-13,o),
+(271,73,o),
+(310,157,c),
+(290,166,l),
+(244,73,o),
+(208,38,o),
+(176,38,cs),
+(162,38,o),
+(154,45,o),
+(154,63,cs),
+(154,69,o),
+(155,80,o),
+(159,97,cs),
+(248,450,l),
+(141,450,l),
+(54,87,ls),
+(52,78,o),
+(50,67,o),
+(50,56,cs),
+(50,15,o),
+(78,-13,o),
+(127,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,425,l),
+(236,450,l),
+(47,450,l),
+(47,425,l)
+);
+}
+);
+width = 312;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (113,0);
+},
+{
+name = ogonek;
+pos = (245,10);
+},
+{
+name = top;
+pos = (217,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,-11,o),
+(298,38,o),
+(335,147,c),
+(310,156,l),
+(269,65,o),
+(225,37,o),
+(203,37,cs),
+(195,37,o),
+(190,41,o),
+(190,54,cs),
+(190,58,o),
+(191,68,o),
+(195,87,cs),
+(279,450,l),
+(145,450,l),
+(71,153,ls),
+(58,100,o),
+(55,86,o),
+(55,70,cs),
+(55,15,o),
+(90,-11,o),
+(142,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,420,l),
+(222,450,l),
+(48,450,l),
+(48,420,l)
+);
+}
+);
+width = 330;
+}
+);
+unicode = 305;
+},
+{
+glyphname = iacute;
+kernLeft = i;
+kernRight = i;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+pos = (-189,-42);
+ref = acutecomb;
+},
+{
+ref = idotless;
+}
+);
+width = 316;
+},
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,450,l),
+(145,450,l),
+(71,153,ls),
+(58,100,o),
+(55,86,o),
+(55,70,cs),
+(55,15,o),
+(90,-11,o),
+(142,-11,cs),
+(233,-11,o),
+(298,38,o),
+(335,147,c),
+(310,156,l),
+(269,65,o),
+(225,37,o),
+(203,37,cs),
+(195,37,o),
+(190,41,o),
+(190,54,cs),
+(190,58,o),
+(191,68,o),
+(195,87,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,420,l),
+(222,420,l),
+(222,450,l),
+(48,450,l)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (-123,0);
+ref = acutecomb;
+},
+{
+ref = idotless;
+}
+);
+width = 330;
+}
+);
+unicode = 237;
+},
+{
+glyphname = ibreve;
+kernLeft = i;
+kernRight = i;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-8,0);
+ref = breve;
+}
+);
+width = 316;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-59,0);
+ref = breve;
+}
+);
+width = 330;
+}
+);
+unicode = 301;
+},
+{
+glyphname = icircumflex;
+kernLeft = i;
+kernRight = i;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-23,0);
+ref = circumflex;
+}
+);
+width = 316;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-41,0);
+ref = circumflex;
+}
+);
+width = 330;
+}
+);
+unicode = 238;
+},
+{
+glyphname = idblgrave;
+kernLeft = i;
+kernRight = i;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-128,0);
+ref = dblgravecomb;
+}
+);
+width = 316;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (-154,0);
+ref = dblgravecomb;
+}
+);
+width = 330;
+}
+);
+unicode = 521;
+},
+{
+glyphname = idieresis;
+kernLeft = i;
+kernRight = i;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-21,0);
+ref = dieresis;
+}
+);
+width = 316;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-16,0);
+ref = dieresis;
+}
+);
+width = 330;
+}
+);
+unicode = 239;
+},
+{
+glyphname = idotbelow;
+kernLeft = i;
+kernRight = i;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = i;
+},
+{
+pos = (-137,0);
+ref = dotbelowcomb;
+}
+);
+width = 312;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = i;
+},
+{
+pos = (-137,0);
+ref = dotbelowcomb;
+}
+);
+width = 330;
+}
+);
+unicode = 7883;
+},
+{
+glyphname = igrave;
+kernLeft = i;
+kernRight = i;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+pos = (-161,-26);
+ref = gravecomb;
+},
+{
+ref = idotless;
+}
+);
+width = 316;
+},
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,450,l),
+(145,450,l),
+(71,153,ls),
+(58,100,o),
+(55,86,o),
+(55,70,cs),
+(55,15,o),
+(90,-11,o),
+(142,-11,cs),
+(233,-11,o),
+(298,38,o),
+(335,147,c),
+(310,156,l),
+(269,65,o),
+(225,37,o),
+(203,37,cs),
+(195,37,o),
+(190,41,o),
+(190,54,cs),
+(190,58,o),
+(191,68,o),
+(195,87,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,420,l),
+(222,420,l),
+(222,450,l),
+(48,450,l)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (-168,0);
+ref = gravecomb;
+},
+{
+ref = idotless;
+}
+);
+width = 330;
+}
+);
+unicode = 236;
+},
+{
+glyphname = ihookabove;
+lastChange = "2016-08-22 14:11:26 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (-115,0);
+ref = hookabovecomb;
+}
+);
+width = 312;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (-115,0);
+ref = hookabovecomb;
+}
+);
+width = 330;
+}
+);
+unicode = 7881;
+},
+{
+glyphname = iinvertedbreve;
+kernLeft = i;
+kernRight = i;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-15,0);
+ref = breveinvertedcomb;
+}
+);
+width = 316;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = idotless;
+},
+{
+pos = (-23,0);
+ref = breveinvertedcomb;
+}
+);
+width = 330;
+}
+);
+unicode = 523;
+},
+{
+glyphname = ij;
+kernLeft = i;
+kernRight = j;
+lastChange = "2016-08-22 13:26:51 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = i;
+},
+{
+pos = (304,0);
+ref = j;
+}
+);
+width = 595;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = i;
+},
+{
+pos = (330,0);
+ref = j;
+}
+);
+width = 617;
+}
+);
+unicode = 307;
+},
+{
+glyphname = imacron;
+kernLeft = i;
+kernRight = i;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-24,0);
+ref = macron;
+}
+);
+width = 316;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-31,0);
+ref = macron;
+}
+);
+width = 330;
+}
+);
+unicode = 299;
+},
+{
+glyphname = iogonek;
+kernLeft = i;
+kernRight = i;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = i;
+},
+{
+alignment = -1;
+pos = (83,0);
+ref = ogonek;
+}
+);
+width = 312;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = i;
+},
+{
+alignment = -1;
+pos = (84,0);
+ref = ogonek;
+}
+);
+width = 330;
+}
+);
+unicode = 303;
+},
+{
+glyphname = itilde;
+kernLeft = i;
+kernRight = i;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-63,0);
+ref = tilde;
+}
+);
+width = 316;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = idotless;
+},
+{
+alignment = -1;
+pos = (-50,0);
+ref = tilde;
+}
+);
+width = 330;
+}
+);
+unicode = 297;
+},
+{
+glyphname = j;
+kernLeft = j;
+kernRight = j;
+lastChange = "2016-08-22 13:50:23 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,-324,o),
+(102,-257,o),
+(129,-134,cs),
+(257,450,l),
+(150,450,l),
+(25,-152,ls),
+(-3,-289,o),
+(-36,-294,o),
+(-51,-294,cs),
+(-65,-294,o),
+(-73,-290,o),
+(-73,-278,cs),
+(-73,-270,o),
+(-70,-256,o),
+(-70,-246,cs),
+(-70,-223,o),
+(-88,-203,o),
+(-117,-203,cs),
+(-145,-203,o),
+(-166,-221,o),
+(-166,-251,cs),
+(-166,-297,o),
+(-117,-324,o),
+(-67,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,425,l),
+(245,450,l),
+(56,450,l),
+(56,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,601,o),
+(305,631,o),
+(305,667,cs),
+(305,703,o),
+(275,733,o),
+(239,733,cs),
+(203,733,o),
+(173,703,o),
+(173,667,cs),
+(173,631,o),
+(203,601,o),
+(239,601,cs)
+);
+}
+);
+width = 291;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,-324,o),
+(116,-257,o),
+(173,-3,cs),
+(274,450,l),
+(137,450,l),
+(12,-110,ls),
+(-26,-281,o),
+(-48,-287,o),
+(-59,-287,cs),
+(-71,-287,o),
+(-75,-280,o),
+(-75,-272,cs),
+(-75,-263,o),
+(-71,-252,o),
+(-71,-236,cs),
+(-71,-197,o),
+(-93,-180,o),
+(-127,-180,cs),
+(-166,-180,o),
+(-189,-203,o),
+(-189,-237,cs),
+(-189,-289,o),
+(-137,-324,o),
+(-75,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,420,l),
+(262,450,l),
+(43,450,l),
+(43,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,577,o),
+(315,612,o),
+(315,656,cs),
+(315,700,o),
+(280,735,o),
+(236,735,cs),
+(192,735,o),
+(157,700,o),
+(157,656,cs),
+(157,612,o),
+(192,577,o),
+(236,577,cs)
+);
+}
+);
+width = 287;
+}
+);
+unicode = 106;
+},
+{
+glyphname = jdotless;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(13,-324,o),
+(102,-257,o),
+(129,-134,cs),
+(257,450,l),
+(150,450,l),
+(25,-152,ls),
+(-3,-289,o),
+(-36,-294,o),
+(-51,-294,cs),
+(-65,-294,o),
+(-73,-290,o),
+(-73,-278,cs),
+(-73,-270,o),
+(-70,-256,o),
+(-70,-246,cs),
+(-70,-223,o),
+(-88,-203,o),
+(-117,-203,cs),
+(-145,-203,o),
+(-166,-221,o),
+(-166,-251,cs),
+(-166,-297,o),
+(-117,-324,o),
+(-67,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,425,l),
+(245,450,l),
+(56,450,l),
+(56,425,l)
+);
+}
+);
+width = 291;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,-324,o),
+(116,-257,o),
+(173,-3,cs),
+(274,450,l),
+(137,450,l),
+(12,-110,ls),
+(-26,-281,o),
+(-48,-287,o),
+(-59,-287,cs),
+(-71,-287,o),
+(-75,-280,o),
+(-75,-272,cs),
+(-75,-263,o),
+(-71,-252,o),
+(-71,-236,cs),
+(-71,-197,o),
+(-93,-180,o),
+(-127,-180,cs),
+(-166,-180,o),
+(-189,-203,o),
+(-189,-237,cs),
+(-189,-289,o),
+(-137,-324,o),
+(-75,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(262,420,l),
+(262,450,l),
+(43,450,l),
+(43,420,l)
+);
+}
+);
+width = 287;
+}
+);
+unicode = 567;
+},
+{
+glyphname = jcircumflex;
+kernLeft = j;
+kernRight = j;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = jdotless;
+},
+{
+alignment = -1;
+pos = (-29,0);
+ref = circumflex;
+}
+);
+width = 271;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = jdotless;
+},
+{
+alignment = -1;
+pos = (-52,0);
+ref = circumflex;
+}
+);
+width = 287;
+}
+);
+unicode = 309;
+},
+{
+glyphname = k;
+kernLeft = k;
+kernRight = k;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (210,0);
+},
+{
+name = top;
+pos = (314,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(296,754,l),
+(189,754,l),
+(21,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,-13,o),
+(451,41,o),
+(491,146,c),
+(468,157,l),
+(439,86,o),
+(402,45,o),
+(373,45,cs),
+(363,45,o),
+(357,50,o),
+(357,71,cs),
+(357,98,o),
+(367,142,o),
+(367,174,cs),
+(367,218,o),
+(348,254,o),
+(290,284,c),
+(321,318,o),
+(355,430,o),
+(392,430,cs),
+(399,430,o),
+(407,426,o),
+(407,417,cs),
+(407,405,o),
+(391,396,o),
+(391,372,cs),
+(391,345,o),
+(412,332,o),
+(435,332,cs),
+(470,332,o),
+(488,353,o),
+(488,384,cs),
+(488,414,o),
+(466,462,o),
+(410,462,cs),
+(324,462,o),
+(314,346,o),
+(250,285,c),
+(224,285,o),
+(201,282,o),
+(168,275,c),
+(161,239,l),
+(169,237,o),
+(172,237,o),
+(179,237,cs),
+(216,237,o),
+(237,242,o),
+(273,264,c),
+(282,257,o),
+(286,243,o),
+(286,227,cs),
+(286,181,o),
+(253,113,o),
+(253,65,cs),
+(253,11,o),
+(294,-13,o),
+(336,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,729,l),
+(284,754,l),
+(95,754,l),
+(95,729,l)
+);
+}
+);
+width = 523;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (220,0);
+},
+{
+name = top;
+pos = (324,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,0,l),
+(334,754,l),
+(197,754,l),
+(13,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,-13,o),
+(499,32,o),
+(545,132,c),
+(518,145,l),
+(488,74,o),
+(456,39,o),
+(433,39,cs),
+(423,39,o),
+(418,45,o),
+(418,64,cs),
+(418,90,o),
+(428,128,o),
+(428,162,cs),
+(428,204,o),
+(413,248,o),
+(318,278,c),
+(346,312,o),
+(390,414,o),
+(414,414,cs),
+(419,414,o),
+(422,410,o),
+(422,402,cs),
+(422,396,o),
+(420,385,o),
+(420,375,cs),
+(420,341,o),
+(445,325,o),
+(477,325,cs),
+(518,325,o),
+(538,352,o),
+(538,383,cs),
+(538,415,o),
+(516,462,o),
+(454,462,cs),
+(363,462,o),
+(352,357,o),
+(284,285,c),
+(265,285,o),
+(232,280,o),
+(212,269,c),
+(204,236,l),
+(213,230,o),
+(222,227,o),
+(233,227,cs),
+(254,227,o),
+(280,237,o),
+(297,254,c),
+(308,247,o),
+(312,238,o),
+(312,223,cs),
+(312,178,o),
+(277,130,o),
+(277,77,cs),
+(277,14,o),
+(327,-13,o),
+(378,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(322,724,l),
+(322,754,l),
+(103,754,l),
+(103,724,l)
+);
+}
+);
+width = 543;
+}
+);
+unicode = 107;
+},
+{
+glyphname = kcommaaccent;
+kernLeft = k;
+kernRight = k;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = k;
+},
+{
+pos = (154,0);
+ref = commaaccentcomb;
+}
+);
+width = 523;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = k;
+},
+{
+pos = (195,0);
+ref = commaaccentcomb;
+}
+);
+width = 543;
+}
+);
+unicode = 311;
+},
+{
+glyphname = kgreenlandic;
+kernRight = k;
+lastChange = "2016-08-22 11:30:29 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(399,-13,o),
+(451,41,o),
+(491,146,c),
+(468,157,l),
+(439,86,o),
+(402,45,o),
+(373,45,cs),
+(363,45,o),
+(357,50,o),
+(357,71,cs),
+(357,98,o),
+(367,142,o),
+(367,174,cs),
+(367,218,o),
+(348,254,o),
+(290,284,c),
+(321,318,o),
+(355,430,o),
+(392,430,cs),
+(399,430,o),
+(407,426,o),
+(407,417,cs),
+(407,405,o),
+(391,396,o),
+(391,372,cs),
+(391,345,o),
+(412,332,o),
+(435,332,cs),
+(470,332,o),
+(488,353,o),
+(488,384,cs),
+(488,414,o),
+(466,462,o),
+(410,462,cs),
+(324,462,o),
+(314,346,o),
+(250,285,c),
+(224,285,o),
+(201,282,o),
+(168,275,c),
+(161,239,l),
+(169,237,o),
+(172,237,o),
+(179,237,cs),
+(216,237,o),
+(237,242,o),
+(273,264,c),
+(282,257,o),
+(286,243,o),
+(286,227,cs),
+(286,181,o),
+(253,113,o),
+(253,65,cs),
+(253,11,o),
+(294,-13,o),
+(336,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,0,l),
+(227,450,l),
+(121,450,l),
+(21,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,425,l),
+(215,450,l),
+(26,450,l),
+(26,425,l)
+);
+}
+);
+width = 523;
+},
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,236,l),
+(217,230,o),
+(226,227,o),
+(237,227,cs),
+(258,227,o),
+(284,237,o),
+(301,254,c),
+(312,247,o),
+(316,238,o),
+(316,223,cs),
+(316,178,o),
+(281,130,o),
+(281,77,cs),
+(281,14,o),
+(331,-13,o),
+(382,-13,cs),
+(448,-13,o),
+(503,32,o),
+(549,132,c),
+(522,145,l),
+(492,74,o),
+(460,39,o),
+(437,39,cs),
+(427,39,o),
+(422,45,o),
+(422,64,cs),
+(422,90,o),
+(432,128,o),
+(432,162,cs),
+(432,204,o),
+(417,248,o),
+(322,278,c),
+(350,312,o),
+(394,414,o),
+(418,414,cs),
+(423,414,o),
+(426,410,o),
+(426,402,cs),
+(426,396,o),
+(424,385,o),
+(424,375,cs),
+(424,341,o),
+(449,325,o),
+(481,325,cs),
+(522,325,o),
+(542,352,o),
+(542,383,cs),
+(542,415,o),
+(520,462,o),
+(458,462,cs),
+(367,462,o),
+(356,357,o),
+(288,285,c),
+(269,285,o),
+(236,280,o),
+(216,269,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,754,l),
+(201,754,l),
+(17,0,l),
+(150,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(107,724,l),
+(326,724,l),
+(326,754,l),
+(107,754,l)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,-13,o),
+(521,32,o),
+(567,132,c),
+(540,145,l),
+(510,74,o),
+(478,39,o),
+(455,39,cs),
+(445,39,o),
+(440,45,o),
+(440,64,cs),
+(440,84,o),
+(440,115,o),
+(440,142,cs),
+(440,184,o),
+(425,228,o),
+(330,258,c),
+(361,296,o),
+(411,414,o),
+(438,414,cs),
+(443,414,o),
+(446,410,o),
+(446,402,cs),
+(446,396,o),
+(444,385,o),
+(444,375,cs),
+(444,341,o),
+(469,325,o),
+(501,325,cs),
+(542,325,o),
+(562,357,o),
+(562,393,cs),
+(562,421,o),
+(540,462,o),
+(478,462,cs),
+(380,462,o),
+(368,345,o),
+(296,265,c),
+(277,265,o),
+(244,260,o),
+(224,249,c),
+(216,216,l),
+(225,207,o),
+(234,207,o),
+(245,207,cs),
+(266,207,o),
+(292,217,o),
+(309,234,c),
+(320,227,o),
+(324,218,o),
+(324,203,cs),
+(324,164,o),
+(299,122,o),
+(299,77,cs),
+(299,14,o),
+(349,-13,o),
+(400,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(280,450,l),
+(143,450,l),
+(35,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,420,l),
+(268,450,l),
+(49,450,l),
+(49,420,l)
+);
+}
+);
+width = 565;
+}
+);
+unicode = 312;
+},
+{
+glyphname = l;
+kernLeft = l;
+kernRight = l;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (110,0);
+},
+{
+name = center;
+pos = (162,225);
+},
+{
+name = top;
+pos = (214,450);
+},
+{
+name = topright;
+pos = (356,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(209,-13,o),
+(268,73,o),
+(308,157,c),
+(288,166,l),
+(240,73,o),
+(203,38,o),
+(169,38,cs),
+(155,38,o),
+(147,45,o),
+(147,63,cs),
+(147,69,o),
+(148,80,o),
+(152,97,cs),
+(314,754,l),
+(207,754,l),
+(47,87,ls),
+(45,78,o),
+(43,67,o),
+(43,56,cs),
+(43,15,o),
+(71,-13,o),
+(120,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(302,729,l),
+(302,754,l),
+(107,754,l),
+(107,729,l)
+);
+}
+);
+width = 324;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (104,0);
+},
+{
+name = center;
+pos = (156,225);
+},
+{
+name = top;
+pos = (208,450);
+},
+{
+name = topright;
+pos = (344,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(199,-11,o),
+(258,43,o),
+(291,152,c),
+(266,161,l),
+(233,69,o),
+(196,41,o),
+(178,41,cs),
+(171,41,o),
+(166,45,o),
+(166,54,cs),
+(166,58,o),
+(167,70,o),
+(171,87,cs),
+(330,754,l),
+(196,754,l),
+(57,132,ls),
+(52,108,o),
+(48,83,o),
+(48,67,cs),
+(48,26,o),
+(74,-11,o),
+(131,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,724,l),
+(273,754,l),
+(118,754,l),
+(118,724,l)
+);
+}
+);
+width = 312;
+}
+);
+unicode = 108;
+},
+{
+glyphname = lacute;
+kernLeft = l;
+kernRight = l;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = l;
+},
+{
+alignment = -1;
+pos = (56,0);
+ref = acute.case;
+}
+);
+width = 324;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = l;
+},
+{
+alignment = -1;
+pos = (75,0);
+ref = acute.case;
+}
+);
+width = 312;
+}
+);
+unicode = 314;
+},
+{
+glyphname = lcaron;
+kernLeft = l;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = l;
+},
+{
+alignment = -1;
+pos = (189,37);
+ref = quoteright;
+}
+);
+width = 388;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = l;
+},
+{
+alignment = -1;
+pos = (207,3);
+ref = quoteright;
+}
+);
+width = 398;
+}
+);
+unicode = 318;
+},
+{
+glyphname = lcommaaccent;
+kernLeft = l;
+kernRight = l;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = l;
+},
+{
+pos = (56,0);
+ref = commaaccentcomb;
+}
+);
+width = 324;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = l;
+},
+{
+pos = (86,0);
+ref = commaaccentcomb;
+}
+);
+width = 312;
+}
+);
+unicode = 316;
+},
+{
+glyphname = ldot;
+kernLeft = l;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = l;
+},
+{
+alignment = -1;
+pos = (243,97);
+ref = periodcentered;
+}
+);
+width = 367;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = l;
+},
+{
+alignment = -1;
+pos = (263,97);
+ref = periodcentered;
+}
+);
+width = 402;
+}
+);
+unicode = 320;
+},
+{
+glyphname = lj;
+kernLeft = l;
+kernRight = j;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = l;
+},
+{
+pos = (324,0);
+ref = j;
+}
+);
+width = 615;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = l;
+},
+{
+pos = (312,0);
+ref = j;
+}
+);
+width = 599;
+}
+);
+unicode = 457;
+},
+{
+glyphname = lslash;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(338,448,l),
+(338,488,l),
+(30,327,l),
+(30,287,l)
+);
+},
+{
+ref = l;
+}
+);
+width = 324;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,439,l),
+(342,489,l),
+(1,328,l),
+(-10,278,l)
+);
+},
+{
+ref = l;
+}
+);
+width = 312;
+}
+);
+unicode = 322;
+},
+{
+glyphname = m;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (354,0);
+},
+{
+name = top;
+pos = (458,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(725,-13,o),
+(779,69,o),
+(818,157,c),
+(798,166,l),
+(756,73,o),
+(723,38,o),
+(694,38,cs),
+(680,38,o),
+(672,46,o),
+(672,63,cs),
+(672,69,o),
+(673,80,o),
+(677,97,cs),
+(737,336,ls),
+(741,353,o),
+(743,368,o),
+(743,380,cs),
+(743,437,o),
+(701,462,o),
+(651,462,cs),
+(580,462,o),
+(522,413,o),
+(484,361,c),
+(477,361,l),
+(449,234,l),
+(476,339,o),
+(546,420,o),
+(604,420,cs),
+(625,420,o),
+(641,410,o),
+(641,385,cs),
+(641,377,o),
+(639,369,o),
+(637,359,cs),
+(572,87,ls),
+(570,78,o),
+(568,67,o),
+(568,56,cs),
+(568,15,o),
+(597,-13,o),
+(644,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,0,l),
+(240,450,l),
+(133,450,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,0,l),
+(474,336,ls),
+(492,414,o),
+(464,462,o),
+(388,462,cs),
+(317,462,o),
+(259,413,o),
+(221,361,c),
+(214,361,l),
+(186,234,l),
+(213,339,o),
+(283,420,o),
+(341,420,cs),
+(362,420,o),
+(378,410,o),
+(378,385,cs),
+(378,377,o),
+(376,369,o),
+(374,359,cs),
+(288,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,425,l),
+(228,450,l),
+(39,450,l),
+(39,425,l)
+);
+}
+);
+width = 812;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (349,0);
+},
+{
+name = top;
+pos = (453,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(724,-11,o),
+(775,17,o),
+(818,126,c),
+(793,135,l),
+(761,63,o),
+(735,35,o),
+(713,35,cs),
+(702,35,o),
+(697,42,o),
+(697,55,cs),
+(697,61,o),
+(698,72,o),
+(702,89,cs),
+(766,338,ls),
+(770,355,o),
+(772,370,o),
+(772,382,cs),
+(772,438,o),
+(722,462,o),
+(672,462,cs),
+(597,462,o),
+(543,408,o),
+(507,351,c),
+(500,351,l),
+(478,229,l),
+(502,340,o),
+(587,416,o),
+(620,416,cs),
+(631,416,o),
+(638,408,o),
+(638,394,cs),
+(638,384,o),
+(635,365,o),
+(633,356,cs),
+(569,107,ls),
+(567,98,o),
+(565,88,o),
+(565,75,cs),
+(565,19,o),
+(601,-11,o),
+(663,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(275,450,l),
+(138,450,l),
+(35,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(435,0,l),
+(502,339,ls),
+(519,425,o),
+(472,462,o),
+(410,462,cs),
+(345,462,o),
+(297,422,o),
+(261,371,c),
+(254,371,l),
+(222,246,l),
+(247,347,o),
+(326,416,o),
+(363,416,cs),
+(375,416,o),
+(381,408,o),
+(381,394,cs),
+(381,384,o),
+(378,365,o),
+(376,356,cs),
+(299,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(263,420,l),
+(263,450,l),
+(44,450,l),
+(44,420,l)
+);
+}
+);
+width = 801;
+}
+);
+unicode = 109;
+},
+{
+glyphname = n;
+kernLeft = n;
+kernRight = n;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (228,0);
+},
+{
+name = top;
+pos = (332,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(473,-13,o),
+(527,69,o),
+(566,157,c),
+(546,166,l),
+(504,73,o),
+(471,38,o),
+(442,38,cs),
+(428,38,o),
+(420,46,o),
+(420,63,cs),
+(420,69,o),
+(421,80,o),
+(425,97,cs),
+(485,336,ls),
+(489,353,o),
+(491,368,o),
+(491,381,cs),
+(491,438,o),
+(449,462,o),
+(398,462,cs),
+(324,462,o),
+(262,413,o),
+(222,361,c),
+(215,361,l),
+(187,234,l),
+(217,342,o),
+(292,420,o),
+(352,420,cs),
+(374,420,o),
+(389,410,o),
+(389,386,cs),
+(389,377,o),
+(387,369,o),
+(385,359,cs),
+(320,87,ls),
+(318,78,o),
+(316,67,o),
+(316,56,cs),
+(316,15,o),
+(345,-13,o),
+(392,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,0,l),
+(240,450,l),
+(133,450,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,425,l),
+(228,450,l),
+(39,450,l),
+(39,425,l)
+);
+}
+);
+width = 560;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (244,0);
+},
+{
+name = top;
+pos = (348,450);
+}
+);
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,450,l),
+(134,450,l),
+(26,0,l),
+(159,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(40,420,l),
+(259,420,l),
+(259,450,l),
+(40,450,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,229,l),
+(246,343,o),
+(346,416,o),
+(382,416,cs),
+(394,416,o),
+(401,408,o),
+(401,394,cs),
+(401,384,o),
+(398,365,o),
+(396,356,cs),
+(332,107,ls),
+(330,98,o),
+(328,88,o),
+(328,75,cs),
+(328,19,o),
+(364,-11,o),
+(426,-11,cs),
+(491,-11,o),
+(554,21,o),
+(600,146,c),
+(575,155,l),
+(539,69,o),
+(501,35,o),
+(476,35,cs),
+(465,35,o),
+(460,42,o),
+(460,55,cs),
+(460,61,o),
+(461,72,o),
+(465,89,cs),
+(529,338,ls),
+(533,355,o),
+(535,370,o),
+(535,382,cs),
+(535,438,o),
+(486,462,o),
+(433,462,cs),
+(353,462,o),
+(293,408,o),
+(253,351,c),
+(246,351,l)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(500,-11,o),
+(563,21,o),
+(609,146,c),
+(584,155,l),
+(548,69,o),
+(510,35,o),
+(485,35,cs),
+(474,35,o),
+(469,42,o),
+(469,55,cs),
+(469,61,o),
+(470,72,o),
+(474,89,cs),
+(538,338,ls),
+(542,355,o),
+(544,370,o),
+(544,382,cs),
+(544,438,o),
+(495,462,o),
+(442,462,cs),
+(362,462,o),
+(302,408,o),
+(262,351,c),
+(255,351,l),
+(224,229,l),
+(255,343,o),
+(355,416,o),
+(391,416,cs),
+(403,416,o),
+(410,408,o),
+(410,394,cs),
+(410,384,o),
+(407,365,o),
+(405,356,cs),
+(341,107,ls),
+(339,98,o),
+(337,88,o),
+(337,75,cs),
+(337,19,o),
+(373,-11,o),
+(435,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(280,450,l),
+(143,450,l),
+(35,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,420,l),
+(268,450,l),
+(49,450,l),
+(49,420,l)
+);
+}
+);
+width = 592;
+}
+);
+unicode = 110;
+},
+{
+glyphname = nacute;
+kernLeft = n;
+kernRight = n;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = n;
+},
+{
+alignment = -1;
+pos = (171,0);
+ref = acute;
+}
+);
+width = 560;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = n;
+},
+{
+alignment = -1;
+pos = (224,0);
+ref = acute;
+}
+);
+width = 592;
+}
+);
+unicode = 324;
+},
+{
+glyphname = napostrophe;
+kernRight = n;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = n;
+},
+{
+pos = (-62,3);
+ref = quoteright;
+}
+);
+width = 560;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = n;
+},
+{
+ref = quoteright;
+}
+);
+width = 592;
+}
+);
+unicode = 329;
+},
+{
+glyphname = ncaron;
+kernLeft = n;
+kernRight = n;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = n;
+},
+{
+alignment = -1;
+pos = (98,0);
+ref = caron;
+}
+);
+width = 560;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = n;
+},
+{
+alignment = -1;
+pos = (88,0);
+ref = caron;
+}
+);
+width = 592;
+}
+);
+unicode = 328;
+},
+{
+glyphname = ncommaaccent;
+kernLeft = n;
+kernRight = n;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = n;
+},
+{
+pos = (206,0);
+ref = commaaccentcomb;
+}
+);
+width = 560;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = n;
+},
+{
+pos = (226,0);
+ref = commaaccentcomb;
+}
+);
+width = 592;
+}
+);
+unicode = 326;
+},
+{
+glyphname = ndotaccent;
+kernLeft = n;
+kernRight = n;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = n;
+},
+{
+alignment = -1;
+pos = (179,0);
+ref = dotaccent;
+}
+);
+width = 560;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = n;
+},
+{
+alignment = -1;
+pos = (189,0);
+ref = dotaccent;
+}
+);
+width = 592;
+}
+);
+unicode = 7749;
+},
+{
+glyphname = eng;
+kernLeft = n;
+lastChange = "2016-08-22 11:45:51 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,-324,o),
+(346,-257,o),
+(375,-134,cs),
+(485,336,ls),
+(489,354,o),
+(491,368,o),
+(491,380,cs),
+(491,438,o),
+(449,462,o),
+(398,462,cs),
+(324,462,o),
+(265,416,o),
+(225,364,c),
+(214,364,l),
+(187,272,l),
+(243,363,o),
+(295,418,o),
+(352,418,cs),
+(374,418,o),
+(389,408,o),
+(389,385,cs),
+(389,377,o),
+(386,369,o),
+(385,359,cs),
+(271,-152,ls),
+(241,-288,o),
+(210,-294,o),
+(195,-294,cs),
+(181,-294,o),
+(173,-290,o),
+(173,-278,cs),
+(173,-270,o),
+(176,-256,o),
+(176,-246,cs),
+(176,-223,o),
+(158,-203,o),
+(129,-203,cs),
+(101,-203,o),
+(80,-221,o),
+(80,-251,cs),
+(80,-297,o),
+(129,-324,o),
+(179,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(129,0,l),
+(240,450,l),
+(133,450,l),
+(26,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,425,l),
+(220,450,l),
+(39,450,l),
+(39,425,l)
+);
+}
+);
+width = 537;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,-324,o),
+(404,-257,o),
+(461,-3,cs),
+(538,338,ls),
+(542,355,o),
+(544,370,o),
+(544,382,cs),
+(544,438,o),
+(496,462,o),
+(442,462,cs),
+(362,462,o),
+(302,408,o),
+(262,351,c),
+(255,351,l),
+(224,229,l),
+(255,343,o),
+(355,416,o),
+(391,416,cs),
+(403,416,o),
+(410,408,o),
+(410,394,cs),
+(410,384,o),
+(407,365,o),
+(405,356,cs),
+(300,-110,ls),
+(261,-285,o),
+(239,-287,o),
+(231,-287,cs),
+(217,-287,o),
+(213,-280,o),
+(213,-272,cs),
+(213,-263,o),
+(217,-252,o),
+(217,-236,cs),
+(217,-197,o),
+(195,-180,o),
+(161,-180,cs),
+(122,-180,o),
+(99,-203,o),
+(99,-237,cs),
+(99,-289,o),
+(151,-324,o),
+(213,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,0,l),
+(280,450,l),
+(143,450,l),
+(35,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,420,l),
+(268,450,l),
+(49,450,l),
+(49,420,l)
+);
+}
+);
+width = 575;
+}
+);
+unicode = 331;
+},
+{
+glyphname = nj;
+kernLeft = n;
+kernRight = j;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = n;
+},
+{
+pos = (560,0);
+ref = j;
+}
+);
+width = 851;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = n;
+},
+{
+pos = (592,0);
+ref = j;
+}
+);
+width = 879;
+}
+);
+unicode = 460;
+},
+{
+glyphname = ntilde;
+kernLeft = n;
+kernRight = n;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = n;
+},
+{
+alignment = -1;
+pos = (60,0);
+ref = tilde;
+}
+);
+width = 560;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = n;
+},
+{
+alignment = -1;
+pos = (62,0);
+ref = tilde;
+}
+);
+width = 592;
+}
+);
+unicode = 241;
+},
+{
+glyphname = o;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:06:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (210,0);
+},
+{
+name = center;
+pos = (262,225);
+},
+{
+name = ogonek;
+pos = (420,10);
+},
+{
+name = top;
+pos = (314,450);
+},
+{
+name = topright;
+pos = (459,397);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,-13,o),
+(496,138,o),
+(496,280,cs),
+(496,384,o),
+(422,462,o),
+(313,462,cs),
+(164,462,o),
+(28,316,o),
+(28,174,cs),
+(28,70,o),
+(101,-13,o),
+(211,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,12,o),
+(141,52,o),
+(141,127,cs),
+(141,261,o),
+(201,437,o),
+(308,437,cs),
+(365,437,o),
+(382,388,o),
+(382,317,cs),
+(382,183,o),
+(322,12,o),
+(213,12,cs)
+);
+}
+);
+width = 524;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (226,0);
+},
+{
+name = center;
+pos = (278,225);
+},
+{
+name = ogonek;
+pos = (448,10);
+},
+{
+name = top;
+pos = (330,450);
+},
+{
+name = topright;
+pos = (482,396);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,-13,o),
+(533,137,o),
+(533,280,cs),
+(533,383,o),
+(451,462,o),
+(333,462,cs),
+(169,462,o),
+(23,312,o),
+(23,169,cs),
+(23,66,o),
+(104,-13,o),
+(222,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,22,o),
+(172,53,o),
+(172,112,cs),
+(172,249,o),
+(228,427,o),
+(330,427,cs),
+(372,427,o),
+(383,396,o),
+(383,337,cs),
+(383,200,o),
+(327,22,o),
+(225,22,cs)
+);
+}
+);
+width = 556;
+}
+);
+unicode = 111;
+},
+{
+glyphname = oacute;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-45,0);
+ref = acutecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-75,0);
+ref = acutecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 243;
+},
+{
+glyphname = obreve;
+kernLeft = o;
+kernRight = o;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (80,0);
+ref = breve;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (77,0);
+ref = breve;
+}
+);
+width = 556;
+}
+);
+unicode = 335;
+},
+{
+glyphname = ocircumflex;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-58,0);
+ref = circumflexcomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-15,0);
+ref = circumflexcomb;
+}
+);
+width = 556;
+}
+);
+unicode = 244;
+},
+{
+glyphname = ocircumflexacute;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-54,0);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-37,0);
+ref = circumflexcomb_acutecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7889;
+},
+{
+glyphname = ocircumflexdotbelow;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-31,0);
+ref = dotbelowcomb;
+},
+{
+pos = (-58,0);
+ref = circumflexcomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-24,0);
+ref = dotbelowcomb;
+},
+{
+pos = (-15,0);
+ref = circumflexcomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7897;
+},
+{
+glyphname = ocircumflexgrave;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-50,0);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-33,0);
+ref = circumflexcomb_gravecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7891;
+},
+{
+glyphname = ocircumflexhookabove;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-56,0);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-36,0);
+ref = circumflexcomb_hookabovecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7893;
+},
+{
+glyphname = ocircumflextilde;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-54,0);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-39,0);
+ref = circumflexcomb_tildecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7895;
+},
+{
+glyphname = odblgrave;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (33,0);
+ref = dblgravecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (43,0);
+ref = dblgravecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 525;
+},
+{
+glyphname = odieresis;
+kernLeft = o;
+kernRight = o;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (114,0);
+ref = dieresis;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (99,0);
+ref = dieresis;
+}
+);
+width = 556;
+}
+);
+unicode = 246;
+},
+{
+glyphname = odotbelow;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-31,0);
+ref = dotbelowcomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-24,0);
+ref = dotbelowcomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7885;
+},
+{
+glyphname = ograve;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-34,0);
+ref = gravecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (14,0);
+ref = gravecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 242;
+},
+{
+glyphname = ohookabove;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-9,0);
+ref = hookabovecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-2,0);
+ref = hookabovecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7887;
+},
+{
+glyphname = ohorn;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (154,-53);
+ref = horncomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (169,-54);
+ref = horncomb;
+}
+);
+width = 556;
+}
+);
+unicode = 417;
+},
+{
+glyphname = ohornacute;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (-45,0);
+ref = acutecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (-75,0);
+ref = acutecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7899;
+},
+{
+glyphname = ohorndotbelow;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (-31,0);
+ref = dotbelowcomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (-24,0);
+ref = dotbelowcomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7907;
+},
+{
+glyphname = ohorngrave;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (-34,0);
+ref = gravecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (14,0);
+ref = gravecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7901;
+},
+{
+glyphname = ohornhookabove;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (-9,0);
+ref = hookabovecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (-2,0);
+ref = hookabovecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7903;
+},
+{
+glyphname = ohorntilde;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (-45,0);
+ref = tildecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = ohorn;
+},
+{
+pos = (-35,0);
+ref = tildecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 7905;
+},
+{
+glyphname = ohungarumlaut;
+kernLeft = o;
+kernRight = o;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (68,0);
+ref = hungarumlaut;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (53,0);
+ref = hungarumlaut;
+}
+);
+width = 556;
+}
+);
+unicode = 337;
+},
+{
+glyphname = oinvertedbreve;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (100,0);
+ref = breveinvertedcomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (110,0);
+ref = breveinvertedcomb;
+}
+);
+width = 556;
+}
+);
+unicode = 527;
+},
+{
+glyphname = omacron;
+kernLeft = o;
+kernRight = o;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (75,0);
+ref = macron;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (82,0);
+ref = macron;
+}
+);
+width = 556;
+}
+);
+unicode = 333;
+},
+{
+glyphname = oogonek;
+kernLeft = o;
+kernRight = o;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (144,-12);
+ref = ogonek;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = o;
+},
+{
+alignment = -1;
+pos = (152,0);
+ref = ogonek;
+}
+);
+width = 556;
+}
+);
+unicode = 491;
+},
+{
+glyphname = oslash;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(34,-53,l),
+(102,20,l),
+(132,-1,o),
+(169,-13,o),
+(212,-13,cs),
+(360,-13,o),
+(497,138,o),
+(497,280,cs),
+(497,326,o),
+(482,368,o),
+(456,399,c),
+(534,483,l),
+(496,483,l),
+(436,419,l),
+(405,446,o),
+(363,462,o),
+(314,462,cs),
+(165,462,o),
+(28,316,o),
+(28,174,cs),
+(28,120,o),
+(47,72,o),
+(81,38,c),
+(-4,-53,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,12,o),
+(156,31,o),
+(147,69,c),
+(383,321,l),
+(383,156,o),
+(311,12,o),
+(214,12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,294,o),
+(214,437,o),
+(309,437,cs),
+(354,437,o),
+(374,406,o),
+(380,359,c),
+(142,104,l)
+);
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(23,-53,l),
+(99,22,l),
+(132,0,o),
+(174,-13,o),
+(222,-13,cs),
+(386,-13,o),
+(533,137,o),
+(533,280,cs),
+(533,328,o),
+(515,372,o),
+(483,404,c),
+(563,483,l),
+(505,483,l),
+(451,429,l),
+(419,450,o),
+(379,462,o),
+(333,462,cs),
+(169,462,o),
+(23,312,o),
+(23,169,cs),
+(23,122,o),
+(39,80,o),
+(68,49,c),
+(-34,-53,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,22,o),
+(174,47,o),
+(172,95,c),
+(382,303,l),
+(374,172,o),
+(319,22,o),
+(225,22,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(183,282,o),
+(238,427,o),
+(330,427,cs),
+(366,427,o),
+(379,404,o),
+(382,361,c),
+(173,153,l)
+);
+}
+);
+width = 556;
+}
+);
+unicode = 248;
+},
+{
+glyphname = oslashacute;
+kernLeft = o;
+kernRight = o;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = oslash;
+},
+{
+alignment = -1;
+pos = (189,0);
+ref = acute;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = oslash;
+},
+{
+alignment = -1;
+pos = (194,0);
+ref = acute;
+}
+);
+width = 556;
+}
+);
+unicode = 511;
+},
+{
+glyphname = otilde;
+kernLeft = o;
+kernRight = o;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-45,0);
+ref = tildecomb;
+}
+);
+width = 524;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = o;
+},
+{
+pos = (-35,0);
+ref = tildecomb;
+}
+);
+width = 556;
+}
+);
+unicode = 245;
+},
+{
+glyphname = oe;
+kernLeft = o;
+kernRight = e;
+lastChange = "2016-08-22 11:48:08 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,-13,o),
+(497,132,o),
+(497,276,cs),
+(497,382,o),
+(423,462,o),
+(316,462,cs),
+(166,462,o),
+(28,307,o),
+(28,168,cs),
+(28,66,o),
+(102,-13,o),
+(211,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,12,o),
+(142,51,o),
+(142,122,cs),
+(142,254,o),
+(204,437,o),
+(311,437,cs),
+(366,437,o),
+(383,388,o),
+(383,314,cs),
+(383,174,o),
+(322,12,o),
+(213,12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(661,-13,o),
+(727,34,o),
+(775,119,c),
+(755,133,l),
+(703,47,o),
+(641,17,o),
+(577,17,cs),
+(512,17,o),
+(485,48,o),
+(485,136,cs),
+(485,259,o),
+(537,432,o),
+(637,432,cs),
+(673,432,o),
+(698,409,o),
+(698,352,cs),
+(698,277,o),
+(655,219,o),
+(536,219,cs),
+(509,219,o),
+(486,222,o),
+(463,229,c),
+(458,204,l),
+(471,201,o),
+(531,193,o),
+(577,193,cs),
+(697,193,o),
+(786,247,o),
+(786,338,cs),
+(786,412,o),
+(727,462,o),
+(644,462,cs),
+(508,462,o),
+(371,327,o),
+(371,184,cs),
+(371,83,o),
+(439,-13,o),
+(570,-13,cs)
+);
+}
+);
+width = 798;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(385,-13,o),
+(532,133,o),
+(532,274,cs),
+(532,379,o),
+(451,462,o),
+(332,462,cs),
+(173,462,o),
+(23,312,o),
+(23,170,cs),
+(23,65,o),
+(105,-13,o),
+(223,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(184,22,o),
+(173,53,o),
+(173,112,cs),
+(173,249,o),
+(231,427,o),
+(330,427,cs),
+(367,427,o),
+(382,403,o),
+(382,332,cs),
+(382,195,o),
+(326,22,o),
+(226,22,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(660,-11,o),
+(746,42,o),
+(799,129,c),
+(774,148,l),
+(712,57,o),
+(640,29,o),
+(575,29,cs),
+(519,29,o),
+(495,50,o),
+(504,105,cs),
+(545,384,o),
+(602,432,o),
+(645,432,cs),
+(682,432,o),
+(702,398,o),
+(702,352,cs),
+(702,285,o),
+(659,232,o),
+(565,232,cs),
+(513,232,o),
+(490,232,o),
+(467,242,c),
+(462,207,l),
+(473,204,o),
+(546,196,o),
+(596,196,cs),
+(740,196,o),
+(815,261,o),
+(815,337,cs),
+(815,409,o),
+(746,462,o),
+(656,462,cs),
+(509,462,o),
+(367,319,o),
+(367,177,cs),
+(367,79,o),
+(435,-11,o),
+(562,-11,cs)
+);
+}
+);
+width = 836;
+}
+);
+unicode = 339;
+},
+{
+glyphname = p;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (236,0);
+},
+{
+name = top;
+pos = (340,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(71,-314,l),
+(243,450,l),
+(136,450,l),
+(-32,-314,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,-314,l),
+(171,-289,l),
+(-112,-289,l),
+(-112,-314,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,-13,o),
+(527,127,o),
+(527,282,cs),
+(527,395,o),
+(452,462,o),
+(368,462,cs),
+(309,462,o),
+(261,429,o),
+(232,386,c),
+(225,386,l),
+(208,298,l),
+(250,394,o),
+(305,430,o),
+(352,430,cs),
+(390,430,o),
+(413,407,o),
+(413,341,cs),
+(413,241,o),
+(360,16,o),
+(249,16,cs),
+(204,16,o),
+(170,54,o),
+(170,106,cs),
+(170,116,o),
+(170,125,o),
+(172,138,c),
+(152,50,l),
+(159,50,l),
+(177,11,o),
+(210,-13,o),
+(262,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,425,l),
+(231,450,l),
+(42,450,l),
+(42,425,l)
+);
+}
+);
+width = 575;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (247,0);
+},
+{
+name = top;
+pos = (351,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(91,-282,l),
+(269,450,l),
+(132,450,l),
+(-42,-282,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(189,-309,l),
+(189,-279,l),
+(-115,-279,l),
+(-115,-309,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(441,-11,o),
+(564,130,o),
+(564,277,cs),
+(564,394,o),
+(487,462,o),
+(400,462,cs),
+(332,462,o),
+(279,420,o),
+(254,383,c),
+(247,383,l),
+(215,245,l),
+(249,375,o),
+(333,421,o),
+(380,421,cs),
+(409,421,o),
+(422,402,o),
+(422,349,cs),
+(422,253,o),
+(380,28,o),
+(274,28,cs),
+(226,28,o),
+(194,74,o),
+(194,128,cs),
+(194,137,o),
+(195,150,o),
+(197,163,c),
+(170,62,l),
+(177,62,l),
+(197,17,o),
+(232,-11,o),
+(296,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,420,l),
+(257,450,l),
+(38,450,l),
+(38,420,l)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 112;
+},
+{
+glyphname = thorn;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,-13,o),
+(507,124,o),
+(507,278,cs),
+(507,394,o),
+(436,462,o),
+(354,462,cs),
+(307,462,o),
+(266,441,o),
+(241,414,c),
+(234,414,l),
+(213,326,l),
+(249,397,o),
+(291,430,o),
+(341,430,cs),
+(390,430,o),
+(400,394,o),
+(400,333,cs),
+(400,169,o),
+(316,16,o),
+(236,16,cs),
+(194,16,o),
+(167,57,o),
+(167,93,cs),
+(167,105,o),
+(170,124,o),
+(173,138,cs),
+(321,754,l),
+(214,754,l),
+(140,440,l),
+(77,163,o),
+(75,147,o),
+(75,131,cs),
+(75,49,o),
+(129,-13,o),
+(225,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,-314,l),
+(171,-289,l),
+(-112,-289,l),
+(-112,-314,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(71,-314,l),
+(243,440,l),
+(140,440,l),
+(-32,-314,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(309,729,l),
+(309,754,l),
+(114,754,l),
+(114,729,l)
+);
+}
+);
+width = 575;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(396,-13,o),
+(536,129,o),
+(536,287,cs),
+(536,408,o),
+(449,462,o),
+(377,462,cs),
+(324,462,o),
+(278,431,o),
+(253,390,c),
+(246,390,l),
+(222,292,l),
+(257,380,o),
+(311,425,o),
+(355,425,cs),
+(383,425,o),
+(391,407,o),
+(391,352,cs),
+(391,197,o),
+(326,26,o),
+(240,26,cs),
+(210,26,o),
+(187,46,o),
+(187,93,cs),
+(187,110,o),
+(190,134,o),
+(193,148,cs),
+(332,754,l),
+(205,754,l),
+(74,204,ls),
+(67,173,o),
+(66,146,o),
+(66,135,cs),
+(66,48,o),
+(129,-13,o),
+(233,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(190,-309,l),
+(190,-279,l),
+(-114,-279,l),
+(-114,-309,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(92,-282,l),
+(193,148,l),
+(74,203,l),
+(-41,-282,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(320,724,l),
+(320,754,l),
+(105,754,l),
+(105,724,l)
+);
+}
+);
+width = 569;
+}
+);
+unicode = 254;
+},
+{
+glyphname = q;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (218,0);
+},
+{
+name = top;
+pos = (322,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,-314,l),
+(536,450,l),
+(429,450,l),
+(251,-314,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,-314,l),
+(438,-289,l),
+(171,-289,l),
+(171,-314,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(273,-13,o),
+(319,23,o),
+(345,70,c),
+(352,70,l),
+(364,170,l),
+(319,40,o),
+(265,19,o),
+(229,19,cs),
+(185,19,o),
+(157,50,o),
+(157,118,cs),
+(157,216,o),
+(215,433,o),
+(315,433,cs),
+(359,433,o),
+(396,391,o),
+(396,335,cs),
+(396,325,o),
+(396,313,o),
+(394,300,c),
+(416,391,l),
+(409,391,l),
+(391,433,o),
+(361,462,o),
+(305,462,cs),
+(184,462,o),
+(43,327,o),
+(43,172,cs),
+(43,57,o),
+(120,-13,o),
+(209,-13,cs)
+);
+}
+);
+width = 540;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (232,0);
+},
+{
+name = top;
+pos = (336,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(395,-282,l),
+(573,450,l),
+(436,450,l),
+(262,-282,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(479,-309,l),
+(479,-279,l),
+(176,-279,l),
+(176,-309,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,-11,o),
+(314,32,o),
+(340,70,c),
+(347,70,l),
+(379,208,l),
+(345,76,o),
+(266,30,o),
+(219,30,cs),
+(189,30,o),
+(177,48,o),
+(177,108,cs),
+(177,257,o),
+(252,423,o),
+(331,423,cs),
+(369,423,o),
+(405,385,o),
+(405,336,cs),
+(405,324,o),
+(403,315,o),
+(402,300,c),
+(425,391,l),
+(418,391,l),
+(395,439,o),
+(365,462,o),
+(312,462,cs),
+(181,462,o),
+(35,320,o),
+(35,166,cs),
+(35,54,o),
+(113,-11,o),
+(198,-11,cs)
+);
+}
+);
+width = 568;
+}
+);
+unicode = 113;
+},
+{
+glyphname = r;
+kernLeft = r;
+kernRight = r;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (161,0);
+},
+{
+name = top;
+pos = (265,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(155,0,l),
+(266,450,l),
+(159,450,l),
+(52,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(254,425,l),
+(254,450,l),
+(65,450,l),
+(65,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,301,o),
+(295,395,o),
+(326,395,cs),
+(346,395,o),
+(342,353,o),
+(388,353,cs),
+(425,353,o),
+(441,380,o),
+(441,407,cs),
+(441,438,o),
+(419,462,o),
+(384,462,cs),
+(335,462,o),
+(284,415,o),
+(248,358,c),
+(241,358,l),
+(203,195,l)
+);
+}
+);
+width = 425;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (167,0);
+},
+{
+name = top;
+pos = (271,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,0,l),
+(287,450,l),
+(150,450,l),
+(42,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(275,420,l),
+(275,450,l),
+(56,450,l),
+(56,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,244,o),
+(289,367,o),
+(326,367,cs),
+(348,367,o),
+(364,326,o),
+(407,326,cs),
+(447,326,o),
+(471,362,o),
+(471,392,cs),
+(471,420,o),
+(450,462,o),
+(399,462,cs),
+(355,462,o),
+(321,432,o),
+(272,367,c),
+(264,367,l),
+(217,174,l)
+);
+}
+);
+width = 437;
+}
+);
+unicode = 114;
+},
+{
+glyphname = racute;
+kernLeft = r;
+kernRight = r;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = r;
+},
+{
+alignment = -1;
+pos = (126,0);
+ref = acute;
+}
+);
+width = 425;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = r;
+},
+{
+alignment = -1;
+pos = (153,0);
+ref = acute;
+}
+);
+width = 437;
+}
+);
+unicode = 341;
+},
+{
+glyphname = rcaron;
+kernLeft = r;
+kernRight = r;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = r;
+},
+{
+alignment = -1;
+pos = (34,0);
+ref = caron;
+}
+);
+width = 425;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = r;
+},
+{
+alignment = -1;
+pos = (4,0);
+ref = caron;
+}
+);
+width = 437;
+}
+);
+unicode = 345;
+},
+{
+glyphname = rcommaaccent;
+kernLeft = r;
+kernRight = r;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = r;
+},
+{
+pos = (88,0);
+ref = commaaccentcomb;
+}
+);
+width = 425;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = r;
+},
+{
+pos = (130,0);
+ref = commaaccentcomb;
+}
+);
+width = 437;
+}
+);
+unicode = 343;
+},
+{
+glyphname = rdblgrave;
+kernLeft = r;
+kernRight = r;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = r;
+},
+{
+pos = (-41,0);
+ref = dblgravecomb;
+}
+);
+width = 425;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = r;
+},
+{
+pos = (-62,0);
+ref = dblgravecomb;
+}
+);
+width = 437;
+}
+);
+unicode = 529;
+},
+{
+glyphname = rdotbelow;
+kernLeft = r;
+kernRight = r;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = r;
+},
+{
+alignment = -1;
+pos = (111,0);
+ref = dotbelow;
+}
+);
+width = 425;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = r;
+},
+{
+alignment = -1;
+pos = (148,0);
+ref = dotbelow;
+}
+);
+width = 437;
+}
+);
+unicode = 7771;
+},
+{
+glyphname = rinvertedbreve;
+kernLeft = r;
+kernRight = r;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = r;
+},
+{
+pos = (43,0);
+ref = breveinvertedcomb;
+}
+);
+width = 425;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = r;
+},
+{
+pos = (52,0);
+ref = breveinvertedcomb;
+}
+);
+width = 437;
+}
+);
+unicode = 531;
+},
+{
+glyphname = s;
+kernLeft = s;
+kernRight = s;
+lastChange = "2016-08-22 13:50:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (136,0);
+},
+{
+name = top;
+pos = (240,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(241,-13,o),
+(328,52,o),
+(328,144,cs),
+(328,281,o),
+(143,277,o),
+(143,367,cs),
+(143,407,o),
+(180,427,o),
+(230,427,cs),
+(266,427,o),
+(289,417,o),
+(289,398,cs),
+(289,382,o),
+(273,374,o),
+(273,354,cs),
+(273,335,o),
+(286,324,o),
+(306,324,cs),
+(333,324,o),
+(352,344,o),
+(352,375,cs),
+(352,420,o),
+(311,454,o),
+(235,454,cs),
+(130,454,o),
+(70,390,o),
+(70,317,cs),
+(70,186,o),
+(257,190,o),
+(257,95,cs),
+(257,52,o),
+(218,17,o),
+(137,17,cs),
+(86,17,o),
+(64,31,o),
+(64,48,cs),
+(64,64,o),
+(82,78,o),
+(82,102,cs),
+(82,122,o),
+(69,135,o),
+(45,135,cs),
+(16,135,o),
+(-4,116,o),
+(-4,83,cs),
+(-4,32,o),
+(46,-13,o),
+(135,-13,cs)
+);
+}
+);
+width = 375;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (154,0);
+},
+{
+name = top;
+pos = (258,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,-11,o),
+(356,51,o),
+(356,146,cs),
+(356,292,o),
+(159,321,o),
+(159,388,cs),
+(159,418,o),
+(197,432,o),
+(231,432,cs),
+(253,432,o),
+(276,426,o),
+(276,408,cs),
+(276,398,o),
+(270,385,o),
+(270,371,cs),
+(270,346,o),
+(290,322,o),
+(326,322,cs),
+(362,322,o),
+(380,346,o),
+(380,374,cs),
+(380,425,o),
+(317,462,o),
+(242,462,cs),
+(141,462,o),
+(68,396,o),
+(68,315,cs),
+(68,182,o),
+(262,150,o),
+(262,75,cs),
+(262,48,o),
+(236,23,o),
+(172,23,cs),
+(125,23,o),
+(110,36,o),
+(110,50,cs),
+(110,64,o),
+(125,73,o),
+(125,96,cs),
+(125,123,o),
+(105,151,o),
+(64,151,cs),
+(30,151,o),
+(0,131,o),
+(0,90,cs),
+(0,32,o),
+(61,-11,o),
+(157,-11,cs)
+);
+}
+);
+width = 412;
+}
+);
+unicode = 115;
+},
+{
+glyphname = sacute;
+kernLeft = s;
+kernRight = s;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (82,0);
+ref = acute;
+}
+);
+width = 375;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (147,0);
+ref = acute;
+}
+);
+width = 412;
+}
+);
+unicode = 347;
+},
+{
+glyphname = scaron;
+kernLeft = s;
+kernRight = s;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (23,0);
+ref = caron;
+}
+);
+width = 375;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (21,0);
+ref = caron;
+}
+);
+width = 412;
+}
+);
+unicode = 353;
+},
+{
+glyphname = scedilla;
+kernLeft = s;
+kernRight = s;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (55,0);
+ref = cedilla;
+}
+);
+width = 375;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (98,0);
+ref = cedilla;
+}
+);
+width = 412;
+}
+);
+unicode = 351;
+},
+{
+glyphname = scircumflex;
+kernLeft = s;
+kernRight = s;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (35,0);
+ref = circumflex;
+}
+);
+width = 375;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (30,0);
+ref = circumflex;
+}
+);
+width = 412;
+}
+);
+unicode = 349;
+},
+{
+glyphname = scommaaccent;
+kernLeft = s;
+kernRight = s;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = s;
+},
+{
+pos = (100,0);
+ref = commaaccentcomb;
+}
+);
+width = 375;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = s;
+},
+{
+pos = (119,0);
+ref = commaaccentcomb;
+}
+);
+width = 412;
+}
+);
+unicode = 537;
+},
+{
+glyphname = sdotbelow;
+kernLeft = s;
+kernRight = s;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (115,0);
+ref = dotbelow;
+}
+);
+width = 375;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = s;
+},
+{
+alignment = -1;
+pos = (138,0);
+ref = dotbelow;
+}
+);
+width = 412;
+}
+);
+unicode = 7779;
+},
+{
+glyphname = germandbls;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-43,-324,o),
+(66,-304,o),
+(130,-1,cs),
+(261,615,ls),
+(278,694,o),
+(314,736,o),
+(373,736,cs),
+(416,736,o),
+(436,714,o),
+(436,663,cs),
+(436,600,o),
+(405,448,o),
+(310,448,cs),
+(272,448,l),
+(267,422,l),
+(304,422,ls),
+(364,422,o),
+(386,393,o),
+(386,319,cs),
+(386,202,o),
+(332,19,o),
+(267,19,cs),
+(256,19,o),
+(246,24,o),
+(246,32,cs),
+(246,46,o),
+(275,54,o),
+(275,84,cs),
+(275,107,o),
+(257,120,o),
+(232,120,cs),
+(198,120,o),
+(180,95,o),
+(180,63,cs),
+(180,19,o),
+(213,-6,o),
+(268,-6,cs),
+(409,-6,o),
+(506,157,o),
+(506,274,cs),
+(506,367,o),
+(444,428,o),
+(366,435,c),
+(366,439,l),
+(462,464,o),
+(541,530,o),
+(541,619,cs),
+(541,697,o),
+(480,763,o),
+(378,763,cs),
+(268,763,o),
+(166,687,o),
+(137,550,cs),
+(-10,-140,ls),
+(-36,-260,o),
+(-66,-294,o),
+(-108,-294,cs),
+(-128,-294,o),
+(-132,-287,o),
+(-132,-276,cs),
+(-132,-267,o),
+(-129,-256,o),
+(-129,-247,cs),
+(-129,-223,o),
+(-148,-203,o),
+(-176,-203,cs),
+(-204,-203,o),
+(-225,-223,o),
+(-225,-252,cs),
+(-225,-288,o),
+(-193,-324,o),
+(-107,-324,cs)
+);
+}
+);
+width = 557;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(2,-324,o),
+(126,-176,o),
+(200,175,cs),
+(293,615,ls),
+(309,693,o),
+(347,731,o),
+(403,731,cs),
+(441,731,o),
+(467,713,o),
+(467,656,cs),
+(467,594,o),
+(437,450,o),
+(343,450,cs),
+(305,450,l),
+(298,418,l),
+(335,418,ls),
+(388,418,o),
+(417,383,o),
+(417,309,cs),
+(417,210,o),
+(366,24,o),
+(295,24,cs),
+(285,24,o),
+(280,28,o),
+(280,38,cs),
+(280,63,o),
+(315,69,o),
+(315,101,cs),
+(315,125,o),
+(296,135,o),
+(274,135,cs),
+(235,135,o),
+(213,104,o),
+(213,68,cs),
+(213,28,o),
+(239,-6,o),
+(313,-6,cs),
+(468,-6,o),
+(565,143,o),
+(565,263,cs),
+(565,354,o),
+(508,428,o),
+(424,435,c),
+(424,439,l),
+(522,465,o),
+(598,532,o),
+(598,622,cs),
+(598,712,o),
+(521,763,o),
+(406,763,cs),
+(266,763,o),
+(150,687,o),
+(121,550,cs),
+(11,33,ls),
+(-53,-268,o),
+(-69,-289,o),
+(-102,-289,cs),
+(-117,-289,o),
+(-125,-285,o),
+(-125,-272,cs),
+(-125,-256,o),
+(-112,-245,o),
+(-112,-224,cs),
+(-112,-198,o),
+(-132,-172,o),
+(-172,-172,cs),
+(-213,-172,o),
+(-234,-199,o),
+(-234,-236,cs),
+(-234,-279,o),
+(-205,-324,o),
+(-131,-324,cs)
+);
+}
+);
+width = 589;
+}
+);
+unicode = 223;
+},
+{
+glyphname = t;
+kernLeft = t;
+kernRight = t;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (112,0);
+},
+{
+name = center;
+pos = (164,225);
+},
+{
+name = top;
+pos = (216,450);
+},
+{
+name = topright;
+pos = (360,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,-13,o),
+(270,73,o),
+(309,157,c),
+(289,166,l),
+(243,73,o),
+(207,38,o),
+(175,38,cs),
+(161,38,o),
+(153,45,o),
+(153,63,cs),
+(153,69,o),
+(154,80,o),
+(158,97,cs),
+(275,563,l),
+(168,563,l),
+(53,87,ls),
+(51,78,o),
+(49,67,o),
+(49,56,cs),
+(49,15,o),
+(77,-13,o),
+(126,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,425,l),
+(336,450,l),
+(69,450,l),
+(69,425,l)
+);
+}
+);
+width = 328;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (122,0);
+},
+{
+name = center;
+pos = (174,225);
+},
+{
+name = top;
+pos = (226,450);
+},
+{
+name = topright;
+pos = (380,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(216,-11,o),
+(293,40,o),
+(332,142,c),
+(307,151,l),
+(266,64,o),
+(221,36,o),
+(196,36,cs),
+(183,36,o),
+(176,43,o),
+(176,55,cs),
+(176,59,o),
+(177,70,o),
+(181,87,cs),
+(293,574,l),
+(159,574,l),
+(59,132,ls),
+(55,114,o),
+(50,84,o),
+(50,66,cs),
+(50,26,o),
+(75,-11,o),
+(140,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,420,l),
+(360,450,l),
+(64,450,l),
+(64,420,l)
+);
+}
+);
+width = 348;
+}
+);
+unicode = 116;
+},
+{
+glyphname = tbar;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,277,l),
+(312,312,l),
+(19,312,l),
+(19,277,l)
+);
+},
+{
+ref = t;
+}
+);
+width = 328;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,277,l),
+(332,312,l),
+(39,312,l),
+(39,277,l)
+);
+},
+{
+ref = t;
+}
+);
+width = 348;
+}
+);
+unicode = 359;
+},
+{
+glyphname = tcaron;
+kernLeft = t;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = t;
+},
+{
+alignment = -1;
+pos = (170,38);
+ref = quoteright;
+}
+);
+width = 362;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = t;
+},
+{
+alignment = -1;
+pos = (201,54);
+ref = quoteright;
+}
+);
+width = 373;
+}
+);
+unicode = 357;
+},
+{
+glyphname = tcedilla;
+kernLeft = t;
+kernRight = t;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = t;
+},
+{
+alignment = -1;
+pos = (20,0);
+ref = cedilla;
+}
+);
+width = 328;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = t;
+},
+{
+alignment = -1;
+pos = (73,0);
+ref = cedilla;
+}
+);
+width = 348;
+}
+);
+unicode = 355;
+},
+{
+glyphname = tcommaaccent;
+kernLeft = t;
+kernRight = t;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = t;
+},
+{
+pos = (97,0);
+ref = commaaccentcomb;
+}
+);
+width = 328;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = t;
+},
+{
+pos = (141,0);
+ref = commaaccentcomb;
+}
+);
+width = 348;
+}
+);
+unicode = 539;
+},
+{
+glyphname = tdotbelow;
+kernLeft = t;
+kernRight = t;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = t;
+},
+{
+alignment = -1;
+pos = (102,0);
+ref = dotbelow;
+}
+);
+width = 328;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = t;
+},
+{
+alignment = -1;
+pos = (112,0);
+ref = dotbelow;
+}
+);
+width = 348;
+}
+);
+unicode = 7789;
+},
+{
+glyphname = u;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:07:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (234,0);
+},
+{
+name = ogonek;
+pos = (462,10);
+},
+{
+name = top;
+pos = (338,450);
+},
+{
+name = topright;
+pos = (550,397);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,-12,o),
+(285,41,o),
+(327,96,c),
+(334,96,l),
+(356,216,l),
+(327,113,o),
+(257,32,o),
+(195,32,cs),
+(174,32,o),
+(158,42,o),
+(158,65,cs),
+(158,73,o),
+(160,81,o),
+(162,91,cs),
+(248,450,l),
+(144,450,l),
+(62,114,ls),
+(58,97,o),
+(56,82,o),
+(56,70,cs),
+(56,12,o),
+(99,-12,o),
+(150,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,425,l),
+(224,450,l),
+(65,450,l),
+(65,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,-12,o),
+(523,45,o),
+(564,142,c),
+(544,151,l),
+(507,73,o),
+(472,30,o),
+(444,30,cs),
+(430,30,o),
+(424,41,o),
+(424,60,cs),
+(424,77,o),
+(429,106,o),
+(439,147,cs),
+(514,450,l),
+(412,450,l),
+(341,154,ls),
+(334,125,o),
+(331,101,o),
+(331,82,cs),
+(331,9,o),
+(373,-12,o),
+(412,-12,cs)
+);
+}
+);
+width = 571;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (247,0);
+},
+{
+name = ogonek;
+pos = (486,10);
+},
+{
+name = top;
+pos = (351,450);
+},
+{
+name = topright;
+pos = (590,397);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,-11,o),
+(292,43,o),
+(332,98,c),
+(339,98,l),
+(370,220,l),
+(339,108,o),
+(239,35,o),
+(203,35,cs),
+(191,35,o),
+(184,43,o),
+(184,57,cs),
+(184,67,o),
+(187,86,o),
+(189,95,cs),
+(280,450,l),
+(143,450,l),
+(56,113,ls),
+(52,96,o),
+(50,81,o),
+(50,69,cs),
+(50,13,o),
+(99,-11,o),
+(152,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,420,l),
+(215,450,l),
+(41,450,l),
+(41,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(513,-11,o),
+(576,69,o),
+(602,152,c),
+(577,161,l),
+(540,69,o),
+(499,41,o),
+(479,41,cs),
+(472,41,o),
+(467,45,o),
+(467,54,cs),
+(467,58,o),
+(468,70,o),
+(472,87,cs),
+(559,450,l),
+(425,450,l),
+(351,153,ls),
+(338,100,o),
+(335,86,o),
+(335,70,cs),
+(335,15,o),
+(370,-11,o),
+(422,-11,cs)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 117;
+},
+{
+glyphname = uacute;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (-21,0);
+ref = acutecomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (-54,0);
+ref = acutecomb;
+}
+);
+width = 598;
+}
+);
+unicode = 250;
+},
+{
+glyphname = ubreve;
+kernLeft = u;
+kernRight = u;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (89,0);
+ref = breve;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (97,0);
+ref = breve;
+}
+);
+width = 598;
+}
+);
+unicode = 365;
+},
+{
+glyphname = ucircumflex;
+kernLeft = u;
+kernRight = u;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (100,0);
+ref = circumflex;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (110,0);
+ref = circumflex;
+}
+);
+width = 598;
+}
+);
+unicode = 251;
+},
+{
+glyphname = udblgrave;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (-38,0);
+ref = dblgravecomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (5,0);
+ref = dblgravecomb;
+}
+);
+width = 598;
+}
+);
+unicode = 533;
+},
+{
+glyphname = udieresis;
+kernLeft = u;
+kernRight = u;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (92,0);
+ref = dieresis;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (121,0);
+ref = dieresis;
+}
+);
+width = 598;
+}
+);
+unicode = 252;
+},
+{
+glyphname = udotbelow;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:06:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (-7,0);
+ref = dotbelowcomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (-3,0);
+ref = dotbelowcomb;
+}
+);
+width = 598;
+}
+);
+unicode = 7909;
+},
+{
+glyphname = ugrave;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (-10,0);
+ref = gravecomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (35,0);
+ref = gravecomb;
+}
+);
+width = 598;
+}
+);
+unicode = 249;
+},
+{
+glyphname = uhookabove;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (15,0);
+ref = hookabovecomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (19,0);
+ref = hookabovecomb;
+}
+);
+width = 598;
+}
+);
+unicode = 7911;
+},
+{
+glyphname = uhorn;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (245,-53);
+ref = horncomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (277,-53);
+ref = horncomb;
+}
+);
+width = 598;
+}
+);
+unicode = 432;
+},
+{
+glyphname = uhornacute;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (-21,0);
+ref = acutecomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (-54,0);
+ref = acutecomb;
+}
+);
+width = 598;
+}
+);
+unicode = 7913;
+},
+{
+glyphname = uhorndotbelow;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (-7,0);
+ref = dotbelowcomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (-3,0);
+ref = dotbelowcomb;
+}
+);
+width = 598;
+}
+);
+unicode = 7921;
+},
+{
+glyphname = uhorngrave;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (-10,0);
+ref = gravecomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (35,0);
+ref = gravecomb;
+}
+);
+width = 598;
+}
+);
+unicode = 7915;
+},
+{
+glyphname = uhornhookabove;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (15,0);
+ref = hookabovecomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (19,0);
+ref = hookabovecomb;
+}
+);
+width = 598;
+}
+);
+unicode = 7917;
+},
+{
+glyphname = uhorntilde;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (-21,0);
+ref = tildecomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = uhorn;
+},
+{
+pos = (-14,0);
+ref = tildecomb;
+}
+);
+width = 598;
+}
+);
+unicode = 7919;
+},
+{
+glyphname = uhungarumlaut;
+kernLeft = u;
+kernRight = u;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (102,0);
+ref = hungarumlaut;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (98,0);
+ref = hungarumlaut;
+}
+);
+width = 598;
+}
+);
+unicode = 369;
+},
+{
+glyphname = uinvertedbreve;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (82,0);
+ref = breveinvertedcomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (116,0);
+ref = breveinvertedcomb;
+}
+);
+width = 598;
+}
+);
+unicode = 535;
+},
+{
+glyphname = umacron;
+kernLeft = u;
+kernRight = u;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (73,0);
+ref = macron;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (108,-4);
+ref = macron;
+}
+);
+width = 598;
+}
+);
+unicode = 363;
+},
+{
+glyphname = uogonek;
+kernLeft = u;
+kernRight = u;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (361,0);
+ref = ogonek;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (349,0);
+ref = ogonek;
+}
+);
+width = 598;
+}
+);
+unicode = 371;
+},
+{
+glyphname = uring;
+kernLeft = u;
+kernRight = u;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (157,0);
+ref = ring;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = u;
+},
+{
+alignment = -1;
+pos = (163,0);
+ref = ring;
+}
+);
+width = 598;
+}
+);
+unicode = 367;
+},
+{
+glyphname = utilde;
+kernLeft = u;
+kernRight = u;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (-21,0);
+ref = tildecomb;
+}
+);
+width = 571;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = u;
+},
+{
+pos = (-14,0);
+ref = tildecomb;
+}
+);
+width = 598;
+}
+);
+unicode = 361;
+},
+{
+glyphname = v;
+lastChange = "2016-08-22 13:51:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (198,0);
+},
+{
+name = top;
+pos = (302,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(383,-13,o),
+(481,242,o),
+(481,375,cs),
+(481,433,o),
+(462,462,o),
+(422,462,cs),
+(388,462,o),
+(371,440,o),
+(371,412,cs),
+(371,356,o),
+(442,382,o),
+(442,318,cs),
+(442,240,o),
+(344,29,o),
+(242,29,cs),
+(214,29,o),
+(191,46,o),
+(191,80,cs),
+(191,87,o),
+(192,95,o),
+(195,108,cs),
+(253,336,ls),
+(264,378,o),
+(265,389,o),
+(265,397,cs),
+(265,440,o),
+(241,462,o),
+(197,462,cs),
+(117,462,o),
+(65,389,o),
+(25,308,c),
+(45,299,l),
+(89,381,o),
+(119,411,o),
+(145,411,cs),
+(157,411,o),
+(161,404,o),
+(161,392,cs),
+(161,386,o),
+(160,375,o),
+(156,358,cs),
+(95,131,ls),
+(91,115,o),
+(89,100,o),
+(89,87,cs),
+(89,19,o),
+(140,-13,o),
+(203,-13,cs)
+);
+}
+);
+width = 500;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (204,0);
+},
+{
+name = top;
+pos = (308,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(384,-12,o),
+(482,226,o),
+(482,365,cs),
+(482,439,o),
+(453,467,o),
+(408,467,cs),
+(366,467,o),
+(343,443,o),
+(343,404,cs),
+(343,324,o),
+(438,367,o),
+(438,311,cs),
+(438,256,o),
+(354,40,o),
+(256,40,cs),
+(229,40,o),
+(217,56,o),
+(217,85,cs),
+(217,94,o),
+(218,101,o),
+(221,114,cs),
+(275,338,ls),
+(277,352,o),
+(280,362,o),
+(280,376,cs),
+(280,426,o),
+(253,462,o),
+(192,462,cs),
+(118,462,o),
+(71,409,o),
+(28,308,c),
+(51,297,l),
+(91,381,o),
+(118,411,o),
+(141,411,cs),
+(153,411,o),
+(157,403,o),
+(157,392,cs),
+(157,386,o),
+(156,375,o),
+(152,358,cs),
+(94,143,ls),
+(90,127,o),
+(88,113,o),
+(88,98,cs),
+(88,23,o),
+(138,-12,o),
+(206,-12,cs)
+);
+}
+);
+width = 512;
+}
+);
+unicode = 118;
+},
+{
+glyphname = w;
+kernLeft = w;
+kernRight = w;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (332,0);
+},
+{
+name = top;
+pos = (436,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,-13,o),
+(358,78,o),
+(394,188,c),
+(407,188,l),
+(447,450,l),
+(417,332,o),
+(327,29,o),
+(215,29,cs),
+(195,29,o),
+(186,38,o),
+(186,61,cs),
+(186,69,o),
+(187,78,o),
+(190,89,cs),
+(253,336,ls),
+(264,378,o),
+(265,389,o),
+(265,397,cs),
+(265,440,o),
+(241,462,o),
+(197,462,cs),
+(117,462,o),
+(65,389,o),
+(25,308,c),
+(45,299,l),
+(89,381,o),
+(119,411,o),
+(144,411,cs),
+(156,411,o),
+(161,404,o),
+(161,392,cs),
+(161,386,o),
+(160,375,o),
+(156,358,cs),
+(90,112,ls),
+(87,99,o),
+(85,88,o),
+(85,76,cs),
+(85,23,o),
+(121,-13,o),
+(181,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(659,-13,o),
+(748,242,o),
+(748,374,cs),
+(748,433,o),
+(729,462,o),
+(689,462,cs),
+(655,462,o),
+(638,440,o),
+(638,412,cs),
+(638,355,o),
+(709,384,o),
+(709,315,cs),
+(709,239,o),
+(628,29,o),
+(535,29,cs),
+(505,29,o),
+(489,51,o),
+(489,107,cs),
+(489,167,o),
+(506,272,o),
+(551,450,c),
+(448,450,l),
+(392,150,ls),
+(374,52,o),
+(439,-13,o),
+(505,-13,cs)
+);
+}
+);
+width = 767;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (336,0);
+},
+{
+name = top;
+pos = (440,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,-12,o),
+(379,140,o),
+(406,210,c),
+(411,210,l),
+(447,450,l),
+(383,177,o),
+(292,40,o),
+(245,40,cs),
+(236,40,o),
+(227,45,o),
+(227,66,cs),
+(227,73,o),
+(228,81,o),
+(231,94,cs),
+(281,338,ls),
+(284,355,o),
+(286,366,o),
+(286,379,cs),
+(286,425,o),
+(259,462,o),
+(198,462,cs),
+(124,462,o),
+(77,409,o),
+(34,308,c),
+(57,297,l),
+(97,381,o),
+(124,411,o),
+(147,411,cs),
+(159,411,o),
+(163,403,o),
+(163,392,cs),
+(163,386,o),
+(162,374,o),
+(158,358,cs),
+(102,132,ls),
+(98,116,o),
+(96,101,o),
+(96,88,cs),
+(96,23,o),
+(144,-12,o),
+(199,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(666,-12,o),
+(760,239,o),
+(760,366,cs),
+(760,437,o),
+(731,462,o),
+(688,462,cs),
+(646,462,o),
+(623,438,o),
+(623,399,cs),
+(623,319,o),
+(718,363,o),
+(718,306,cs),
+(718,252,o),
+(637,40,o),
+(560,40,cs),
+(537,40,o),
+(523,59,o),
+(523,99,cs),
+(523,158,o),
+(539,226,o),
+(585,450,c),
+(447,450,l),
+(403,163,ls),
+(389,70,o),
+(429,-12,o),
+(516,-12,cs)
+);
+}
+);
+width = 776;
+}
+);
+unicode = 119;
+},
+{
+glyphname = wacute;
+kernLeft = w;
+kernRight = w;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = w;
+},
+{
+alignment = -1;
+pos = (321,0);
+ref = acute;
+}
+);
+width = 767;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = w;
+},
+{
+alignment = -1;
+pos = (335,0);
+ref = acute;
+}
+);
+width = 776;
+}
+);
+unicode = 7811;
+},
+{
+glyphname = wcircumflex;
+kernLeft = w;
+kernRight = w;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = w;
+},
+{
+alignment = -1;
+pos = (254,0);
+ref = circumflex;
+}
+);
+width = 767;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = w;
+},
+{
+alignment = -1;
+pos = (235,0);
+ref = circumflex;
+}
+);
+width = 776;
+}
+);
+unicode = 373;
+},
+{
+glyphname = wdieresis;
+kernLeft = w;
+kernRight = w;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = w;
+},
+{
+alignment = -1;
+pos = (263,0);
+ref = dieresis;
+}
+);
+width = 767;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = w;
+},
+{
+alignment = -1;
+pos = (233,0);
+ref = dieresis;
+}
+);
+width = 776;
+}
+);
+unicode = 7813;
+},
+{
+glyphname = wgrave;
+kernLeft = w;
+kernRight = w;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = w;
+},
+{
+alignment = -1;
+pos = (193,0);
+ref = grave;
+}
+);
+width = 767;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = w;
+},
+{
+alignment = -1;
+pos = (244,0);
+ref = grave;
+}
+);
+width = 776;
+}
+);
+unicode = 7809;
+},
+{
+glyphname = x;
+lastChange = "2016-08-22 13:51:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (223,0);
+},
+{
+name = top;
+pos = (327,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(428,-13,o),
+(472,53,o),
+(517,147,c),
+(497,156,l),
+(454,68,o),
+(426,38,o),
+(401,38,cs),
+(382,38,o),
+(365,54,o),
+(360,82,cs),
+(310,364,ls),
+(297,435,o),
+(272,462,o),
+(228,462,cs),
+(154,462,o),
+(107,385,o),
+(68,302,c),
+(88,293,l),
+(132,383,o),
+(156,411,o),
+(178,411,cs),
+(192,411,o),
+(200,398,o),
+(206,367,cs),
+(262,69,ls),
+(274,8,o),
+(301,-13,o),
+(347,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(103,-13,o),
+(169,51,o),
+(240,161,c),
+(244,161,l),
+(246,218,l),
+(210,147,o),
+(136,51,o),
+(108,51,cs),
+(93,51,o),
+(82,81,o),
+(51,81,cs),
+(22,81,o),
+(6,55,o),
+(6,32,cs),
+(6,11,o),
+(19,-13,o),
+(51,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(333,297,o),
+(390,396,o),
+(426,396,cs),
+(444,396,o),
+(456,374,o),
+(485,374,cs),
+(514,374,o),
+(529,396,o),
+(529,417,cs),
+(529,436,o),
+(517,460,o),
+(484,460,cs),
+(429,460,o),
+(367,397,o),
+(325,310,c),
+(314,310,l),
+(314,196,l)
+);
+}
+);
+width = 550;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (205,0);
+},
+{
+name = top;
+pos = (309,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(406,-13,o),
+(446,53,o),
+(491,147,c),
+(468,159,l),
+(425,73,o),
+(404,43,o),
+(379,43,cs),
+(367,43,o),
+(362,50,o),
+(359,67,cs),
+(303,364,ls),
+(288,440,o),
+(256,462,o),
+(209,462,cs),
+(129,462,o),
+(81,396,o),
+(43,302,c),
+(66,293,l),
+(105,376,o),
+(125,402,o),
+(144,402,cs),
+(155,402,o),
+(159,393,o),
+(164,367,cs),
+(214,101,ls),
+(230,17,o),
+(270,-13,o),
+(324,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(83,-13,o),
+(125,21,o),
+(202,143,c),
+(206,143,l),
+(224,223,l),
+(139,91,o),
+(126,79,o),
+(111,79,cs),
+(86,79,o),
+(83,111,o),
+(43,111,cs),
+(3,111,o),
+(-18,78,o),
+(-18,48,cs),
+(-18,19,o),
+(1,-13,o),
+(41,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(329,330,o),
+(359,373,o),
+(383,373,cs),
+(403,373,o),
+(414,343,o),
+(450,343,cs),
+(487,343,o),
+(507,374,o),
+(507,404,cs),
+(507,437,o),
+(484,462,o),
+(448,462,cs),
+(406,462,o),
+(368,427,o),
+(312,342,c),
+(301,342,l),
+(314,285,l)
+);
+}
+);
+width = 514;
+}
+);
+unicode = 120;
+},
+{
+glyphname = y;
+kernLeft = y;
+kernRight = y;
+lastChange = "2016-10-31 11:00:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (392,0);
+},
+{
+name = top;
+pos = (316,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(130,-314,o),
+(246,-185,o),
+(331,61,cs),
+(432,352,ls),
+(440,375,o),
+(449,381,o),
+(458,381,cs),
+(471,381,o),
+(476,368,o),
+(495,368,cs),
+(518,368,o),
+(536,388,o),
+(536,415,cs),
+(536,434,o),
+(527,462,o),
+(489,462,cs),
+(462,462,o),
+(435,449,o),
+(418,400,cs),
+(298,46,l),
+(266,-29,ls),
+(203,-177,o),
+(115,-273,o),
+(84,-273,cs),
+(60,-273,o),
+(63,-218,o),
+(20,-218,cs),
+(-7,-218,o),
+(-21,-240,o),
+(-21,-263,cs),
+(-21,-292,o),
+(1,-314,o),
+(39,-314,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(333,82,l),
+(324,120,l),
+(320,120,l),
+(239,390,ls),
+(221,443,o),
+(200,462,o),
+(163,462,cs),
+(92,462,o),
+(58,397,o),
+(20,302,c),
+(40,293,l),
+(77,378,o),
+(92,407,o),
+(112,407,cs),
+(124,407,o),
+(130,396,o),
+(139,367,cs),
+(263,-49,l)
+);
+}
+);
+width = 527;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (392,0);
+},
+{
+name = top;
+pos = (326,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,-314,o),
+(261,-150,o),
+(358,83,cs),
+(455,317,ls),
+(467,346,o),
+(474,352,o),
+(483,352,cs),
+(493,352,o),
+(507,338,o),
+(527,338,cs),
+(566,338,o),
+(590,365,o),
+(590,402,cs),
+(590,437,o),
+(572,462,o),
+(528,462,cs),
+(492,462,o),
+(461,445,o),
+(437,379,cs),
+(320,68,l),
+(288,7,ls),
+(210,-142,o),
+(116,-255,o),
+(82,-255,cs),
+(53,-255,o),
+(64,-177,o),
+(-1,-177,cs),
+(-37,-177,o),
+(-64,-200,o),
+(-64,-237,cs),
+(-64,-277,o),
+(-34,-314,o),
+(19,-314,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(372,144,l),
+(363,182,l),
+(359,182,l),
+(286,397,ls),
+(268,449,o),
+(238,462,o),
+(200,462,cs),
+(113,462,o),
+(74,395,o),
+(25,297,c),
+(55,283,l),
+(92,364,o),
+(109,390,o),
+(126,390,cs),
+(138,390,o),
+(143,379,o),
+(153,350,cs),
+(289,-25,l)
+);
+}
+);
+width = 547;
+}
+);
+unicode = 121;
+},
+{
+glyphname = yacute;
+kernLeft = y;
+kernRight = y;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (-43,0);
+ref = acutecomb;
+}
+);
+width = 527;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (-79,0);
+ref = acutecomb;
+}
+);
+width = 547;
+}
+);
+unicode = 253;
+},
+{
+glyphname = ycircumflex;
+kernLeft = y;
+kernRight = y;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = y;
+},
+{
+alignment = -1;
+pos = (99,0);
+ref = circumflex;
+}
+);
+width = 527;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = y;
+},
+{
+alignment = -1;
+pos = (124,0);
+ref = circumflex;
+}
+);
+width = 547;
+}
+);
+unicode = 375;
+},
+{
+glyphname = ydieresis;
+kernLeft = y;
+kernRight = y;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = y;
+},
+{
+alignment = -1;
+pos = (83,0);
+ref = dieresis;
+}
+);
+width = 527;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = y;
+},
+{
+alignment = -1;
+pos = (94,0);
+ref = dieresis;
+}
+);
+width = 547;
+}
+);
+unicode = 255;
+},
+{
+glyphname = ydotbelow;
+kernLeft = y;
+kernRight = y;
+lastChange = "2016-10-31 11:00:18 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (151,0);
+ref = dotbelowcomb;
+}
+);
+width = 527;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (142,0);
+ref = dotbelowcomb;
+}
+);
+width = 547;
+}
+);
+unicode = 7925;
+},
+{
+glyphname = ygrave;
+kernLeft = y;
+kernRight = y;
+lastChange = "2016-08-22 14:18:41 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (-32,0);
+ref = gravecomb;
+}
+);
+width = 527;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (10,0);
+ref = gravecomb;
+}
+);
+width = 547;
+}
+);
+unicode = 7923;
+},
+{
+glyphname = yhookabove;
+kernLeft = y;
+kernRight = y;
+lastChange = "2016-08-22 14:18:41 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (-7,0);
+ref = hookabovecomb;
+}
+);
+width = 527;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (-6,0);
+ref = hookabovecomb;
+}
+);
+width = 547;
+}
+);
+unicode = 7927;
+},
+{
+glyphname = ytilde;
+kernLeft = y;
+kernRight = y;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (-43,0);
+ref = tildecomb;
+}
+);
+width = 527;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = y;
+},
+{
+pos = (-39,0);
+ref = tildecomb;
+}
+);
+width = 547;
+}
+);
+unicode = 7929;
+},
+{
+glyphname = z;
+kernLeft = z;
+kernRight = z;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (185,0);
+},
+{
+name = top;
+pos = (289,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(94,-8,o),
+(34,47,o),
+(77,47,cs),
+(112,47,o),
+(188,-13,o),
+(266,-13,cs),
+(344,-13,o),
+(411,46,o),
+(411,120,cs),
+(411,155,o),
+(396,185,o),
+(368,185,cs),
+(350,185,o),
+(332,173,o),
+(332,148,cs),
+(332,105,o),
+(387,127,o),
+(387,99,cs),
+(387,86,o),
+(376,70,o),
+(350,70,cs),
+(306,70,o),
+(219,116,o),
+(133,116,c),
+(133,120,l),
+(407,382,ls),
+(449,423,o),
+(453,434,o),
+(453,441,cs),
+(453,452,o),
+(446,457,o),
+(435,457,cs),
+(401,457,o),
+(423,412,o),
+(396,412,cs),
+(294,412,o),
+(267,415,o),
+(154,450,c),
+(139,450,l),
+(65,294,l),
+(82,287,l),
+(118,354,l),
+(148,342,o),
+(176,339,o),
+(207,339,cs),
+(244,339,o),
+(286,345,o),
+(337,357,c),
+(339,354,l),
+(86,112,ls),
+(32,60,o),
+(17,35,o),
+(17,15,cs),
+(17,1,o),
+(23,-8,o),
+(38,-8,cs)
+);
+}
+);
+width = 474;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (195,0);
+},
+{
+name = top;
+pos = (299,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(107,-13,o),
+(54,47,o),
+(89,47,cs),
+(153,47,o),
+(213,-13,o),
+(290,-13,cs),
+(385,-13,o),
+(452,78,o),
+(452,162,cs),
+(452,208,o),
+(432,239,o),
+(398,239,cs),
+(374,239,o),
+(350,224,o),
+(350,194,cs),
+(350,142,o),
+(419,160,o),
+(419,136,cs),
+(419,126,o),
+(409,103,o),
+(379,103,cs),
+(342,103,o),
+(314,138,o),
+(159,138,c),
+(159,142,l),
+(467,399,ls),
+(484,413,o),
+(492,427,o),
+(492,440,cs),
+(492,454,o),
+(483,462,o),
+(466,462,cs),
+(427,462,o),
+(444,417,o),
+(423,417,cs),
+(333,417,o),
+(238,428,o),
+(166,450,c),
+(141,450,l),
+(54,264,l),
+(81,253,l),
+(118,326,l),
+(145,315,o),
+(169,315,o),
+(198,315,cs),
+(234,315,o),
+(288,321,o),
+(339,336,c),
+(341,333,l),
+(79,112,ls),
+(19,62,o),
+(9,43,o),
+(9,24,cs),
+(9,2,o),
+(23,-13,o),
+(47,-13,cs)
+);
+}
+);
+width = 494;
+}
+);
+unicode = 122;
+},
+{
+glyphname = zacute;
+kernLeft = z;
+kernRight = z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = z;
+},
+{
+alignment = -1;
+pos = (145,0);
+ref = acute;
+}
+);
+width = 474;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = z;
+},
+{
+alignment = -1;
+pos = (149,0);
+ref = acute;
+}
+);
+width = 494;
+}
+);
+unicode = 378;
+},
+{
+glyphname = zcaron;
+kernLeft = z;
+kernRight = z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = z;
+},
+{
+alignment = -1;
+pos = (68,0);
+ref = caron;
+}
+);
+width = 474;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = z;
+},
+{
+alignment = -1;
+pos = (35,0);
+ref = caron;
+}
+);
+width = 494;
+}
+);
+unicode = 382;
+},
+{
+glyphname = zdotaccent;
+kernLeft = z;
+kernRight = z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = z;
+},
+{
+alignment = -1;
+pos = (142,0);
+ref = dotaccent;
+}
+);
+width = 474;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = z;
+},
+{
+alignment = -1;
+pos = (143,0);
+ref = dotaccent;
+}
+);
+width = 494;
+}
+);
+unicode = 380;
+},
+{
+glyphname = zdotbelow;
+kernLeft = z;
+kernRight = z;
+lastChange = "2021-12-17 13:49:56 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+ref = z;
+},
+{
+alignment = -1;
+pos = (171,0);
+ref = dotbelow;
+}
+);
+width = 474;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+ref = z;
+},
+{
+alignment = -1;
+pos = (202,0);
+ref = dotbelow;
+}
+);
+width = 494;
+}
+);
+unicode = 7827;
+},
+{
+glyphname = f_f;
+kernLeft = f;
+kernRight = f;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(3,-324,o),
+(101,-256,o),
+(171,45,cs),
+(265,453,ls),
+(307,634,o),
+(348,688,o),
+(406,688,cs),
+(427,688,o),
+(441,681,o),
+(441,670,cs),
+(441,657,o),
+(420,647,o),
+(420,621,cs),
+(420,596,o),
+(439,577,o),
+(470,577,cs),
+(504,577,o),
+(524,603,o),
+(524,633,cs),
+(524,684,o),
+(471,718,o),
+(413,718,cs),
+(309,718,o),
+(188,608,o),
+(144,392,cs),
+(35,-140,ls),
+(10,-260,o),
+(-26,-294,o),
+(-68,-294,cs),
+(-88,-294,o),
+(-92,-287,o),
+(-92,-276,cs),
+(-92,-267,o),
+(-89,-256,o),
+(-89,-247,cs),
+(-89,-223,o),
+(-108,-203,o),
+(-136,-203,cs),
+(-164,-203,o),
+(-185,-223,o),
+(-185,-251,cs),
+(-185,-293,o),
+(-140,-324,o),
+(-82,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(288,-274,o),
+(384,-206,o),
+(456,95,cs),
+(553,501,ls),
+(596,681,o),
+(636,736,o),
+(694,736,cs),
+(715,736,o),
+(729,729,o),
+(729,718,cs),
+(729,705,o),
+(708,695,o),
+(708,669,cs),
+(708,645,o),
+(727,625,o),
+(758,625,cs),
+(792,625,o),
+(812,651,o),
+(812,681,cs),
+(812,732,o),
+(759,766,o),
+(701,766,cs),
+(597,766,o),
+(478,655,o),
+(432,440,cs),
+(320,-90,ls),
+(295,-210,o),
+(259,-244,o),
+(217,-244,cs),
+(197,-244,o),
+(193,-237,o),
+(193,-226,cs),
+(193,-217,o),
+(196,-206,o),
+(196,-197,cs),
+(196,-172,o),
+(177,-153,o),
+(149,-153,cs),
+(121,-153,o),
+(100,-173,o),
+(100,-201,cs),
+(100,-243,o),
+(145,-274,o),
+(203,-274,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,425,l),
+(378,450,l),
+(57,450,l),
+(57,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(654,425,l),
+(654,450,l),
+(333,450,l),
+(333,425,l)
+);
+}
+);
+width = 589;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(37,-324,o),
+(159,-182,o),
+(223,175,cs),
+(277,476,ls),
+(307,655,o),
+(346,711,o),
+(394,711,cs),
+(414,711,o),
+(421,701,o),
+(421,693,cs),
+(421,678,o),
+(400,665,o),
+(400,633,cs),
+(400,598,o),
+(425,575,o),
+(463,575,cs),
+(506,575,o),
+(526,604,o),
+(526,642,cs),
+(526,702,o),
+(475,741,o),
+(408,741,cs),
+(298,741,o),
+(167,638,o),
+(125,418,cs),
+(61,82,ls),
+(-6,-269,o),
+(-28,-289,o),
+(-61,-289,cs),
+(-76,-289,o),
+(-84,-285,o),
+(-84,-272,cs),
+(-84,-256,o),
+(-71,-245,o),
+(-71,-224,cs),
+(-71,-198,o),
+(-91,-172,o),
+(-131,-172,cs),
+(-172,-172,o),
+(-193,-199,o),
+(-193,-235,cs),
+(-193,-279,o),
+(-163,-324,o),
+(-91,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(319,-289,o),
+(440,-143,o),
+(507,210,cs),
+(562,501,ls),
+(595,684,o),
+(638,736,o),
+(682,736,cs),
+(700,736,o),
+(708,728,o),
+(708,718,cs),
+(708,702,o),
+(687,691,o),
+(687,658,cs),
+(687,623,o),
+(712,600,o),
+(750,600,cs),
+(793,600,o),
+(813,629,o),
+(813,667,cs),
+(813,727,o),
+(761,766,o),
+(696,766,cs),
+(588,766,o),
+(456,660,o),
+(410,434,cs),
+(336,68,ls),
+(275,-233,o),
+(256,-254,o),
+(224,-254,cs),
+(207,-254,o),
+(200,-248,o),
+(200,-237,cs),
+(200,-222,o),
+(213,-210,o),
+(213,-189,cs),
+(213,-164,o),
+(193,-137,o),
+(153,-137,cs),
+(112,-137,o),
+(91,-164,o),
+(91,-200,cs),
+(91,-244,o),
+(122,-289,o),
+(192,-289,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(386,420,l),
+(386,450,l),
+(25,450,l),
+(25,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(673,420,l),
+(673,450,l),
+(312,450,l),
+(312,420,l)
+);
+}
+);
+width = 594;
+}
+);
+},
+{
+glyphname = f_f_i;
+kernLeft = f;
+kernRight = i;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,-284,o),
+(377,-216,o),
+(445,85,cs),
+(542,511,ls),
+(580,679,o),
+(628,736,o),
+(689,736,cs),
+(711,736,o),
+(728,729,o),
+(728,718,cs),
+(728,705,o),
+(707,695,o),
+(707,669,cs),
+(707,645,o),
+(726,625,o),
+(757,625,cs),
+(791,625,o),
+(811,651,o),
+(811,681,cs),
+(811,732,o),
+(756,766,o),
+(696,766,cs),
+(588,766,o),
+(463,657,o),
+(421,450,cs),
+(309,-100,ls),
+(285,-220,o),
+(248,-254,o),
+(206,-254,cs),
+(186,-254,o),
+(182,-247,o),
+(182,-236,cs),
+(182,-227,o),
+(185,-216,o),
+(185,-207,cs),
+(185,-182,o),
+(166,-163,o),
+(138,-163,cs),
+(110,-163,o),
+(89,-183,o),
+(89,-211,cs),
+(89,-253,o),
+(134,-284,o),
+(192,-284,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(6,-324,o),
+(112,-210,o),
+(171,45,cs),
+(268,463,ls),
+(307,634,o),
+(351,688,o),
+(409,688,cs),
+(430,688,o),
+(444,681,o),
+(444,670,cs),
+(444,657,o),
+(423,647,o),
+(423,621,cs),
+(423,596,o),
+(442,577,o),
+(473,577,cs),
+(507,577,o),
+(527,603,o),
+(527,633,cs),
+(527,684,o),
+(474,718,o),
+(416,718,cs),
+(309,718,o),
+(189,605,o),
+(147,402,cs),
+(35,-140,ls),
+(11,-256,o),
+(-24,-294,o),
+(-68,-294,cs),
+(-88,-294,o),
+(-92,-287,o),
+(-92,-276,cs),
+(-92,-267,o),
+(-89,-256,o),
+(-89,-247,cs),
+(-89,-223,o),
+(-108,-203,o),
+(-136,-203,cs),
+(-164,-203,o),
+(-185,-223,o),
+(-185,-251,cs),
+(-185,-294,o),
+(-136,-324,o),
+(-88,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,425,l),
+(381,450,l),
+(60,450,l),
+(60,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(643,425,l),
+(643,450,l),
+(322,450,l),
+(322,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(753,-13,o),
+(811,73,o),
+(850,157,c),
+(830,166,l),
+(784,73,o),
+(748,38,o),
+(716,38,cs),
+(702,38,o),
+(694,45,o),
+(694,63,cs),
+(694,69,o),
+(695,80,o),
+(699,97,cs),
+(788,450,l),
+(681,450,l),
+(594,87,ls),
+(592,78,o),
+(590,67,o),
+(590,56,cs),
+(590,15,o),
+(618,-13,o),
+(667,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(776,425,l),
+(776,450,l),
+(587,450,l),
+(587,425,l)
+);
+}
+);
+width = 852;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,-289,o),
+(423,-145,o),
+(499,210,cs),
+(561,501,l),
+(597,681,o),
+(654,736,o),
+(709,736,cs),
+(731,736,o),
+(742,728,o),
+(742,718,cs),
+(742,703,o),
+(721,689,o),
+(721,655,cs),
+(721,618,o),
+(746,596,o),
+(784,596,cs),
+(827,596,o),
+(847,625,o),
+(847,662,cs),
+(847,727,o),
+(786,766,o),
+(714,766,cs),
+(595,766,o),
+(455,660,o),
+(406,434,cs),
+(327,68,ls),
+(262,-233,o),
+(247,-254,o),
+(214,-254,cs),
+(199,-254,o),
+(191,-248,o),
+(191,-237,cs),
+(191,-221,o),
+(204,-210,o),
+(204,-189,cs),
+(204,-164,o),
+(184,-137,o),
+(144,-137,cs),
+(103,-137,o),
+(82,-164,o),
+(82,-200,cs),
+(82,-244,o),
+(113,-289,o),
+(183,-289,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(37,-324,o),
+(159,-182,o),
+(223,175,cs),
+(277,476,ls),
+(307,655,o),
+(346,711,o),
+(394,711,cs),
+(414,711,o),
+(421,701,o),
+(421,693,cs),
+(421,678,o),
+(400,665,o),
+(400,633,cs),
+(400,598,o),
+(425,575,o),
+(463,575,cs),
+(506,575,o),
+(526,604,o),
+(526,642,cs),
+(526,702,o),
+(475,741,o),
+(408,741,cs),
+(298,741,o),
+(167,638,o),
+(125,418,cs),
+(61,82,ls),
+(-6,-269,o),
+(-28,-289,o),
+(-61,-289,cs),
+(-76,-289,o),
+(-84,-285,o),
+(-84,-272,cs),
+(-84,-256,o),
+(-71,-245,o),
+(-71,-224,cs),
+(-71,-198,o),
+(-91,-172,o),
+(-131,-172,cs),
+(-172,-172,o),
+(-193,-199,o),
+(-193,-235,cs),
+(-193,-279,o),
+(-163,-324,o),
+(-91,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(388,420,l),
+(388,450,l),
+(27,450,l),
+(27,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(671,420,l),
+(671,450,l),
+(310,450,l),
+(310,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(778,-11,o),
+(850,35,o),
+(887,147,c),
+(862,156,l),
+(821,65,o),
+(777,37,o),
+(756,37,cs),
+(748,37,o),
+(742,41,o),
+(742,52,cs),
+(742,57,o),
+(743,69,o),
+(747,87,cs),
+(831,450,l),
+(697,450,l),
+(623,153,ls),
+(610,100,o),
+(607,86,o),
+(607,70,cs),
+(607,15,o),
+(640,-11,o),
+(699,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(774,420,l),
+(774,450,l),
+(600,450,l),
+(600,420,l)
+);
+}
+);
+width = 882;
+}
+);
+},
+{
+glyphname = f_f_l;
+kernLeft = f;
+kernRight = l;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,-274,o),
+(384,-206,o),
+(456,95,cs),
+(556,511,ls),
+(597,686,o),
+(639,736,o),
+(697,736,cs),
+(718,736,o),
+(732,729,o),
+(732,718,cs),
+(732,705,o),
+(711,695,o),
+(711,669,cs),
+(711,645,o),
+(730,625,o),
+(761,625,cs),
+(795,625,o),
+(815,651,o),
+(815,681,cs),
+(815,732,o),
+(762,766,o),
+(704,766,cs),
+(598,766,o),
+(479,657,o),
+(435,450,cs),
+(320,-90,ls),
+(295,-210,o),
+(259,-244,o),
+(217,-244,cs),
+(197,-244,o),
+(193,-237,o),
+(193,-226,cs),
+(193,-217,o),
+(196,-206,o),
+(196,-197,cs),
+(196,-172,o),
+(177,-153,o),
+(149,-153,cs),
+(121,-153,o),
+(100,-173,o),
+(100,-201,cs),
+(100,-243,o),
+(145,-274,o),
+(203,-274,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(-2,-324,o),
+(100,-263,o),
+(171,45,cs),
+(268,463,ls),
+(307,632,o),
+(350,686,o),
+(408,686,cs),
+(429,686,o),
+(443,679,o),
+(443,668,cs),
+(443,655,o),
+(422,645,o),
+(422,619,cs),
+(422,594,o),
+(441,575,o),
+(472,575,cs),
+(506,575,o),
+(526,601,o),
+(526,631,cs),
+(526,682,o),
+(473,716,o),
+(415,716,cs),
+(308,716,o),
+(188,603,o),
+(147,402,cs),
+(35,-140,ls),
+(11,-256,o),
+(-24,-294,o),
+(-68,-294,cs),
+(-88,-294,o),
+(-92,-287,o),
+(-92,-276,cs),
+(-92,-267,o),
+(-89,-256,o),
+(-89,-247,cs),
+(-89,-223,o),
+(-108,-203,o),
+(-136,-203,cs),
+(-164,-203,o),
+(-185,-223,o),
+(-185,-251,cs),
+(-185,-293,o),
+(-140,-324,o),
+(-82,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,425,l),
+(381,450,l),
+(60,450,l),
+(60,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(657,425,l),
+(657,450,l),
+(336,450,l),
+(336,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(777,-13,o),
+(836,73,o),
+(876,157,c),
+(856,166,l),
+(808,73,o),
+(771,38,o),
+(738,38,cs),
+(723,38,o),
+(715,45,o),
+(715,63,cs),
+(715,69,o),
+(716,80,o),
+(720,97,cs),
+(885,764,l),
+(769,734,l),
+(615,87,ls),
+(613,78,o),
+(611,67,o),
+(611,56,cs),
+(611,15,o),
+(639,-13,o),
+(689,-13,cs)
+);
+}
+);
+width = 895;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(316,-289,o),
+(431,-142,o),
+(500,210,cs),
+(557,501,ls),
+(591,682,o),
+(631,736,o),
+(678,736,cs),
+(696,736,o),
+(704,728,o),
+(704,718,cs),
+(704,702,o),
+(683,691,o),
+(683,658,cs),
+(683,623,o),
+(708,600,o),
+(746,600,cs),
+(789,600,o),
+(809,629,o),
+(809,667,cs),
+(809,727,o),
+(757,766,o),
+(692,766,cs),
+(584,766,o),
+(452,660,o),
+(405,434,cs),
+(329,68,ls),
+(266,-233,o),
+(249,-254,o),
+(216,-254,cs),
+(201,-254,o),
+(193,-250,o),
+(193,-237,cs),
+(193,-222,o),
+(206,-211,o),
+(206,-189,cs),
+(206,-165,o),
+(186,-137,o),
+(146,-137,cs),
+(105,-137,o),
+(84,-164,o),
+(84,-200,cs),
+(84,-244,o),
+(114,-289,o),
+(185,-289,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(37,-324,o),
+(159,-182,o),
+(223,175,cs),
+(277,476,ls),
+(307,655,o),
+(347,711,o),
+(395,711,cs),
+(415,711,o),
+(422,701,o),
+(422,693,cs),
+(422,678,o),
+(401,665,o),
+(401,633,cs),
+(401,598,o),
+(426,575,o),
+(464,575,cs),
+(507,575,o),
+(527,604,o),
+(527,642,cs),
+(527,702,o),
+(476,741,o),
+(409,741,cs),
+(299,741,o),
+(167,638,o),
+(125,418,cs),
+(61,82,ls),
+(-6,-269,o),
+(-28,-289,o),
+(-61,-289,cs),
+(-76,-289,o),
+(-84,-285,o),
+(-84,-272,cs),
+(-84,-256,o),
+(-71,-245,o),
+(-71,-224,cs),
+(-71,-198,o),
+(-91,-172,o),
+(-131,-172,cs),
+(-172,-172,o),
+(-193,-199,o),
+(-193,-235,cs),
+(-193,-279,o),
+(-163,-324,o),
+(-91,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(386,420,l),
+(386,450,l),
+(25,450,l),
+(25,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(668,420,l),
+(668,450,l),
+(307,450,l),
+(307,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(772,-11,o),
+(831,43,o),
+(864,152,c),
+(839,161,l),
+(806,69,o),
+(769,41,o),
+(751,41,cs),
+(744,41,o),
+(739,45,o),
+(739,54,cs),
+(739,58,o),
+(740,70,o),
+(744,87,cs),
+(906,766,l),
+(766,741,l),
+(630,132,ls),
+(625,108,o),
+(621,83,o),
+(621,67,cs),
+(621,26,o),
+(647,-11,o),
+(704,-11,cs)
+);
+}
+);
+width = 885;
+}
+);
+},
+{
+glyphname = f_i;
+kernLeft = f;
+kernRight = i;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(3,-324,o),
+(101,-256,o),
+(171,45,cs),
+(279,511,ls),
+(319,684,o),
+(365,736,o),
+(425,736,cs),
+(447,736,o),
+(464,729,o),
+(464,718,cs),
+(464,705,o),
+(443,695,o),
+(443,669,cs),
+(443,645,o),
+(462,625,o),
+(493,625,cs),
+(527,625,o),
+(547,651,o),
+(547,681,cs),
+(547,732,o),
+(492,766,o),
+(432,766,cs),
+(324,766,o),
+(201,657,o),
+(158,450,cs),
+(35,-140,ls),
+(10,-260,o),
+(-26,-294,o),
+(-68,-294,cs),
+(-88,-294,o),
+(-92,-287,o),
+(-92,-276,cs),
+(-92,-267,o),
+(-89,-256,o),
+(-89,-247,cs),
+(-89,-223,o),
+(-108,-203,o),
+(-136,-203,cs),
+(-164,-203,o),
+(-185,-223,o),
+(-185,-251,cs),
+(-185,-293,o),
+(-140,-324,o),
+(-82,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,425,l),
+(380,450,l),
+(59,450,l),
+(59,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(491,-13,o),
+(549,73,o),
+(588,157,c),
+(568,166,l),
+(522,73,o),
+(486,38,o),
+(454,38,cs),
+(440,38,o),
+(432,45,o),
+(432,63,cs),
+(432,69,o),
+(433,80,o),
+(437,97,cs),
+(525,450,l),
+(418,450,l),
+(332,87,ls),
+(330,78,o),
+(328,67,o),
+(328,56,cs),
+(328,15,o),
+(356,-13,o),
+(405,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(513,425,l),
+(513,450,l),
+(324,450,l),
+(324,425,l)
+);
+}
+);
+width = 590;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,-324,o),
+(151,-181,o),
+(224,175,cs),
+(291,501,ls),
+(327,681,o),
+(385,736,o),
+(440,736,cs),
+(462,736,o),
+(473,728,o),
+(473,718,cs),
+(473,703,o),
+(452,689,o),
+(452,655,cs),
+(452,618,o),
+(477,596,o),
+(515,596,cs),
+(558,596,o),
+(578,625,o),
+(578,662,cs),
+(578,727,o),
+(517,766,o),
+(445,766,cs),
+(326,766,o),
+(183,661,o),
+(136,434,cs),
+(52,33,ls),
+(-11,-268,o),
+(-28,-289,o),
+(-61,-289,cs),
+(-76,-289,o),
+(-84,-285,o),
+(-84,-272,cs),
+(-84,-256,o),
+(-71,-245,o),
+(-71,-224,cs),
+(-71,-198,o),
+(-91,-172,o),
+(-131,-172,cs),
+(-172,-172,o),
+(-193,-199,o),
+(-193,-235,cs),
+(-193,-279,o),
+(-163,-324,o),
+(-92,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(401,420,l),
+(401,450,l),
+(40,450,l),
+(40,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(508,-11,o),
+(580,35,o),
+(617,147,c),
+(592,156,l),
+(551,65,o),
+(507,37,o),
+(486,37,cs),
+(478,37,o),
+(472,41,o),
+(472,52,cs),
+(472,57,o),
+(473,69,o),
+(477,87,cs),
+(561,450,l),
+(427,450,l),
+(353,153,ls),
+(340,100,o),
+(337,86,o),
+(337,70,cs),
+(337,15,o),
+(370,-11,o),
+(429,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(504,420,l),
+(504,450,l),
+(330,450,l),
+(330,420,l)
+);
+}
+);
+width = 612;
+}
+);
+},
+{
+glyphname = f_l;
+kernLeft = f;
+kernRight = l;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(3,-324,o),
+(101,-256,o),
+(171,45,cs),
+(279,511,ls),
+(319,684,o),
+(362,736,o),
+(420,736,cs),
+(441,736,o),
+(455,729,o),
+(455,718,cs),
+(455,705,o),
+(434,695,o),
+(434,669,cs),
+(434,645,o),
+(453,625,o),
+(484,625,cs),
+(518,625,o),
+(538,651,o),
+(538,681,cs),
+(538,732,o),
+(485,766,o),
+(427,766,cs),
+(323,766,o),
+(201,659,o),
+(158,450,cs),
+(35,-140,ls),
+(10,-260,o),
+(-26,-294,o),
+(-68,-294,cs),
+(-88,-294,o),
+(-92,-287,o),
+(-92,-276,cs),
+(-92,-267,o),
+(-89,-256,o),
+(-89,-247,cs),
+(-89,-223,o),
+(-108,-203,o),
+(-136,-203,cs),
+(-164,-203,o),
+(-185,-223,o),
+(-185,-251,cs),
+(-185,-293,o),
+(-140,-324,o),
+(-82,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,425,l),
+(364,450,l),
+(59,450,l),
+(59,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(499,-13,o),
+(558,73,o),
+(598,157,c),
+(578,166,l),
+(530,73,o),
+(493,38,o),
+(459,38,cs),
+(445,38,o),
+(437,45,o),
+(437,63,cs),
+(437,69,o),
+(438,80,o),
+(442,97,cs),
+(606,764,l),
+(491,732,l),
+(337,87,ls),
+(335,78,o),
+(333,67,o),
+(333,56,cs),
+(333,15,o),
+(361,-13,o),
+(410,-13,cs)
+);
+}
+);
+width = 616;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(35,-324,o),
+(153,-177,o),
+(223,175,cs),
+(288,501,ls),
+(322,682,o),
+(362,736,o),
+(409,736,cs),
+(427,736,o),
+(435,728,o),
+(435,718,cs),
+(435,702,o),
+(414,691,o),
+(414,658,cs),
+(414,623,o),
+(439,600,o),
+(477,600,cs),
+(520,600,o),
+(540,629,o),
+(540,667,cs),
+(540,727,o),
+(488,766,o),
+(423,766,cs),
+(315,766,o),
+(183,660,o),
+(136,434,cs),
+(52,33,ls),
+(-11,-268,o),
+(-28,-289,o),
+(-61,-289,cs),
+(-76,-289,o),
+(-84,-285,o),
+(-84,-272,cs),
+(-84,-256,o),
+(-71,-245,o),
+(-71,-224,cs),
+(-71,-198,o),
+(-91,-172,o),
+(-131,-172,cs),
+(-172,-172,o),
+(-193,-199,o),
+(-193,-235,cs),
+(-193,-279,o),
+(-163,-324,o),
+(-92,-324,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(399,420,l),
+(399,450,l),
+(38,450,l),
+(38,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(503,-11,o),
+(562,43,o),
+(595,152,c),
+(570,161,l),
+(537,69,o),
+(500,41,o),
+(482,41,cs),
+(475,41,o),
+(470,45,o),
+(470,54,cs),
+(470,58,o),
+(471,70,o),
+(475,87,cs),
+(637,766,l),
+(497,741,l),
+(361,132,ls),
+(356,108,o),
+(352,83,o),
+(352,67,cs),
+(352,26,o),
+(378,-11,o),
+(435,-11,cs)
+);
+}
+);
+width = 616;
+}
+);
+},
+{
+glyphname = ordfeminine;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(260,458,o),
+(288,478,o),
+(305,512,c),
+(309,512,l),
+(316,577,l),
+(292,508,o),
+(262,488,o),
+(239,488,cs),
+(217,488,o),
+(207,507,o),
+(207,542,cs),
+(207,606,o),
+(241,734,o),
+(298,734,cs),
+(324,734,o),
+(337,706,o),
+(337,679,cs),
+(337,671,o),
+(336,664,o),
+(336,655,c),
+(350,715,l),
+(346,715,l),
+(337,743,o),
+(326,763,o),
+(289,763,cs),
+(211,763,o),
+(125,673,o),
+(125,573,cs),
+(125,500,o),
+(171,458,o),
+(224,458,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(409,458,o),
+(440,511,o),
+(460,559,c),
+(437,565,l),
+(418,519,o),
+(399,496,o),
+(385,496,cs),
+(379,496,o),
+(375,501,o),
+(375,514,cs),
+(375,526,o),
+(378,539,o),
+(384,562,cs),
+(432,753,l),
+(359,753,l),
+(314,567,ls),
+(309,548,o),
+(307,531,o),
+(307,519,cs),
+(307,471,o),
+(339,458,o),
+(362,458,cs)
+);
+}
+);
+width = 370;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,458,o),
+(299,478,o),
+(318,512,c),
+(322,512,l),
+(332,587,l),
+(308,518,o),
+(275,498,o),
+(252,498,cs),
+(230,498,o),
+(220,517,o),
+(220,550,cs),
+(220,610,o),
+(254,724,o),
+(310,724,cs),
+(338,724,o),
+(350,696,o),
+(350,669,cs),
+(350,661,o),
+(349,654,o),
+(349,645,c),
+(363,715,l),
+(359,715,l),
+(349,743,o),
+(335,763,o),
+(296,763,cs),
+(212,763,o),
+(123,673,o),
+(123,573,cs),
+(123,500,o),
+(172,458,o),
+(229,458,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(432,458,o),
+(466,495,o),
+(488,559,c),
+(465,565,l),
+(446,519,o),
+(427,496,o),
+(413,496,cs),
+(407,496,o),
+(403,501,o),
+(403,514,cs),
+(403,526,o),
+(406,539,o),
+(412,562,cs),
+(460,753,l),
+(372,753,l),
+(327,567,ls),
+(322,548,o),
+(320,530,o),
+(320,519,cs),
+(320,470,o),
+(356,458,o),
+(384,458,cs)
+);
+}
+);
+width = 402;
+}
+);
+unicode = 170;
+},
+{
+glyphname = ordmasculine;
+lastChange = "2016-08-22 13:52:25 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,457,o),
+(422,554,o),
+(422,645,cs),
+(422,712,o),
+(373,763,o),
+(302,763,cs),
+(204,763,o),
+(115,667,o),
+(115,576,cs),
+(115,509,o),
+(163,457,o),
+(234,457,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(210,484,o),
+(199,506,o),
+(199,549,cs),
+(199,628,o),
+(231,737,o),
+(291,737,cs),
+(326,737,o),
+(337,706,o),
+(337,672,cs),
+(337,586,o),
+(305,484,o),
+(245,484,cs)
+);
+}
+);
+width = 346;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(358,457,o),
+(453,554,o),
+(453,645,cs),
+(453,712,o),
+(400,763,o),
+(319,763,cs),
+(212,763,o),
+(118,667,o),
+(118,576,cs),
+(118,509,o),
+(170,457,o),
+(251,457,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(227,484,o),
+(216,506,o),
+(216,549,cs),
+(216,628,o),
+(248,737,o),
+(315,737,cs),
+(343,737,o),
+(354,706,o),
+(354,672,cs),
+(354,586,o),
+(322,484,o),
+(257,484,cs)
+);
+}
+);
+width = 374;
+}
+);
+unicode = 186;
+},
+{
+glyphname = Delta;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(641,0,l),
+(641,37,l),
+(359,729,l),
+(302,715,l),
+(31,37,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,570,l),
+(478,37,l),
+(67,37,l)
+);
+}
+);
+width = 680;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(663,0,l),
+(663,43,l),
+(366,733,l),
+(296,716,l),
+(11,43,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(278,527,l),
+(469,73,l),
+(93,73,l)
+);
+}
+);
+width = 700;
+}
+);
+unicode = 916;
+},
+{
+glyphname = Omega;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,0,l),
+(345,23,l),
+(257,156,o),
+(222,257,o),
+(222,412,cs),
+(222,636,o),
+(295,702,o),
+(380,702,cs),
+(471,702,o),
+(545,625,o),
+(545,408,cs),
+(545,267,o),
+(514,160,o),
+(421,23,c),
+(430,0,l),
+(701,0,l),
+(730,174,l),
+(707,174,l),
+(686,109,o),
+(672,95,o),
+(630,95,cs),
+(508,99,l),
+(607,187,o),
+(694,269,o),
+(694,421,cs),
+(694,607,o),
+(565,733,o),
+(387,733,cs),
+(208,733,o),
+(72,606,o),
+(72,412,cs),
+(72,249,o),
+(168,165,o),
+(251,100,c),
+(144,96,ls),
+(100,96,o),
+(84,112,o),
+(62,174,c),
+(38,174,l),
+(63,0,l)
+);
+}
+);
+width = 762;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,0,l),
+(375,26,l),
+(326,132,o),
+(263,268,o),
+(263,399,cs),
+(263,626,o),
+(323,694,o),
+(415,694,cs),
+(506,694,o),
+(572,615,o),
+(572,402,cs),
+(572,267,o),
+(500,123,o),
+(458,26,c),
+(468,0,l),
+(756,0,l),
+(788,189,l),
+(747,189,l),
+(724,127,o),
+(709,116,o),
+(665,116,cs),
+(552,116,l),
+(644,188,o),
+(751,274,o),
+(751,414,cs),
+(751,612,o),
+(615,733,o),
+(419,733,cs),
+(226,733,o),
+(83,609,o),
+(83,408,cs),
+(83,253,o),
+(195,171,o),
+(274,116,c),
+(176,116,ls),
+(127,116,o),
+(111,128,o),
+(87,189,c),
+(48,189,l),
+(75,0,l)
+);
+}
+);
+width = 782;
+}
+);
+unicode = 937;
+},
+{
+glyphname = mu;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,-12,o),
+(285,41,o),
+(327,96,c),
+(334,96,l),
+(356,216,l),
+(327,113,o),
+(257,32,o),
+(195,32,cs),
+(174,32,o),
+(158,42,o),
+(158,65,cs),
+(158,73,o),
+(160,81,o),
+(162,91,cs),
+(248,450,l),
+(144,450,l),
+(62,114,ls),
+(58,97,o),
+(56,82,o),
+(56,70,cs),
+(56,12,o),
+(99,-12,o),
+(150,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(37,-261,o),
+(68,-236,o),
+(68,-174,cs),
+(68,-143,o),
+(60,-118,o),
+(60,-69,cs),
+(60,-45,o),
+(62,-16,o),
+(68,21,c),
+(72,21,l),
+(65,126,l),
+(29,-59,o),
+(-41,-153,o),
+(-41,-217,cs),
+(-41,-248,o),
+(-24,-261,o),
+(1,-261,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,425,l),
+(224,450,l),
+(65,450,l),
+(65,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,-12,o),
+(523,45,o),
+(564,142,c),
+(544,151,l),
+(507,73,o),
+(472,30,o),
+(444,30,cs),
+(430,30,o),
+(424,41,o),
+(424,60,cs),
+(424,77,o),
+(429,106,o),
+(439,147,cs),
+(514,450,l),
+(412,450,l),
+(341,154,ls),
+(334,125,o),
+(331,101,o),
+(331,82,cs),
+(331,9,o),
+(373,-12,o),
+(412,-12,cs)
+);
+}
+);
+width = 571;
+},
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,420,l),
+(215,420,l),
+(215,450,l),
+(41,450,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(559,450,l),
+(425,450,l),
+(351,153,ls),
+(338,100,o),
+(335,86,o),
+(335,70,cs),
+(335,15,o),
+(370,-11,o),
+(422,-11,cs),
+(513,-11,o),
+(576,69,o),
+(602,152,c),
+(577,161,l),
+(540,69,o),
+(499,41,o),
+(479,41,cs),
+(472,41,o),
+(467,45,o),
+(467,54,cs),
+(467,58,o),
+(468,70,o),
+(472,87,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,220,l),
+(339,108,o),
+(239,35,o),
+(203,35,cs),
+(191,35,o),
+(184,43,o),
+(184,57,cs),
+(184,67,o),
+(187,86,o),
+(189,95,cs),
+(280,450,l),
+(143,450,l),
+(56,113,ls),
+(52,96,o),
+(50,81,o),
+(50,69,cs),
+(50,13,o),
+(99,-11,o),
+(152,-11,cs),
+(232,-11,o),
+(292,43,o),
+(332,98,c),
+(339,98,l)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,-11,o),
+(292,43,o),
+(332,98,c),
+(339,98,l),
+(370,220,l),
+(339,108,o),
+(239,35,o),
+(203,35,cs),
+(191,35,o),
+(184,43,o),
+(184,57,cs),
+(184,67,o),
+(187,86,o),
+(189,95,cs),
+(280,450,l),
+(143,450,l),
+(56,113,ls),
+(52,96,o),
+(50,81,o),
+(50,69,cs),
+(50,13,o),
+(99,-11,o),
+(152,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,-277,o),
+(81,-246,o),
+(81,-174,cs),
+(81,-145,o),
+(76,-108,o),
+(76,-57,cs),
+(76,-38,o),
+(76,-17,o),
+(78,8,c),
+(82,8,l),
+(54,104,l),
+(13,-90,o),
+(-49,-153,o),
+(-49,-220,cs),
+(-49,-252,o),
+(-34,-277,o),
+(5,-277,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,420,l),
+(215,450,l),
+(41,450,l),
+(41,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(513,-11,o),
+(576,69,o),
+(602,152,c),
+(577,161,l),
+(540,69,o),
+(499,41,o),
+(479,41,cs),
+(472,41,o),
+(467,45,o),
+(467,54,cs),
+(467,58,o),
+(468,70,o),
+(472,87,cs),
+(559,450,l),
+(425,450,l),
+(351,153,ls),
+(338,100,o),
+(335,86,o),
+(335,70,cs),
+(335,15,o),
+(370,-11,o),
+(422,-11,cs)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 956;
+},
+{
+glyphname = pi;
+lastChange = "2016-08-22 12:51:23 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(98,-12,o),
+(126,-5,o),
+(151,6,c),
+(168,29,o),
+(220,117,o),
+(220,365,cs),
+(220,377,l),
+(353,377,l),
+(350,331,o),
+(343,218,o),
+(343,155,cs),
+(343,40,o),
+(366,-13,o),
+(447,-13,cs),
+(507,-13,o),
+(544,16,o),
+(572,62,c),
+(563,80,l),
+(546,64,o),
+(530,57,o),
+(515,57,cs),
+(483,57,o),
+(471,89,o),
+(471,214,cs),
+(471,270,o),
+(471,324,o),
+(476,377,c),
+(531,377,l),
+(582,490,l),
+(567,496,l),
+(550,472,o),
+(534,465,o),
+(489,465,cs),
+(395,465,o),
+(302,465,o),
+(208,465,cs),
+(124,465,o),
+(79,438,o),
+(19,362,c),
+(36,340,l),
+(80,369,o),
+(105,377,o),
+(168,377,c),
+(168,272,o),
+(145,116,o),
+(70,9,c),
+(78,-13,l)
+);
+}
+);
+width = 602;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(116,-12,o),
+(144,-6,o),
+(174,6,c),
+(192,28,o),
+(245,111,o),
+(245,353,cs),
+(245,363,l),
+(372,363,l),
+(366,295,o),
+(362,206,o),
+(362,163,cs),
+(362,17,o),
+(408,-14,o),
+(472,-14,cs),
+(542,-14,o),
+(591,24,o),
+(619,64,c),
+(605,96,l),
+(588,83,o),
+(576,77,o),
+(561,77,cs),
+(535,77,o),
+(516,96,o),
+(516,166,cs),
+(516,239,o),
+(516,295,o),
+(522,363,c),
+(590,363,l),
+(633,500,l),
+(599,509,l),
+(579,476,o),
+(566,474,o),
+(518,474,cs),
+(459,474,o),
+(292,477,o),
+(249,477,cs),
+(133,477,o),
+(101,455,o),
+(29,361,c),
+(48,325,l),
+(97,354,o),
+(125,363,o),
+(187,363,c),
+(187,266,o),
+(160,118,o),
+(84,12,c),
+(93,-14,l)
+);
+}
+);
+width = 622;
+}
+);
+unicode = 960;
+},
+{
+glyphname = zero;
+lastChange = "2016-08-22 13:52:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,-11,o),
+(602,249,o),
+(602,445,cs),
+(602,567,o),
+(546,706,o),
+(418,706,cs),
+(254,706,o),
+(78,476,o),
+(78,248,cs),
+(78,119,o),
+(135,-11,o),
+(268,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(218,14,o),
+(182,38,o),
+(182,126,cs),
+(182,266,o),
+(272,680,o),
+(425,680,cs),
+(472,680,o),
+(498,641,o),
+(498,560,cs),
+(498,416,o),
+(416,14,o),
+(257,14,cs)
+);
+}
+);
+width = 606;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(472,-11,o),
+(625,249,o),
+(625,443,cs),
+(625,567,o),
+(562,706,o),
+(424,706,cs),
+(247,706,o),
+(61,477,o),
+(61,251,cs),
+(61,118,o),
+(125,-11,o),
+(268,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,19,o),
+(205,34,o),
+(205,123,cs),
+(205,263,o),
+(283,675,o),
+(422,675,cs),
+(459,675,o),
+(481,646,o),
+(481,566,cs),
+(481,423,o),
+(410,19,o),
+(264,19,cs)
+);
+}
+);
+width = 626;
+}
+);
+unicode = 48;
+},
+{
+glyphname = one;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(207,0,l),
+(359,706,l),
+(247,706,l),
+(99,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,0,l),
+(336,25,l),
+(2,25,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(352,681,l),
+(352,706,l),
+(123,706,l),
+(123,681,l)
+);
+}
+);
+width = 360;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,0,l),
+(405,706,l),
+(253,706,l),
+(105,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(392,0,l),
+(392,35,l),
+(-12,35,l),
+(-12,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,671,l),
+(378,706,l),
+(109,706,l),
+(109,671,l)
+);
+}
+);
+width = 432;
+}
+);
+unicode = 49;
+},
+{
+glyphname = two;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,0,l),
+(487,188,l),
+(462,188,l),
+(438,102,o),
+(420,89,o),
+(377,89,cs),
+(110,89,l),
+(110,93,l),
+(401,333,ls),
+(503,417,o),
+(548,476,o),
+(548,547,cs),
+(548,644,o),
+(465,706,o),
+(349,706,cs),
+(217,706,o),
+(136,625,o),
+(136,534,cs),
+(136,470,o),
+(176,448,o),
+(207,448,cs),
+(237,448,o),
+(262,468,o),
+(262,502,cs),
+(262,564,o),
+(177,535,o),
+(177,577,cs),
+(177,615,o),
+(246,681,o),
+(325,681,cs),
+(392,681,o),
+(428,633,o),
+(428,550,cs),
+(428,445,o),
+(370,354,o),
+(267,265,cs),
+(27,58,l),
+(15,0,l)
+);
+}
+);
+width = 538;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(458,0,l),
+(514,218,l),
+(482,218,l),
+(465,140,o),
+(453,131,o),
+(419,131,cs),
+(140,131,l),
+(140,135,l),
+(403,306,ls),
+(531,389,o),
+(569,462,o),
+(569,527,cs),
+(569,636,o),
+(466,706,o),
+(335,706,cs),
+(174,706,o),
+(102,601,o),
+(102,515,cs),
+(102,436,o),
+(164,420,o),
+(194,420,cs),
+(233,420,o),
+(267,446,o),
+(267,492,cs),
+(267,570,o),
+(169,550,o),
+(169,585,cs),
+(169,610,o),
+(224,671,o),
+(300,671,cs),
+(361,671,o),
+(400,632,o),
+(400,538,cs),
+(400,449,o),
+(365,354,o),
+(218,244,cs),
+(16,93,l),
+(-6,0,l)
+);
+}
+);
+width = 570;
+}
+);
+unicode = 50;
+},
+{
+glyphname = three;
+lastChange = "2016-08-22 13:52:45 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(390,-13,o),
+(512,103,o),
+(512,211,cs),
+(512,302,o),
+(426,376,o),
+(341,376,c),
+(341,381,l),
+(472,418,o),
+(545,496,o),
+(545,571,cs),
+(545,641,o),
+(481,711,o),
+(357,711,cs),
+(250,711,o),
+(165,658,o),
+(165,591,cs),
+(165,554,o),
+(191,538,o),
+(216,538,cs),
+(246,538,o),
+(268,560,o),
+(268,588,cs),
+(268,617,o),
+(243,619,o),
+(243,640,cs),
+(243,667,o),
+(286,686,o),
+(336,686,cs),
+(404,686,o),
+(434,650,o),
+(434,594,cs),
+(434,517,o),
+(378,390,o),
+(263,390,cs),
+(238,390,o),
+(216,396,o),
+(204,396,cs),
+(190,396,o),
+(177,388,o),
+(177,375,cs),
+(177,363,o),
+(186,354,o),
+(206,354,cs),
+(225,354,o),
+(241,363,o),
+(250,363,cs),
+(337,363,o),
+(386,332,o),
+(386,237,cs),
+(386,153,o),
+(347,12,o),
+(208,12,cs),
+(149,12,o),
+(93,38,o),
+(93,62,cs),
+(93,88,o),
+(155,81,o),
+(155,132,cs),
+(155,162,o),
+(133,184,o),
+(100,184,cs),
+(60,184,o),
+(35,154,o),
+(35,112,cs),
+(35,50,o),
+(91,-13,o),
+(218,-13,cs)
+);
+}
+);
+width = 545;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(386,-13,o),
+(515,86,o),
+(515,205,cs),
+(515,305,o),
+(424,376,o),
+(334,376,c),
+(334,381,l),
+(467,418,o),
+(538,487,o),
+(538,566,cs),
+(538,643,o),
+(472,711,o),
+(347,711,cs),
+(234,711,o),
+(148,654,o),
+(148,581,cs),
+(148,537,o),
+(179,518,o),
+(209,518,cs),
+(245,518,o),
+(271,545,o),
+(271,577,cs),
+(271,614,o),
+(236,614,o),
+(236,640,cs),
+(236,664,o),
+(265,681,o),
+(314,681,cs),
+(366,681,o),
+(397,662,o),
+(397,598,cs),
+(397,517,o),
+(346,395,o),
+(245,395,cs),
+(222,395,o),
+(198,401,o),
+(187,401,cs),
+(173,401,o),
+(160,391,o),
+(160,374,cs),
+(160,360,o),
+(169,349,o),
+(192,349,cs),
+(212,349,o),
+(211,358,o),
+(245,358,cs),
+(319,358,o),
+(349,317,o),
+(349,220,cs),
+(349,74,o),
+(280,17,o),
+(197,17,cs),
+(148,17,o),
+(86,37,o),
+(86,63,cs),
+(86,89,o),
+(148,84,o),
+(148,136,cs),
+(148,171,o),
+(120,194,o),
+(85,194,cs),
+(40,194,o),
+(18,156,o),
+(18,114,cs),
+(18,48,o),
+(74,-13,o),
+(211,-13,cs)
+);
+}
+);
+width = 565;
+}
+);
+unicode = 51;
+},
+{
+glyphname = four;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(62,220,l),
+(62,224,l),
+(373,565,l),
+(377,565,l),
+(481,681,l),
+(464,706,l),
+(18,224,l),
+(35,199,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(463,0,l),
+(463,25,l),
+(168,25,l),
+(168,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(527,196,l),
+(527,224,l),
+(18,224,l),
+(18,196,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(520,108,l),
+(565,289,l),
+(540,289,l),
+(495,108,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(366,0,l),
+(518,706,l),
+(464,706,l),
+(385,605,l),
+(258,0,l)
+);
+}
+);
+width = 552;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(58,220,l),
+(58,224,l),
+(343,537,l),
+(347,537,l),
+(477,681,l),
+(460,706,l),
+(14,224,l),
+(31,199,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,0,l),
+(469,30,l),
+(164,30,l),
+(164,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(533,191,l),
+(533,224,l),
+(14,224,l),
+(14,191,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(526,108,l),
+(571,289,l),
+(541,289,l),
+(496,108,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,0,l),
+(534,706,l),
+(460,706,l),
+(357,585,l),
+(234,0,l)
+);
+}
+);
+width = 572;
+}
+);
+unicode = 52;
+},
+{
+glyphname = five;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(398,-8,o),
+(546,113,o),
+(546,246,cs),
+(546,350,o),
+(454,428,o),
+(309,428,cs),
+(269,428,o),
+(231,422,o),
+(182,407,c),
+(178,411,l),
+(238,617,l),
+(535,617,l),
+(603,754,l),
+(573,754,l),
+(547,710,o),
+(536,706,o),
+(466,706,cs),
+(232,706,l),
+(138,376,l),
+(149,366,l),
+(191,385,o),
+(238,395,o),
+(277,395,cs),
+(348,395,o),
+(415,362,o),
+(415,253,cs),
+(415,164,o),
+(370,18,o),
+(222,18,cs),
+(153,18,o),
+(117,50,o),
+(117,64,cs),
+(117,83,o),
+(178,91,o),
+(178,138,cs),
+(178,168,o),
+(153,191,o),
+(119,191,cs),
+(77,191,o),
+(52,156,o),
+(52,120,cs),
+(52,69,o),
+(101,-8,o),
+(233,-8,cs)
+);
+}
+);
+width = 581;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(415,-11,o),
+(547,116,o),
+(547,242,cs),
+(547,351,o),
+(448,428,o),
+(292,428,cs),
+(249,428,o),
+(212,422,o),
+(163,407,c),
+(159,411,l),
+(207,575,l),
+(534,575,l),
+(614,754,l),
+(584,754,l),
+(558,710,o),
+(547,706,o),
+(477,706,cs),
+(206,706,l),
+(112,376,l),
+(130,356,l),
+(172,375,o),
+(219,385,o),
+(259,385,cs),
+(325,385,o),
+(376,358,o),
+(376,263,cs),
+(376,179,o),
+(337,18,o),
+(215,18,cs),
+(162,18,o),
+(128,49,o),
+(128,65,cs),
+(128,85,o),
+(184,96,o),
+(184,152,cs),
+(184,194,o),
+(152,221,o),
+(113,221,cs),
+(60,221,o),
+(33,171,o),
+(33,125,cs),
+(33,64,o),
+(82,-11,o),
+(227,-11,cs)
+);
+}
+);
+width = 601;
+}
+);
+unicode = 53;
+},
+{
+glyphname = six;
+lastChange = "2016-08-22 13:52:55 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(441,-13,o),
+(576,137,o),
+(576,277,cs),
+(576,384,o),
+(498,462,o),
+(385,462,cs),
+(339,462,o),
+(301,449,o),
+(248,414,c),
+(245,417,l),
+(274,548,o),
+(404,686,o),
+(582,706,c),
+(582,731,l),
+(355,731,o),
+(72,477,o),
+(72,221,cs),
+(72,86,o),
+(150,-13,o),
+(280,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,12,o),
+(179,47,o),
+(179,142,cs),
+(179,220,o),
+(201,306,o),
+(219,352,c),
+(274,410,o),
+(329,437,o),
+(379,437,cs),
+(437,437,o),
+(461,401,o),
+(461,324,cs),
+(461,225,o),
+(421,12,o),
+(272,12,c)
+);
+}
+);
+width = 595;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,-13,o),
+(596,127,o),
+(596,267,cs),
+(596,373,o),
+(514,462,o),
+(397,462,cs),
+(352,462,o),
+(315,449,o),
+(271,414,c),
+(268,417,l),
+(297,543,o),
+(427,677,o),
+(605,696,c),
+(605,731,l),
+(362,731,o),
+(55,503,o),
+(55,228,cs),
+(55,83,o),
+(141,-13,o),
+(281,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,17,o),
+(212,54,o),
+(212,123,cs),
+(212,212,o),
+(234,308,o),
+(252,352,c),
+(295,403,o),
+(337,427,o),
+(377,427,cs),
+(427,427,o),
+(436,391,o),
+(436,342,cs),
+(436,246,o),
+(402,17,o),
+(276,17,cs)
+);
+}
+);
+width = 615;
+}
+);
+unicode = 54;
+},
+{
+glyphname = seven;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(285,-10,o),
+(313,25,o),
+(313,78,cs),
+(313,102,o),
+(307,138,o),
+(307,165,cs),
+(307,213,o),
+(327,279,o),
+(397,378,cs),
+(610,681,l),
+(613,706,l),
+(192,706,l),
+(101,518,l),
+(131,518,l),
+(167,604,o),
+(193,617,o),
+(261,617,cs),
+(528,617,l),
+(528,613,l),
+(330,334,ls),
+(196,146,o),
+(179,102,o),
+(179,60,cs),
+(179,9,o),
+(205,-10,o),
+(239,-10,cs)
+);
+}
+);
+width = 502;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,-10,o),
+(327,28,o),
+(327,90,cs),
+(327,122,o),
+(316,146,o),
+(316,192,cs),
+(316,232,o),
+(324,289,o),
+(392,378,cs),
+(615,671,l),
+(618,706,l),
+(177,706,l),
+(76,498,l),
+(116,498,l),
+(145,566,o),
+(171,576,o),
+(226,576,cs),
+(483,576,l),
+(483,572,l),
+(302,334,ls),
+(158,144,o),
+(142,120,o),
+(142,77,cs),
+(142,14,o),
+(176,-10,o),
+(225,-10,cs)
+);
+}
+);
+width = 522;
+}
+);
+unicode = 55;
+},
+{
+glyphname = eight;
+lastChange = "2016-08-22 12:56:48 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(443,-13,o),
+(569,90,o),
+(569,197,cs),
+(569,289,o),
+(476,370,o),
+(336,370,cs),
+(182,370,o),
+(57,273,o),
+(57,159,cs),
+(57,62,o),
+(146,-13,o),
+(283,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,12,o),
+(180,46,o),
+(180,126,cs),
+(180,246,o),
+(253,349,o),
+(352,349,cs),
+(414,349,o),
+(448,308,o),
+(448,233,cs),
+(448,154,o),
+(410,12,o),
+(277,12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(413,361,l),
+(532,381,o),
+(617,470,o),
+(617,555,cs),
+(617,636,o),
+(539,707,o),
+(416,707,c),
+(279,707,o),
+(156,620,o),
+(156,516,cs),
+(156,449,o),
+(207,390,o),
+(289,367,c),
+(289,363,l),
+(413,357,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(299,370,o),
+(265,405,o),
+(265,483,cs),
+(265,592,o),
+(332,686,o),
+(423,686,cs),
+(477,686,o),
+(506,652,o),
+(506,585,cs),
+(506,513,o),
+(473,370,o),
+(357,370,cs)
+);
+}
+);
+width = 610;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,-13,o),
+(580,90,o),
+(580,197,cs),
+(580,289,o),
+(484,370,o),
+(335,370,cs),
+(172,370,o),
+(38,273,o),
+(38,159,cs),
+(38,62,o),
+(136,-13,o),
+(281,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,22,o),
+(197,52,o),
+(197,126,cs),
+(197,242,o),
+(268,344,o),
+(348,344,cs),
+(397,344,o),
+(423,305,o),
+(423,235,cs),
+(423,156,o),
+(389,22,o),
+(278,22,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,365,l),
+(539,385,o),
+(628,474,o),
+(628,559,cs),
+(628,640,o),
+(547,711,o),
+(416,711,cs),
+(271,711,o),
+(137,624,o),
+(137,520,cs),
+(137,453,o),
+(192,393,o),
+(280,370,c),
+(280,366,l),
+(414,361,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(311,384,o),
+(292,410,o),
+(292,469,cs),
+(292,555,o),
+(332,685,o),
+(423,685,cs),
+(457,685,o),
+(481,667,o),
+(481,606,cs),
+(481,540,o),
+(453,384,o),
+(352,384,cs)
+);
+}
+);
+width = 630;
+}
+);
+unicode = 56;
+},
+{
+glyphname = nine;
+lastChange = "2016-08-22 13:53:04 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,-13,o),
+(610,241,o),
+(610,497,cs),
+(610,632,o),
+(532,731,o),
+(402,731,cs),
+(241,731,o),
+(106,581,o),
+(106,441,cs),
+(106,334,o),
+(184,256,o),
+(297,256,c),
+(343,256,o),
+(381,269,o),
+(434,304,c),
+(437,301,l),
+(408,170,o),
+(278,32,o),
+(100,12,c),
+(100,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(245,281,o),
+(221,317,o),
+(221,394,cs),
+(221,493,o),
+(261,706,o),
+(410,706,c),
+(471,706,o),
+(503,671,o),
+(503,576,cs),
+(503,498,o),
+(481,412,o),
+(463,366,c),
+(408,308,o),
+(353,281,o),
+(303,281,cs)
+);
+}
+);
+width = 595;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(331,-13,o),
+(638,215,o),
+(638,490,cs),
+(638,635,o),
+(552,731,o),
+(412,731,cs),
+(242,731,o),
+(97,591,o),
+(97,451,cs),
+(97,345,o),
+(179,256,o),
+(296,256,c),
+(341,256,o),
+(378,269,o),
+(422,304,c),
+(425,301,l),
+(396,175,o),
+(266,41,o),
+(88,22,c),
+(88,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(266,291,o),
+(257,327,o),
+(257,376,cs),
+(257,472,o),
+(291,701,o),
+(417,701,c),
+(468,701,o),
+(481,664,o),
+(481,595,cs),
+(481,506,o),
+(459,410,o),
+(441,366,c),
+(398,315,o),
+(356,291,o),
+(316,291,cs)
+);
+}
+);
+width = 615;
+}
+);
+unicode = 57;
+},
+{
+glyphname = zero.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(24,534,o),
+(101,451,o),
+(203,451,cs),
+(305,451,o),
+(383,534,o),
+(383,656,cs),
+(383,778,o),
+(305,862,o),
+(203,862,cs),
+(101,862,o),
+(24,778,o),
+(24,656,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,807,o),
+(144,842,o),
+(203,842,cs),
+(259,842,o),
+(280,807,o),
+(280,656,cs),
+(280,506,o),
+(259,472,o),
+(203,472,cs),
+(144,472,o),
+(126,506,o),
+(126,656,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(271,-5,o),
+(356,138,o),
+(356,245,cs),
+(356,313,o),
+(320,390,o),
+(243,390,cs),
+(145,390,o),
+(41,264,o),
+(41,140,cs),
+(41,66,o),
+(77,-5,o),
+(157,-5,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(142,12,o),
+(126,19,o),
+(126,68,cs),
+(126,145,o),
+(167,372,o),
+(241,372,cs),
+(260,372,o),
+(271,358,o),
+(271,314,cs),
+(271,235,o),
+(234,12,o),
+(156,12,cs)
+);
+}
+);
+width = 391;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,-5,o),
+(366,138,o),
+(366,245,cs),
+(366,313,o),
+(330,390,o),
+(253,390,cs),
+(155,390,o),
+(51,264,o),
+(51,140,cs),
+(51,66,o),
+(87,-5,o),
+(167,-5,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(152,12,o),
+(136,19,o),
+(136,68,cs),
+(136,145,o),
+(177,372,o),
+(251,372,cs),
+(270,372,o),
+(281,358,o),
+(281,314,cs),
+(281,235,o),
+(244,12,o),
+(166,12,cs)
+);
+}
+);
+width = 411;
+}
+);
+},
+{
+glyphname = one.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(4,836,l),
+(91,836,l),
+(91,476,l),
+(4,476,l),
+(4,459,l),
+(266,459,l),
+(266,476,l),
+(184,476,l),
+(184,854,l),
+(4,854,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,0,l),
+(217,21,l),
+(143,21,l),
+(223,389,l),
+(52,389,l),
+(52,368,l),
+(128,368,l),
+(57,21,l),
+(-14,21,l),
+(-14,0,l)
+);
+}
+);
+width = 278;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(227,0,l),
+(227,21,l),
+(153,21,l),
+(233,389,l),
+(62,389,l),
+(62,368,l),
+(138,368,l),
+(67,21,l),
+(-4,21,l),
+(-4,0,l)
+);
+}
+);
+width = 298;
+}
+);
+},
+{
+glyphname = two.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,602,l),
+(304,549,o),
+(296,544,o),
+(271,544,cs),
+(89,544,l),
+(89,548,l),
+(247,643,ls),
+(303,676,o),
+(321,715,o),
+(321,755,cs),
+(321,832,o),
+(249,862,o),
+(180,862,cs),
+(107,862,o),
+(34,829,o),
+(34,762,cs),
+(34,730,o),
+(51,695,o),
+(92,695,cs),
+(117,695,o),
+(141,710,o),
+(141,743,cs),
+(141,766,o),
+(129,784,o),
+(104,784,cs),
+(88,784,o),
+(82,777,o),
+(76,777,cs),
+(71,777,o),
+(68,781,o),
+(68,788,cs),
+(68,810,o),
+(102,838,o),
+(142,838,cs),
+(190,838,o),
+(220,799,o),
+(220,735,cs),
+(220,691,o),
+(206,659,o),
+(146,614,cs),
+(17,516,l),
+(17,459,l),
+(321,459,l),
+(321,602,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,0,l),
+(290,126,l),
+(272,126,l),
+(263,84,o),
+(258,80,o),
+(241,80,cs),
+(86,80,l),
+(86,84,l),
+(226,164,ls),
+(300,206,o),
+(319,253,o),
+(319,287,cs),
+(319,349,o),
+(260,389,o),
+(186,389,cs),
+(94,389,o),
+(56,327,o),
+(56,280,cs),
+(56,234,o),
+(93,226,o),
+(109,226,cs),
+(132,226,o),
+(152,242,o),
+(152,269,cs),
+(152,315,o),
+(96,306,o),
+(96,324,cs),
+(96,335,o),
+(124,368,o),
+(165,368,cs),
+(198,368,o),
+(220,348,o),
+(220,294,cs),
+(220,248,o),
+(206,193,o),
+(117,131,cs),
+(12,58,l),
+(-1,0,l)
+);
+}
+);
+width = 350;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,0,l),
+(300,126,l),
+(282,126,l),
+(273,84,o),
+(268,80,o),
+(251,80,cs),
+(96,80,l),
+(96,84,l),
+(236,164,ls),
+(310,206,o),
+(329,253,o),
+(329,287,cs),
+(329,349,o),
+(270,389,o),
+(196,389,cs),
+(104,389,o),
+(66,327,o),
+(66,280,cs),
+(66,234,o),
+(103,226,o),
+(119,226,cs),
+(142,226,o),
+(162,242,o),
+(162,269,cs),
+(162,315,o),
+(106,306,o),
+(106,324,cs),
+(106,335,o),
+(134,368,o),
+(175,368,cs),
+(208,368,o),
+(230,348,o),
+(230,294,cs),
+(230,248,o),
+(216,193,o),
+(127,131,cs),
+(22,58,l),
+(9,0,l)
+);
+}
+);
+width = 370;
+}
+);
+},
+{
+glyphname = three.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,663,l),
+(182,663,o),
+(208,630,o),
+(208,568,cs),
+(208,507,o),
+(183,472,o),
+(133,472,cs),
+(115,472,o),
+(74,476,o),
+(74,490,cs),
+(74,505,o),
+(111,507,o),
+(111,547,cs),
+(111,583,o),
+(83,591,o),
+(64,591,cs),
+(30,591,o),
+(13,563,o),
+(13,532,cs),
+(13,482,o),
+(61,451,o),
+(141,451,cs),
+(249,451,o),
+(317,509,o),
+(317,572,cs),
+(317,642,o),
+(253,675,o),
+(172,678,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,663,l),
+(172,663,l),
+(172,684,l),
+(76,684,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,678,l),
+(253,685,o),
+(299,721,o),
+(299,772,cs),
+(299,827,o),
+(247,862,o),
+(161,862,cs),
+(71,862,o),
+(36,823,o),
+(36,784,cs),
+(36,755,o),
+(55,739,o),
+(81,739,cs),
+(104,739,o),
+(130,751,o),
+(130,778,cs),
+(130,807,o),
+(99,812,o),
+(99,826,cs),
+(99,839,o),
+(123,842,o),
+(143,842,cs),
+(176,842,o),
+(197,830,o),
+(197,777,cs),
+(197,717,o),
+(170,684,o),
+(100,684,c)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(200,-8,o),
+(271,43,o),
+(271,111,cs),
+(271,168,o),
+(221,206,o),
+(171,206,c),
+(171,210,l),
+(244,230,o),
+(282,266,o),
+(282,310,cs),
+(282,354,o),
+(246,391,o),
+(177,391,cs),
+(115,391,o),
+(68,359,o),
+(68,317,cs),
+(68,292,o),
+(85,281,o),
+(102,281,cs),
+(123,281,o),
+(138,297,o),
+(138,315,cs),
+(138,337,o),
+(117,336,o),
+(117,352,cs),
+(117,364,o),
+(131,373,o),
+(158,373,cs),
+(184,373,o),
+(201,366,o),
+(201,329,cs),
+(201,284,o),
+(174,218,o),
+(120,218,cs),
+(108,218,o),
+(95,221,o),
+(89,221,cs),
+(81,221,o),
+(74,215,o),
+(74,205,cs),
+(74,197,o),
+(79,190,o),
+(92,190,cs),
+(103,190,o),
+(100,195,o),
+(122,195,cs),
+(161,195,o),
+(174,171,o),
+(174,117,cs),
+(174,25,o),
+(132,9,o),
+(95,9,cs),
+(70,9,o),
+(35,19,o),
+(35,34,cs),
+(35,48,o),
+(69,46,o),
+(69,75,cs),
+(69,95,o),
+(53,108,o),
+(33,108,cs),
+(8,108,o),
+(-3,85,o),
+(-3,62,cs),
+(-3,25,o),
+(27,-8,o),
+(104,-8,cs)
+);
+}
+);
+width = 337;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,-8,o),
+(281,43,o),
+(281,111,cs),
+(281,168,o),
+(231,206,o),
+(181,206,c),
+(181,210,l),
+(254,230,o),
+(292,266,o),
+(292,310,cs),
+(292,354,o),
+(256,391,o),
+(187,391,cs),
+(125,391,o),
+(78,359,o),
+(78,317,cs),
+(78,292,o),
+(95,281,o),
+(112,281,cs),
+(133,281,o),
+(148,297,o),
+(148,315,cs),
+(148,337,o),
+(127,336,o),
+(127,352,cs),
+(127,364,o),
+(141,373,o),
+(168,373,cs),
+(194,373,o),
+(211,366,o),
+(211,329,cs),
+(211,284,o),
+(184,218,o),
+(130,218,cs),
+(118,218,o),
+(105,221,o),
+(99,221,cs),
+(91,221,o),
+(84,215,o),
+(84,205,cs),
+(84,197,o),
+(89,190,o),
+(102,190,cs),
+(113,190,o),
+(110,195,o),
+(132,195,cs),
+(171,195,o),
+(184,171,o),
+(184,117,cs),
+(184,25,o),
+(142,9,o),
+(105,9,cs),
+(80,9,o),
+(45,19,o),
+(45,34,cs),
+(45,48,o),
+(79,46,o),
+(79,75,cs),
+(79,95,o),
+(63,108,o),
+(43,108,cs),
+(18,108,o),
+(7,85,o),
+(7,62,cs),
+(7,25,o),
+(37,-8,o),
+(114,-8,cs)
+);
+}
+);
+width = 357;
+}
+);
+},
+{
+glyphname = four.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,588,l),
+(36,592,l),
+(171,779,l),
+(175,779,l),
+(175,588,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,569,l),
+(338,524,l),
+(356,524,l),
+(356,631,l),
+(338,631,l),
+(338,588,l),
+(268,588,l),
+(268,862,l),
+(208,862,l),
+(8,588,l),
+(8,569,l),
+(175,569,l),
+(175,476,l),
+(115,476,l),
+(115,459,l),
+(322,459,l),
+(322,476,l),
+(267,476,l),
+(267,569,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,0,l),
+(263,17,l),
+(220,17,l),
+(239,104,l),
+(288,104,l),
+(277,60,l),
+(294,60,l),
+(319,159,l),
+(302,159,l),
+(293,123,l),
+(243,123,l),
+(300,389,l),
+(257,389,l),
+(13,123,l),
+(13,104,l),
+(152,104,l),
+(133,17,l),
+(95,17,l),
+(95,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,291,l),
+(191,291,l),
+(156,123,l),
+(37,123,l)
+);
+}
+);
+width = 377;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(273,0,l),
+(273,17,l),
+(230,17,l),
+(249,104,l),
+(298,104,l),
+(287,60,l),
+(304,60,l),
+(329,159,l),
+(312,159,l),
+(303,123,l),
+(253,123,l),
+(310,389,l),
+(267,389,l),
+(23,123,l),
+(23,104,l),
+(162,104,l),
+(143,17,l),
+(105,17,l),
+(105,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(196,291,l),
+(201,291,l),
+(166,123,l),
+(47,123,l)
+);
+}
+);
+width = 397;
+}
+);
+},
+{
+glyphname = five.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,769,l),
+(292,769,l),
+(312,876,l),
+(295,876,l),
+(288,857,o),
+(281,854,o),
+(259,854,cs),
+(65,854,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(47,668,l),
+(56,661,l),
+(70,687,l),
+(84,854,l),
+(61,854,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,706,o),
+(73,696,o),
+(63,690,c),
+(56,661,l),
+(67,671,o),
+(101,678,o),
+(128,678,cs),
+(183,678,o),
+(222,647,o),
+(222,571,cs),
+(222,504,o),
+(192,472,o),
+(135,472,cs),
+(113,472,o),
+(81,476,o),
+(81,488,cs),
+(81,500,o),
+(117,501,o),
+(117,539,cs),
+(117,571,o),
+(92,584,o),
+(68,584,cs),
+(37,584,o),
+(15,562,o),
+(15,530,cs),
+(15,485,o),
+(62,451,o),
+(149,451,cs),
+(251,451,o),
+(333,498,o),
+(333,582,cs),
+(333,648,o),
+(282,706,o),
+(170,706,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,-6,o),
+(292,65,o),
+(292,134,cs),
+(292,195,o),
+(237,237,o),
+(150,237,cs),
+(126,237,o),
+(106,234,o),
+(79,225,c),
+(77,228,l),
+(101,310,l),
+(284,310,l),
+(330,417,l),
+(314,417,l),
+(299,392,o),
+(293,390,o),
+(255,390,cs),
+(101,390,l),
+(50,208,l),
+(61,195,l),
+(84,206,o),
+(110,211,o),
+(132,211,cs),
+(167,211,o),
+(192,198,o),
+(192,148,cs),
+(192,102,o),
+(172,11,o),
+(109,11,cs),
+(83,11,o),
+(64,28,o),
+(64,37,cs),
+(64,48,o),
+(94,55,o),
+(94,87,cs),
+(94,113,o),
+(76,128,o),
+(54,128,cs),
+(23,128,o),
+(8,98,o),
+(8,71,cs),
+(8,35,o),
+(35,-6,o),
+(116,-6,cs)
+);
+}
+);
+width = 349;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,-6,o),
+(302,65,o),
+(302,134,cs),
+(302,195,o),
+(247,237,o),
+(160,237,cs),
+(136,237,o),
+(116,234,o),
+(89,225,c),
+(87,228,l),
+(111,310,l),
+(294,310,l),
+(340,417,l),
+(324,417,l),
+(309,392,o),
+(303,390,o),
+(265,390,cs),
+(111,390,l),
+(60,208,l),
+(71,195,l),
+(94,206,o),
+(120,211,o),
+(142,211,cs),
+(177,211,o),
+(202,198,o),
+(202,148,cs),
+(202,102,o),
+(182,11,o),
+(119,11,cs),
+(93,11,o),
+(74,28,o),
+(74,37,cs),
+(74,48,o),
+(104,55,o),
+(104,87,cs),
+(104,113,o),
+(86,128,o),
+(64,128,cs),
+(33,128,o),
+(18,98,o),
+(18,71,cs),
+(18,35,o),
+(45,-6,o),
+(126,-6,cs)
+);
+}
+);
+width = 369;
+}
+);
+},
+{
+glyphname = six.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,874,l),
+(147,869,o),
+(25,747,o),
+(25,619,cs),
+(25,517,o),
+(94,451,o),
+(180,451,cs),
+(260,451,o),
+(334,509,o),
+(334,588,cs),
+(334,658,o),
+(275,712,o),
+(203,712,cs),
+(173,712,o),
+(153,703,o),
+(136,689,c),
+(132,689,l),
+(144,771,o),
+(199,844,o),
+(287,854,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,599,o),
+(121,627,o),
+(126,650,c),
+(138,670,o),
+(157,688,o),
+(186,688,cs),
+(216,688,o),
+(233,669,o),
+(233,580,cs),
+(233,501,o),
+(220,472,o),
+(178,472,cs),
+(136,472,o),
+(121,500,o),
+(121,580,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,-7,o),
+(306,68,o),
+(306,145,cs),
+(306,204,o),
+(261,255,o),
+(196,255,cs),
+(172,255,o),
+(152,247,o),
+(129,228,c),
+(126,231,l),
+(142,299,o),
+(214,371,o),
+(312,382,c),
+(312,403,l),
+(176,403,o),
+(5,282,o),
+(5,127,cs),
+(5,45,o),
+(53,-7,o),
+(131,-7,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(102,10,o),
+(98,31,o),
+(98,64,cs),
+(98,115,o),
+(110,170,o),
+(120,194,c),
+(142,221,o),
+(163,233,o),
+(183,233,cs),
+(209,233,o),
+(212,214,o),
+(212,192,cs),
+(212,140,o),
+(194,10,o),
+(129,10,cs)
+);
+}
+);
+width = 348;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,-7,o),
+(316,68,o),
+(316,145,cs),
+(316,204,o),
+(271,255,o),
+(206,255,cs),
+(182,255,o),
+(162,247,o),
+(139,228,c),
+(136,231,l),
+(152,299,o),
+(224,371,o),
+(322,382,c),
+(322,403,l),
+(186,403,o),
+(15,282,o),
+(15,127,cs),
+(15,45,o),
+(63,-7,o),
+(141,-7,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(112,10,o),
+(108,31,o),
+(108,64,cs),
+(108,115,o),
+(120,170,o),
+(130,194,c),
+(152,221,o),
+(173,233,o),
+(193,233,cs),
+(219,233,o),
+(222,214,o),
+(222,192,cs),
+(222,140,o),
+(204,10,o),
+(139,10,cs)
+);
+}
+);
+width = 368;
+}
+);
+},
+{
+glyphname = seven.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(20,707,l),
+(41,707,l),
+(59,759,o),
+(57,768,o),
+(70,768,cs),
+(261,768,l),
+(166,618,ls),
+(127,557,o),
+(111,530,o),
+(111,501,cs),
+(111,471,o),
+(129,451,o),
+(166,451,cs),
+(199,451,o),
+(226,466,o),
+(226,501,cs),
+(226,528,o),
+(209,560,o),
+(209,597,cs),
+(209,621,o),
+(220,651,o),
+(245,690,cs),
+(325,818,l),
+(325,854,l),
+(60,854,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,-9,o),
+(188,13,o),
+(188,49,cs),
+(188,68,o),
+(181,79,o),
+(181,108,cs),
+(181,128,o),
+(184,158,o),
+(220,205,cs),
+(344,365,l),
+(345,386,l),
+(101,386,l),
+(45,268,l),
+(68,268,l),
+(83,302,o),
+(97,307,o),
+(125,307,cs),
+(264,307,l),
+(264,303,l),
+(168,181,ls),
+(86,77,o),
+(79,67,o),
+(79,43,cs),
+(79,6,o),
+(99,-9,o),
+(128,-9,cs)
+);
+}
+);
+width = 335;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(174,-9,o),
+(198,13,o),
+(198,49,cs),
+(198,68,o),
+(191,79,o),
+(191,108,cs),
+(191,128,o),
+(194,158,o),
+(230,205,cs),
+(354,365,l),
+(355,386,l),
+(111,386,l),
+(55,268,l),
+(78,268,l),
+(93,302,o),
+(107,307,o),
+(135,307,cs),
+(274,307,l),
+(274,303,l),
+(178,181,ls),
+(96,77,o),
+(89,67,o),
+(89,43,cs),
+(89,6,o),
+(109,-9,o),
+(138,-9,cs)
+);
+}
+);
+width = 355;
+}
+);
+},
+{
+glyphname = eight.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,622,o),
+(133,654,o),
+(176,654,cs),
+(219,654,o),
+(233,620,o),
+(233,559,cs),
+(233,494,o),
+(216,468,o),
+(176,468,cs),
+(135,468,o),
+(118,494,o),
+(118,559,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,815,o),
+(273,862,o),
+(175,862,cs),
+(81,862,o),
+(34,818,o),
+(34,764,cs),
+(34,702,o),
+(97,664,o),
+(176,664,cs),
+(256,664,o),
+(318,702,o),
+(318,763,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,705,o),
+(211,675,o),
+(176,675,cs),
+(142,675,o),
+(129,705,o),
+(129,762,cs),
+(129,818,o),
+(142,842,o),
+(176,842,cs),
+(211,842,o),
+(223,818,o),
+(223,762,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(17,497,o),
+(69,451,o),
+(176,451,cs),
+(283,451,o),
+(334,497,o),
+(334,555,cs),
+(334,618,o),
+(283,650,o),
+(213,664,c),
+(213,668,l),
+(140,668,l),
+(140,664,l),
+(68,651,o),
+(17,618,o),
+(17,555,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,-9,o),
+(297,48,o),
+(297,107,cs),
+(297,147,o),
+(262,184,o),
+(204,196,c),
+(204,200,l),
+(274,211,o),
+(323,259,o),
+(323,306,cs),
+(323,351,o),
+(278,390,o),
+(205,390,cs),
+(125,390,o),
+(50,342,o),
+(50,285,cs),
+(50,248,o),
+(81,215,o),
+(130,203,c),
+(130,199,l),
+(54,188,o),
+(-4,140,o),
+(-4,86,cs),
+(-4,32,o),
+(51,-9,o),
+(131,-9,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(104,12,o),
+(88,28,o),
+(88,67,cs),
+(88,131,o),
+(127,187,o),
+(168,187,cs),
+(192,187,o),
+(205,166,o),
+(205,128,cs),
+(205,84,o),
+(187,12,o),
+(130,12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,212,o),
+(142,224,o),
+(142,253,cs),
+(142,296,o),
+(159,375,o),
+(209,375,cs),
+(225,375,o),
+(237,368,o),
+(237,335,cs),
+(237,300,o),
+(223,212,o),
+(170,212,cs)
+);
+}
+);
+width = 352;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,-9,o),
+(307,48,o),
+(307,107,cs),
+(307,147,o),
+(272,184,o),
+(214,196,c),
+(214,200,l),
+(284,211,o),
+(333,259,o),
+(333,306,cs),
+(333,351,o),
+(288,390,o),
+(215,390,cs),
+(135,390,o),
+(60,342,o),
+(60,285,cs),
+(60,248,o),
+(91,215,o),
+(140,203,c),
+(140,199,l),
+(64,188,o),
+(6,140,o),
+(6,86,cs),
+(6,32,o),
+(61,-9,o),
+(141,-9,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(114,12,o),
+(98,28,o),
+(98,67,cs),
+(98,131,o),
+(137,187,o),
+(178,187,cs),
+(202,187,o),
+(215,166,o),
+(215,128,cs),
+(215,84,o),
+(197,12,o),
+(140,12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(160,212,o),
+(152,224,o),
+(152,253,cs),
+(152,296,o),
+(169,375,o),
+(219,375,cs),
+(235,375,o),
+(247,368,o),
+(247,335,cs),
+(247,300,o),
+(233,212,o),
+(180,212,cs)
+);
+}
+);
+width = 372;
+}
+);
+},
+{
+glyphname = nine.denominator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,455,l),
+(196,460,o),
+(325,563,o),
+(325,694,cs),
+(325,796,o),
+(256,862,o),
+(169,862,cs),
+(89,862,o),
+(16,803,o),
+(16,725,cs),
+(16,655,o),
+(74,601,o),
+(147,601,cs),
+(176,601,o),
+(195,608,o),
+(213,623,c),
+(217,623,l),
+(205,540,o),
+(145,484,o),
+(57,475,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,713,o),
+(228,686,o),
+(223,663,c),
+(212,642,o),
+(192,625,o),
+(163,625,cs),
+(133,625,o),
+(116,644,o),
+(116,732,cs),
+(116,812,o),
+(129,842,o),
+(171,842,cs),
+(213,842,o),
+(228,812,o),
+(228,733,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,-9,o),
+(330,112,o),
+(330,267,cs),
+(330,349,o),
+(282,401,o),
+(204,401,cs),
+(110,401,o),
+(29,326,o),
+(29,248,cs),
+(29,190,o),
+(75,139,o),
+(139,139,cs),
+(164,139,o),
+(184,146,o),
+(206,166,c),
+(208,163,l),
+(192,94,o),
+(121,22,o),
+(24,12,c),
+(24,-9,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,160,o),
+(123,180,o),
+(123,202,cs),
+(123,254,o),
+(141,383,o),
+(207,383,cs),
+(233,383,o),
+(237,363,o),
+(237,329,cs),
+(237,278,o),
+(225,224,o),
+(215,200,c),
+(194,173,o),
+(173,160,o),
+(152,160,cs)
+);
+}
+);
+width = 348;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(169,-9,o),
+(340,112,o),
+(340,267,cs),
+(340,349,o),
+(292,401,o),
+(214,401,cs),
+(120,401,o),
+(39,326,o),
+(39,248,cs),
+(39,190,o),
+(85,139,o),
+(149,139,cs),
+(174,139,o),
+(194,146,o),
+(216,166,c),
+(218,163,l),
+(202,94,o),
+(131,22,o),
+(34,12,c),
+(34,-9,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(136,160,o),
+(133,180,o),
+(133,202,cs),
+(133,254,o),
+(151,383,o),
+(217,383,cs),
+(243,383,o),
+(247,363,o),
+(247,329,cs),
+(247,278,o),
+(235,224,o),
+(225,200,c),
+(204,173,o),
+(183,160,o),
+(162,160,cs)
+);
+}
+);
+width = 368;
+}
+);
+},
+{
+glyphname = zero.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(24,534,o),
+(101,451,o),
+(203,451,cs),
+(305,451,o),
+(383,534,o),
+(383,656,cs),
+(383,778,o),
+(305,862,o),
+(203,862,cs),
+(101,862,o),
+(24,778,o),
+(24,656,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,807,o),
+(144,842,o),
+(203,842,cs),
+(259,842,o),
+(280,807,o),
+(280,656,cs),
+(280,506,o),
+(259,472,o),
+(203,472,cs),
+(144,472,o),
+(126,506,o),
+(126,656,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,359,o),
+(442,502,o),
+(442,609,cs),
+(442,677,o),
+(406,754,o),
+(329,754,cs),
+(231,754,o),
+(127,628,o),
+(127,504,cs),
+(127,430,o),
+(163,359,o),
+(243,359,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,376,o),
+(212,383,o),
+(212,432,cs),
+(212,509,o),
+(253,736,o),
+(327,736,cs),
+(346,736,o),
+(357,722,o),
+(357,678,cs),
+(357,599,o),
+(320,376,o),
+(242,376,cs)
+);
+}
+);
+width = 391;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,359,o),
+(452,502,o),
+(452,609,cs),
+(452,677,o),
+(416,754,o),
+(339,754,cs),
+(241,754,o),
+(137,628,o),
+(137,504,cs),
+(137,430,o),
+(173,359,o),
+(253,359,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(238,376,o),
+(222,383,o),
+(222,432,cs),
+(222,509,o),
+(263,736,o),
+(337,736,cs),
+(356,736,o),
+(367,722,o),
+(367,678,cs),
+(367,599,o),
+(330,376,o),
+(252,376,cs)
+);
+}
+);
+width = 411;
+}
+);
+},
+{
+glyphname = one.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(4,836,l),
+(91,836,l),
+(91,476,l),
+(4,476,l),
+(4,459,l),
+(266,459,l),
+(266,476,l),
+(184,476,l),
+(184,854,l),
+(4,854,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(297,359,l),
+(297,380,l),
+(223,380,l),
+(303,748,l),
+(132,748,l),
+(132,727,l),
+(208,727,l),
+(137,380,l),
+(66,380,l),
+(66,359,l)
+);
+}
+);
+width = 278;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,359,l),
+(307,380,l),
+(233,380,l),
+(313,748,l),
+(142,748,l),
+(142,727,l),
+(218,727,l),
+(147,380,l),
+(76,380,l),
+(76,359,l)
+);
+}
+);
+width = 298;
+}
+);
+},
+{
+glyphname = two.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,602,l),
+(304,549,o),
+(296,544,o),
+(271,544,cs),
+(89,544,l),
+(89,548,l),
+(247,643,ls),
+(303,676,o),
+(321,715,o),
+(321,755,cs),
+(321,832,o),
+(249,862,o),
+(180,862,cs),
+(107,862,o),
+(34,829,o),
+(34,762,cs),
+(34,730,o),
+(51,695,o),
+(92,695,cs),
+(117,695,o),
+(141,710,o),
+(141,743,cs),
+(141,766,o),
+(129,784,o),
+(104,784,cs),
+(88,784,o),
+(82,777,o),
+(76,777,cs),
+(71,777,o),
+(68,781,o),
+(68,788,cs),
+(68,810,o),
+(102,838,o),
+(142,838,cs),
+(190,838,o),
+(220,799,o),
+(220,735,cs),
+(220,691,o),
+(206,659,o),
+(146,614,cs),
+(17,516,l),
+(17,459,l),
+(321,459,l),
+(321,602,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(340,358,l),
+(372,484,l),
+(354,484,l),
+(345,442,o),
+(340,438,o),
+(323,438,cs),
+(168,438,l),
+(168,442,l),
+(308,522,ls),
+(382,564,o),
+(401,611,o),
+(401,645,cs),
+(401,707,o),
+(342,747,o),
+(268,747,cs),
+(176,747,o),
+(138,685,o),
+(138,638,cs),
+(138,592,o),
+(175,584,o),
+(191,584,cs),
+(214,584,o),
+(234,600,o),
+(234,627,cs),
+(234,673,o),
+(178,664,o),
+(178,682,cs),
+(178,693,o),
+(206,726,o),
+(247,726,cs),
+(280,726,o),
+(302,706,o),
+(302,652,cs),
+(302,606,o),
+(288,551,o),
+(199,489,cs),
+(94,416,l),
+(81,358,l)
+);
+}
+);
+width = 350;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,358,l),
+(382,484,l),
+(364,484,l),
+(355,442,o),
+(350,438,o),
+(333,438,cs),
+(178,438,l),
+(178,442,l),
+(318,522,ls),
+(392,564,o),
+(411,611,o),
+(411,645,cs),
+(411,707,o),
+(352,747,o),
+(278,747,cs),
+(186,747,o),
+(148,685,o),
+(148,638,cs),
+(148,592,o),
+(185,584,o),
+(201,584,cs),
+(224,584,o),
+(244,600,o),
+(244,627,cs),
+(244,673,o),
+(188,664,o),
+(188,682,cs),
+(188,693,o),
+(216,726,o),
+(257,726,cs),
+(290,726,o),
+(312,706,o),
+(312,652,cs),
+(312,606,o),
+(298,551,o),
+(209,489,cs),
+(104,416,l),
+(91,358,l)
+);
+}
+);
+width = 370;
+}
+);
+},
+{
+glyphname = three.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,663,l),
+(182,663,o),
+(208,630,o),
+(208,568,cs),
+(208,507,o),
+(183,472,o),
+(133,472,cs),
+(115,472,o),
+(74,476,o),
+(74,490,cs),
+(74,505,o),
+(111,507,o),
+(111,547,cs),
+(111,583,o),
+(83,591,o),
+(64,591,cs),
+(30,591,o),
+(13,563,o),
+(13,532,cs),
+(13,482,o),
+(61,451,o),
+(141,451,cs),
+(249,451,o),
+(317,509,o),
+(317,572,cs),
+(317,642,o),
+(253,675,o),
+(172,678,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,663,l),
+(172,663,l),
+(172,684,l),
+(76,684,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,678,l),
+(253,685,o),
+(299,721,o),
+(299,772,cs),
+(299,827,o),
+(247,862,o),
+(161,862,cs),
+(71,862,o),
+(36,823,o),
+(36,784,cs),
+(36,755,o),
+(55,739,o),
+(81,739,cs),
+(104,739,o),
+(130,751,o),
+(130,778,cs),
+(130,807,o),
+(99,812,o),
+(99,826,cs),
+(99,839,o),
+(123,842,o),
+(143,842,cs),
+(176,842,o),
+(197,830,o),
+(197,777,cs),
+(197,717,o),
+(170,684,o),
+(100,684,c)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(288,351,o),
+(359,402,o),
+(359,470,cs),
+(359,527,o),
+(309,565,o),
+(259,565,c),
+(259,569,l),
+(332,589,o),
+(370,625,o),
+(370,669,cs),
+(370,713,o),
+(334,750,o),
+(265,750,cs),
+(203,750,o),
+(156,718,o),
+(156,676,cs),
+(156,651,o),
+(173,640,o),
+(190,640,cs),
+(211,640,o),
+(226,656,o),
+(226,674,cs),
+(226,696,o),
+(205,695,o),
+(205,711,cs),
+(205,723,o),
+(219,732,o),
+(246,732,cs),
+(272,732,o),
+(289,725,o),
+(289,688,cs),
+(289,643,o),
+(262,577,o),
+(208,577,cs),
+(196,577,o),
+(183,580,o),
+(177,580,cs),
+(169,580,o),
+(162,574,o),
+(162,564,cs),
+(162,556,o),
+(167,549,o),
+(180,549,cs),
+(191,549,o),
+(188,554,o),
+(210,554,cs),
+(249,554,o),
+(262,530,o),
+(262,476,cs),
+(262,384,o),
+(220,368,o),
+(183,368,cs),
+(158,368,o),
+(123,378,o),
+(123,393,cs),
+(123,407,o),
+(157,405,o),
+(157,434,cs),
+(157,454,o),
+(141,467,o),
+(121,467,cs),
+(96,467,o),
+(85,444,o),
+(85,421,cs),
+(85,384,o),
+(115,351,o),
+(192,351,cs)
+);
+}
+);
+width = 337;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,351,o),
+(369,402,o),
+(369,470,cs),
+(369,527,o),
+(319,565,o),
+(269,565,c),
+(269,569,l),
+(342,589,o),
+(380,625,o),
+(380,669,cs),
+(380,713,o),
+(344,750,o),
+(275,750,cs),
+(213,750,o),
+(166,718,o),
+(166,676,cs),
+(166,651,o),
+(183,640,o),
+(200,640,cs),
+(221,640,o),
+(236,656,o),
+(236,674,cs),
+(236,696,o),
+(215,695,o),
+(215,711,cs),
+(215,723,o),
+(229,732,o),
+(256,732,cs),
+(282,732,o),
+(299,725,o),
+(299,688,cs),
+(299,643,o),
+(272,577,o),
+(218,577,cs),
+(206,577,o),
+(193,580,o),
+(187,580,cs),
+(179,580,o),
+(172,574,o),
+(172,564,cs),
+(172,556,o),
+(177,549,o),
+(190,549,cs),
+(201,549,o),
+(198,554,o),
+(220,554,cs),
+(259,554,o),
+(272,530,o),
+(272,476,cs),
+(272,384,o),
+(230,368,o),
+(193,368,cs),
+(168,368,o),
+(133,378,o),
+(133,393,cs),
+(133,407,o),
+(167,405,o),
+(167,434,cs),
+(167,454,o),
+(151,467,o),
+(131,467,cs),
+(106,467,o),
+(95,444,o),
+(95,421,cs),
+(95,384,o),
+(125,351,o),
+(202,351,cs)
+);
+}
+);
+width = 357;
+}
+);
+},
+{
+glyphname = four.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,588,l),
+(36,592,l),
+(171,779,l),
+(175,779,l),
+(175,588,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,569,l),
+(338,524,l),
+(356,524,l),
+(356,631,l),
+(338,631,l),
+(338,588,l),
+(268,588,l),
+(268,862,l),
+(208,862,l),
+(8,588,l),
+(8,569,l),
+(175,569,l),
+(175,476,l),
+(115,476,l),
+(115,459,l),
+(322,459,l),
+(322,476,l),
+(267,476,l),
+(267,569,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,359,l),
+(347,376,l),
+(304,376,l),
+(323,463,l),
+(372,463,l),
+(361,419,l),
+(378,419,l),
+(403,518,l),
+(386,518,l),
+(377,482,l),
+(327,482,l),
+(384,748,l),
+(341,748,l),
+(97,482,l),
+(97,463,l),
+(236,463,l),
+(217,376,l),
+(179,376,l),
+(179,359,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,650,l),
+(275,650,l),
+(240,482,l),
+(121,482,l)
+);
+}
+);
+width = 377;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(357,359,l),
+(357,376,l),
+(314,376,l),
+(333,463,l),
+(382,463,l),
+(371,419,l),
+(388,419,l),
+(413,518,l),
+(396,518,l),
+(387,482,l),
+(337,482,l),
+(394,748,l),
+(351,748,l),
+(107,482,l),
+(107,463,l),
+(246,463,l),
+(227,376,l),
+(189,376,l),
+(189,359,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(280,650,l),
+(285,650,l),
+(250,482,l),
+(131,482,l)
+);
+}
+);
+width = 397;
+}
+);
+},
+{
+glyphname = five.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,769,l),
+(292,769,l),
+(312,876,l),
+(295,876,l),
+(288,857,o),
+(281,854,o),
+(259,854,cs),
+(65,854,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(47,668,l),
+(56,661,l),
+(70,687,l),
+(84,854,l),
+(61,854,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,706,o),
+(73,696,o),
+(63,690,c),
+(56,661,l),
+(67,671,o),
+(101,678,o),
+(128,678,cs),
+(183,678,o),
+(222,647,o),
+(222,571,cs),
+(222,504,o),
+(192,472,o),
+(135,472,cs),
+(113,472,o),
+(81,476,o),
+(81,488,cs),
+(81,500,o),
+(117,501,o),
+(117,539,cs),
+(117,571,o),
+(92,584,o),
+(68,584,cs),
+(37,584,o),
+(15,562,o),
+(15,530,cs),
+(15,485,o),
+(62,451,o),
+(149,451,cs),
+(251,451,o),
+(333,498,o),
+(333,582,cs),
+(333,648,o),
+(282,706,o),
+(170,706,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(312,358,o),
+(382,429,o),
+(382,498,cs),
+(382,559,o),
+(327,601,o),
+(240,601,cs),
+(216,601,o),
+(196,598,o),
+(169,589,c),
+(167,592,l),
+(191,674,l),
+(374,674,l),
+(420,781,l),
+(404,781,l),
+(389,756,o),
+(383,754,o),
+(345,754,cs),
+(191,754,l),
+(140,572,l),
+(151,559,l),
+(174,570,o),
+(200,575,o),
+(222,575,cs),
+(257,575,o),
+(282,562,o),
+(282,512,cs),
+(282,466,o),
+(262,375,o),
+(199,375,cs),
+(173,375,o),
+(154,392,o),
+(154,401,cs),
+(154,412,o),
+(184,419,o),
+(184,451,cs),
+(184,477,o),
+(166,492,o),
+(144,492,cs),
+(113,492,o),
+(98,462,o),
+(98,435,cs),
+(98,399,o),
+(125,358,o),
+(206,358,cs)
+);
+}
+);
+width = 349;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(322,358,o),
+(392,429,o),
+(392,498,cs),
+(392,559,o),
+(337,601,o),
+(250,601,cs),
+(226,601,o),
+(206,598,o),
+(179,589,c),
+(177,592,l),
+(201,674,l),
+(384,674,l),
+(430,781,l),
+(414,781,l),
+(399,756,o),
+(393,754,o),
+(355,754,cs),
+(201,754,l),
+(150,572,l),
+(161,559,l),
+(184,570,o),
+(210,575,o),
+(232,575,cs),
+(267,575,o),
+(292,562,o),
+(292,512,cs),
+(292,466,o),
+(272,375,o),
+(209,375,cs),
+(183,375,o),
+(164,392,o),
+(164,401,cs),
+(164,412,o),
+(194,419,o),
+(194,451,cs),
+(194,477,o),
+(176,492,o),
+(154,492,cs),
+(123,492,o),
+(108,462,o),
+(108,435,cs),
+(108,399,o),
+(135,358,o),
+(216,358,cs)
+);
+}
+);
+width = 369;
+}
+);
+},
+{
+glyphname = six.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,874,l),
+(147,869,o),
+(25,747,o),
+(25,619,cs),
+(25,517,o),
+(94,451,o),
+(180,451,cs),
+(260,451,o),
+(334,509,o),
+(334,588,cs),
+(334,658,o),
+(275,712,o),
+(203,712,cs),
+(173,712,o),
+(153,703,o),
+(136,689,c),
+(132,689,l),
+(144,771,o),
+(199,844,o),
+(287,854,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,599,o),
+(121,627,o),
+(126,650,c),
+(138,670,o),
+(157,688,o),
+(186,688,cs),
+(216,688,o),
+(233,669,o),
+(233,580,cs),
+(233,501,o),
+(220,472,o),
+(178,472,cs),
+(136,472,o),
+(121,500,o),
+(121,580,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(315,350,o),
+(396,425,o),
+(396,502,cs),
+(396,561,o),
+(351,612,o),
+(286,612,cs),
+(262,612,o),
+(242,604,o),
+(219,585,c),
+(216,588,l),
+(232,656,o),
+(304,728,o),
+(402,739,c),
+(402,760,l),
+(266,760,o),
+(95,639,o),
+(95,484,cs),
+(95,402,o),
+(143,350,o),
+(221,350,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(192,367,o),
+(188,388,o),
+(188,421,cs),
+(188,472,o),
+(200,527,o),
+(210,551,c),
+(232,578,o),
+(253,590,o),
+(273,590,cs),
+(299,590,o),
+(302,571,o),
+(302,549,cs),
+(302,497,o),
+(284,367,o),
+(219,367,cs)
+);
+}
+);
+width = 348;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(325,350,o),
+(406,425,o),
+(406,502,cs),
+(406,561,o),
+(361,612,o),
+(296,612,cs),
+(272,612,o),
+(252,604,o),
+(229,585,c),
+(226,588,l),
+(242,656,o),
+(314,728,o),
+(412,739,c),
+(412,760,l),
+(276,760,o),
+(105,639,o),
+(105,484,cs),
+(105,402,o),
+(153,350,o),
+(231,350,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(202,367,o),
+(198,388,o),
+(198,421,cs),
+(198,472,o),
+(210,527,o),
+(220,551,c),
+(242,578,o),
+(263,590,o),
+(283,590,cs),
+(309,590,o),
+(312,571,o),
+(312,549,cs),
+(312,497,o),
+(294,367,o),
+(229,367,cs)
+);
+}
+);
+width = 368;
+}
+);
+},
+{
+glyphname = seven.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(20,707,l),
+(41,707,l),
+(59,759,o),
+(57,768,o),
+(70,768,cs),
+(261,768,l),
+(166,618,ls),
+(127,557,o),
+(111,530,o),
+(111,501,cs),
+(111,471,o),
+(129,451,o),
+(166,451,cs),
+(199,451,o),
+(226,466,o),
+(226,501,cs),
+(226,528,o),
+(209,560,o),
+(209,597,cs),
+(209,621,o),
+(220,651,o),
+(245,690,cs),
+(325,818,l),
+(325,854,l),
+(60,854,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(254,349,o),
+(278,371,o),
+(278,407,cs),
+(278,426,o),
+(271,437,o),
+(271,466,cs),
+(271,486,o),
+(274,516,o),
+(310,563,cs),
+(434,723,l),
+(435,744,l),
+(191,744,l),
+(135,626,l),
+(158,626,l),
+(173,660,o),
+(187,665,o),
+(215,665,cs),
+(354,665,l),
+(354,661,l),
+(258,539,ls),
+(176,435,o),
+(169,425,o),
+(169,401,cs),
+(169,364,o),
+(189,349,o),
+(218,349,cs)
+);
+}
+);
+width = 335;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(264,349,o),
+(288,371,o),
+(288,407,cs),
+(288,426,o),
+(281,437,o),
+(281,466,cs),
+(281,486,o),
+(284,516,o),
+(320,563,cs),
+(444,723,l),
+(445,744,l),
+(201,744,l),
+(145,626,l),
+(168,626,l),
+(183,660,o),
+(197,665,o),
+(225,665,cs),
+(364,665,l),
+(364,661,l),
+(268,539,ls),
+(186,435,o),
+(179,425,o),
+(179,401,cs),
+(179,364,o),
+(199,349,o),
+(228,349,cs)
+);
+}
+);
+width = 355;
+}
+);
+},
+{
+glyphname = eight.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,622,o),
+(133,654,o),
+(176,654,cs),
+(219,654,o),
+(233,620,o),
+(233,559,cs),
+(233,494,o),
+(216,468,o),
+(176,468,cs),
+(135,468,o),
+(118,494,o),
+(118,559,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,815,o),
+(273,862,o),
+(175,862,cs),
+(81,862,o),
+(34,818,o),
+(34,764,cs),
+(34,702,o),
+(97,664,o),
+(176,664,cs),
+(256,664,o),
+(318,702,o),
+(318,763,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,705,o),
+(211,675,o),
+(176,675,cs),
+(142,675,o),
+(129,705,o),
+(129,762,cs),
+(129,818,o),
+(142,842,o),
+(176,842,cs),
+(211,842,o),
+(223,818,o),
+(223,762,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(17,497,o),
+(69,451,o),
+(176,451,cs),
+(283,451,o),
+(334,497,o),
+(334,555,cs),
+(334,618,o),
+(283,650,o),
+(213,664,c),
+(213,668,l),
+(140,668,l),
+(140,664,l),
+(68,651,o),
+(17,618,o),
+(17,555,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(313,349,o),
+(384,406,o),
+(384,465,cs),
+(384,505,o),
+(349,542,o),
+(291,554,c),
+(291,558,l),
+(361,569,o),
+(410,617,o),
+(410,664,cs),
+(410,709,o),
+(365,748,o),
+(292,748,cs),
+(212,748,o),
+(137,700,o),
+(137,643,cs),
+(137,606,o),
+(168,573,o),
+(217,561,c),
+(217,557,l),
+(141,546,o),
+(83,498,o),
+(83,444,cs),
+(83,390,o),
+(138,349,o),
+(218,349,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,370,o),
+(175,386,o),
+(175,425,cs),
+(175,489,o),
+(214,545,o),
+(255,545,cs),
+(279,545,o),
+(292,524,o),
+(292,486,cs),
+(292,442,o),
+(274,370,o),
+(217,370,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,570,o),
+(229,582,o),
+(229,611,cs),
+(229,654,o),
+(246,733,o),
+(296,733,cs),
+(312,733,o),
+(324,726,o),
+(324,693,cs),
+(324,658,o),
+(310,570,o),
+(257,570,cs)
+);
+}
+);
+width = 352;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,349,o),
+(394,406,o),
+(394,465,cs),
+(394,505,o),
+(359,542,o),
+(301,554,c),
+(301,558,l),
+(371,569,o),
+(420,617,o),
+(420,664,cs),
+(420,709,o),
+(375,748,o),
+(302,748,cs),
+(222,748,o),
+(147,700,o),
+(147,643,cs),
+(147,606,o),
+(178,573,o),
+(227,561,c),
+(227,557,l),
+(151,546,o),
+(93,498,o),
+(93,444,cs),
+(93,390,o),
+(148,349,o),
+(228,349,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(201,370,o),
+(185,386,o),
+(185,425,cs),
+(185,489,o),
+(224,545,o),
+(265,545,cs),
+(289,545,o),
+(302,524,o),
+(302,486,cs),
+(302,442,o),
+(284,370,o),
+(227,370,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,570,o),
+(239,582,o),
+(239,611,cs),
+(239,654,o),
+(256,733,o),
+(306,733,cs),
+(322,733,o),
+(334,726,o),
+(334,693,cs),
+(334,658,o),
+(320,570,o),
+(267,570,cs)
+);
+}
+);
+width = 372;
+}
+);
+},
+{
+glyphname = nine.numerator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,455,l),
+(196,460,o),
+(325,563,o),
+(325,694,cs),
+(325,796,o),
+(256,862,o),
+(169,862,cs),
+(89,862,o),
+(16,803,o),
+(16,725,cs),
+(16,655,o),
+(74,601,o),
+(147,601,cs),
+(176,601,o),
+(195,608,o),
+(213,623,c),
+(217,623,l),
+(205,540,o),
+(145,484,o),
+(57,475,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,713,o),
+(228,686,o),
+(223,663,c),
+(212,642,o),
+(192,625,o),
+(163,625,cs),
+(133,625,o),
+(116,644,o),
+(116,732,cs),
+(116,812,o),
+(129,842,o),
+(171,842,cs),
+(213,842,o),
+(228,812,o),
+(228,733,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(249,350,o),
+(420,471,o),
+(420,626,cs),
+(420,708,o),
+(372,760,o),
+(294,760,cs),
+(200,760,o),
+(119,685,o),
+(119,607,cs),
+(119,549,o),
+(165,498,o),
+(229,498,cs),
+(254,498,o),
+(274,505,o),
+(296,525,c),
+(299,522,l),
+(283,453,o),
+(211,381,o),
+(114,371,c),
+(114,350,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(216,519,o),
+(213,539,o),
+(213,561,cs),
+(213,613,o),
+(231,742,o),
+(297,742,cs),
+(323,742,o),
+(327,722,o),
+(327,688,cs),
+(327,637,o),
+(315,583,o),
+(305,559,c),
+(284,532,o),
+(263,519,o),
+(242,519,cs)
+);
+}
+);
+width = 348;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,350,o),
+(430,471,o),
+(430,626,cs),
+(430,708,o),
+(382,760,o),
+(304,760,cs),
+(210,760,o),
+(129,685,o),
+(129,607,cs),
+(129,549,o),
+(175,498,o),
+(239,498,cs),
+(264,498,o),
+(284,505,o),
+(306,525,c),
+(309,522,l),
+(293,453,o),
+(221,381,o),
+(124,371,c),
+(124,350,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(226,519,o),
+(223,539,o),
+(223,561,cs),
+(223,613,o),
+(241,742,o),
+(307,742,cs),
+(333,742,o),
+(337,722,o),
+(337,688,cs),
+(337,637,o),
+(325,583,o),
+(315,559,c),
+(294,532,o),
+(273,519,o),
+(252,519,cs)
+);
+}
+);
+width = 368;
+}
+);
+},
+{
+glyphname = zeroinferior;
+lastChange = "2016-08-22 13:57:29 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(24,534,o),
+(101,451,o),
+(203,451,cs),
+(305,451,o),
+(383,534,o),
+(383,656,cs),
+(383,778,o),
+(305,862,o),
+(203,862,cs),
+(101,862,o),
+(24,778,o),
+(24,656,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,807,o),
+(144,842,o),
+(203,842,cs),
+(259,842,o),
+(280,807,o),
+(280,656,cs),
+(280,506,o),
+(259,472,o),
+(203,472,cs),
+(144,472,o),
+(126,506,o),
+(126,656,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,-105,o),
+(330,38,o),
+(330,145,cs),
+(330,213,o),
+(294,290,o),
+(217,290,cs),
+(119,290,o),
+(15,164,o),
+(15,40,cs),
+(15,-34,o),
+(51,-105,o),
+(131,-105,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(116,-88,o),
+(100,-81,o),
+(100,-32,cs),
+(100,45,o),
+(141,272,o),
+(215,272,cs),
+(234,272,o),
+(245,258,o),
+(245,214,cs),
+(245,135,o),
+(208,-88,o),
+(130,-88,cs)
+);
+}
+);
+width = 391;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,-105,o),
+(340,38,o),
+(340,145,cs),
+(340,213,o),
+(304,290,o),
+(227,290,cs),
+(129,290,o),
+(25,164,o),
+(25,40,cs),
+(25,-34,o),
+(61,-105,o),
+(141,-105,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,-88,o),
+(110,-81,o),
+(110,-32,cs),
+(110,45,o),
+(151,272,o),
+(225,272,cs),
+(244,272,o),
+(255,258,o),
+(255,214,cs),
+(255,135,o),
+(218,-88,o),
+(140,-88,cs)
+);
+}
+);
+width = 411;
+}
+);
+unicode = 8320;
+},
+{
+glyphname = oneinferior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(4,836,l),
+(91,836,l),
+(91,476,l),
+(4,476,l),
+(4,459,l),
+(266,459,l),
+(266,476,l),
+(184,476,l),
+(184,854,l),
+(4,854,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(218,-100,l),
+(218,-79,l),
+(144,-79,l),
+(224,289,l),
+(53,289,l),
+(53,268,l),
+(129,268,l),
+(58,-79,l),
+(-13,-79,l),
+(-13,-100,l)
+);
+}
+);
+width = 278;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,-100,l),
+(228,-79,l),
+(154,-79,l),
+(234,289,l),
+(63,289,l),
+(63,268,l),
+(139,268,l),
+(68,-79,l),
+(-3,-79,l),
+(-3,-100,l)
+);
+}
+);
+width = 298;
+}
+);
+unicode = 8321;
+},
+{
+glyphname = twoinferior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,602,l),
+(304,549,o),
+(296,544,o),
+(271,544,cs),
+(89,544,l),
+(89,548,l),
+(247,643,ls),
+(303,676,o),
+(321,715,o),
+(321,755,cs),
+(321,832,o),
+(249,862,o),
+(180,862,cs),
+(107,862,o),
+(34,829,o),
+(34,762,cs),
+(34,730,o),
+(51,695,o),
+(92,695,cs),
+(117,695,o),
+(141,710,o),
+(141,743,cs),
+(141,766,o),
+(129,784,o),
+(104,784,cs),
+(88,784,o),
+(82,777,o),
+(76,777,cs),
+(71,777,o),
+(68,781,o),
+(68,788,cs),
+(68,810,o),
+(102,838,o),
+(142,838,cs),
+(190,838,o),
+(220,799,o),
+(220,735,cs),
+(220,691,o),
+(206,659,o),
+(146,614,cs),
+(17,516,l),
+(17,459,l),
+(321,459,l),
+(321,602,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(235,-100,l),
+(267,26,l),
+(249,26,l),
+(240,-16,o),
+(235,-20,o),
+(218,-20,cs),
+(63,-20,l),
+(63,-16,l),
+(203,64,ls),
+(277,106,o),
+(296,153,o),
+(296,187,cs),
+(296,249,o),
+(237,289,o),
+(163,289,cs),
+(71,289,o),
+(33,227,o),
+(33,180,cs),
+(33,134,o),
+(70,126,o),
+(86,126,cs),
+(109,126,o),
+(129,142,o),
+(129,169,cs),
+(129,215,o),
+(73,206,o),
+(73,224,cs),
+(73,235,o),
+(101,268,o),
+(142,268,cs),
+(175,268,o),
+(197,248,o),
+(197,194,cs),
+(197,148,o),
+(183,93,o),
+(94,31,cs),
+(-11,-42,l),
+(-24,-100,l)
+);
+}
+);
+width = 350;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,-100,l),
+(277,26,l),
+(259,26,l),
+(250,-16,o),
+(245,-20,o),
+(228,-20,cs),
+(73,-20,l),
+(73,-16,l),
+(213,64,ls),
+(287,106,o),
+(306,153,o),
+(306,187,cs),
+(306,249,o),
+(247,289,o),
+(173,289,cs),
+(81,289,o),
+(43,227,o),
+(43,180,cs),
+(43,134,o),
+(80,126,o),
+(96,126,cs),
+(119,126,o),
+(139,142,o),
+(139,169,cs),
+(139,215,o),
+(83,206,o),
+(83,224,cs),
+(83,235,o),
+(111,268,o),
+(152,268,cs),
+(185,268,o),
+(207,248,o),
+(207,194,cs),
+(207,148,o),
+(193,93,o),
+(104,31,cs),
+(-1,-42,l),
+(-14,-100,l)
+);
+}
+);
+width = 370;
+}
+);
+unicode = 8322;
+},
+{
+glyphname = threeinferior;
+lastChange = "2016-08-22 13:57:37 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,663,l),
+(182,663,o),
+(208,630,o),
+(208,568,cs),
+(208,507,o),
+(183,472,o),
+(133,472,cs),
+(115,472,o),
+(74,476,o),
+(74,490,cs),
+(74,505,o),
+(111,507,o),
+(111,547,cs),
+(111,583,o),
+(83,591,o),
+(64,591,cs),
+(30,591,o),
+(13,563,o),
+(13,532,cs),
+(13,482,o),
+(61,451,o),
+(141,451,cs),
+(249,451,o),
+(317,509,o),
+(317,572,cs),
+(317,642,o),
+(253,675,o),
+(172,678,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,663,l),
+(172,663,l),
+(172,684,l),
+(76,684,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,678,l),
+(253,685,o),
+(299,721,o),
+(299,772,cs),
+(299,827,o),
+(247,862,o),
+(161,862,cs),
+(71,862,o),
+(36,823,o),
+(36,784,cs),
+(36,755,o),
+(55,739,o),
+(81,739,cs),
+(104,739,o),
+(130,751,o),
+(130,778,cs),
+(130,807,o),
+(99,812,o),
+(99,826,cs),
+(99,839,o),
+(123,842,o),
+(143,842,cs),
+(176,842,o),
+(197,830,o),
+(197,777,cs),
+(197,717,o),
+(170,684,o),
+(100,684,c)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(180,-108,o),
+(251,-57,o),
+(251,11,cs),
+(251,68,o),
+(201,106,o),
+(151,106,c),
+(151,110,l),
+(224,130,o),
+(262,166,o),
+(262,210,cs),
+(262,254,o),
+(226,291,o),
+(157,291,cs),
+(95,291,o),
+(48,259,o),
+(48,217,cs),
+(48,192,o),
+(65,181,o),
+(82,181,cs),
+(103,181,o),
+(118,197,o),
+(118,215,cs),
+(118,237,o),
+(97,236,o),
+(97,252,cs),
+(97,264,o),
+(111,273,o),
+(138,273,cs),
+(164,273,o),
+(181,266,o),
+(181,229,cs),
+(181,184,o),
+(154,118,o),
+(100,118,cs),
+(88,118,o),
+(75,121,o),
+(69,121,cs),
+(61,121,o),
+(54,115,o),
+(54,105,cs),
+(54,97,o),
+(59,90,o),
+(72,90,cs),
+(83,90,o),
+(80,95,o),
+(102,95,cs),
+(141,95,o),
+(154,71,o),
+(154,17,cs),
+(154,-75,o),
+(112,-91,o),
+(75,-91,cs),
+(50,-91,o),
+(15,-81,o),
+(15,-66,cs),
+(15,-52,o),
+(49,-54,o),
+(49,-25,cs),
+(49,-5,o),
+(33,8,o),
+(13,8,cs),
+(-12,8,o),
+(-23,-15,o),
+(-23,-38,cs),
+(-23,-75,o),
+(7,-108,o),
+(84,-108,cs)
+);
+}
+);
+width = 337;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,-108,o),
+(261,-57,o),
+(261,11,cs),
+(261,68,o),
+(211,106,o),
+(161,106,c),
+(161,110,l),
+(234,130,o),
+(272,166,o),
+(272,210,cs),
+(272,254,o),
+(236,291,o),
+(167,291,cs),
+(105,291,o),
+(58,259,o),
+(58,217,cs),
+(58,192,o),
+(75,181,o),
+(92,181,cs),
+(113,181,o),
+(128,197,o),
+(128,215,cs),
+(128,237,o),
+(107,236,o),
+(107,252,cs),
+(107,264,o),
+(121,273,o),
+(148,273,cs),
+(174,273,o),
+(191,266,o),
+(191,229,cs),
+(191,184,o),
+(164,118,o),
+(110,118,cs),
+(98,118,o),
+(85,121,o),
+(79,121,cs),
+(71,121,o),
+(64,115,o),
+(64,105,cs),
+(64,97,o),
+(69,90,o),
+(82,90,cs),
+(93,90,o),
+(90,95,o),
+(112,95,cs),
+(151,95,o),
+(164,71,o),
+(164,17,cs),
+(164,-75,o),
+(122,-91,o),
+(85,-91,cs),
+(60,-91,o),
+(25,-81,o),
+(25,-66,cs),
+(25,-52,o),
+(59,-54,o),
+(59,-25,cs),
+(59,-5,o),
+(43,8,o),
+(23,8,cs),
+(-2,8,o),
+(-13,-15,o),
+(-13,-38,cs),
+(-13,-75,o),
+(17,-108,o),
+(94,-108,cs)
+);
+}
+);
+width = 357;
+}
+);
+unicode = 8323;
+},
+{
+glyphname = fourinferior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,588,l),
+(36,592,l),
+(171,779,l),
+(175,779,l),
+(175,588,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,569,l),
+(338,524,l),
+(356,524,l),
+(356,631,l),
+(338,631,l),
+(338,588,l),
+(268,588,l),
+(268,862,l),
+(208,862,l),
+(8,588,l),
+(8,569,l),
+(175,569,l),
+(175,476,l),
+(115,476,l),
+(115,459,l),
+(322,459,l),
+(322,476,l),
+(267,476,l),
+(267,569,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(245,-100,l),
+(245,-83,l),
+(202,-83,l),
+(221,4,l),
+(270,4,l),
+(259,-40,l),
+(276,-40,l),
+(301,59,l),
+(284,59,l),
+(275,23,l),
+(225,23,l),
+(282,289,l),
+(239,289,l),
+(-5,23,l),
+(-5,4,l),
+(134,4,l),
+(115,-83,l),
+(77,-83,l),
+(77,-100,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(168,191,l),
+(173,191,l),
+(138,23,l),
+(19,23,l)
+);
+}
+);
+width = 377;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,-100,l),
+(255,-83,l),
+(212,-83,l),
+(231,4,l),
+(280,4,l),
+(269,-40,l),
+(286,-40,l),
+(311,59,l),
+(294,59,l),
+(285,23,l),
+(235,23,l),
+(292,289,l),
+(249,289,l),
+(5,23,l),
+(5,4,l),
+(144,4,l),
+(125,-83,l),
+(87,-83,l),
+(87,-100,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(178,191,l),
+(183,191,l),
+(148,23,l),
+(29,23,l)
+);
+}
+);
+width = 397;
+}
+);
+unicode = 8324;
+},
+{
+glyphname = fiveinferior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,769,l),
+(292,769,l),
+(312,876,l),
+(295,876,l),
+(288,857,o),
+(281,854,o),
+(259,854,cs),
+(65,854,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(47,668,l),
+(56,661,l),
+(70,687,l),
+(84,854,l),
+(61,854,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,706,o),
+(73,696,o),
+(63,690,c),
+(56,661,l),
+(67,671,o),
+(101,678,o),
+(128,678,cs),
+(183,678,o),
+(222,647,o),
+(222,571,cs),
+(222,504,o),
+(192,472,o),
+(135,472,cs),
+(113,472,o),
+(81,476,o),
+(81,488,cs),
+(81,500,o),
+(117,501,o),
+(117,539,cs),
+(117,571,o),
+(92,584,o),
+(68,584,cs),
+(37,584,o),
+(15,562,o),
+(15,530,cs),
+(15,485,o),
+(62,451,o),
+(149,451,cs),
+(251,451,o),
+(333,498,o),
+(333,582,cs),
+(333,648,o),
+(282,706,o),
+(170,706,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,-106,o),
+(274,-35,o),
+(274,34,cs),
+(274,95,o),
+(219,137,o),
+(132,137,cs),
+(108,137,o),
+(88,134,o),
+(61,125,c),
+(59,128,l),
+(83,210,l),
+(266,210,l),
+(312,317,l),
+(296,317,l),
+(281,292,o),
+(275,290,o),
+(237,290,cs),
+(83,290,l),
+(32,108,l),
+(43,95,l),
+(66,106,o),
+(92,111,o),
+(114,111,cs),
+(149,111,o),
+(174,98,o),
+(174,48,cs),
+(174,2,o),
+(154,-89,o),
+(91,-89,cs),
+(65,-89,o),
+(46,-72,o),
+(46,-63,cs),
+(46,-52,o),
+(76,-45,o),
+(76,-13,cs),
+(76,13,o),
+(58,28,o),
+(36,28,cs),
+(5,28,o),
+(-10,-2,o),
+(-10,-29,cs),
+(-10,-65,o),
+(17,-106,o),
+(98,-106,cs)
+);
+}
+);
+width = 349;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,-106,o),
+(284,-35,o),
+(284,34,cs),
+(284,95,o),
+(229,137,o),
+(142,137,cs),
+(118,137,o),
+(98,134,o),
+(71,125,c),
+(69,128,l),
+(93,210,l),
+(276,210,l),
+(322,317,l),
+(306,317,l),
+(291,292,o),
+(285,290,o),
+(247,290,cs),
+(93,290,l),
+(42,108,l),
+(53,95,l),
+(76,106,o),
+(102,111,o),
+(124,111,cs),
+(159,111,o),
+(184,98,o),
+(184,48,cs),
+(184,2,o),
+(164,-89,o),
+(101,-89,cs),
+(75,-89,o),
+(56,-72,o),
+(56,-63,cs),
+(56,-52,o),
+(86,-45,o),
+(86,-13,cs),
+(86,13,o),
+(68,28,o),
+(46,28,cs),
+(15,28,o),
+(0,-2,o),
+(0,-29,cs),
+(0,-65,o),
+(27,-106,o),
+(108,-106,cs)
+);
+}
+);
+width = 369;
+}
+);
+unicode = 8325;
+},
+{
+glyphname = sixinferior;
+lastChange = "2016-08-22 13:57:47 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,874,l),
+(147,869,o),
+(25,747,o),
+(25,619,cs),
+(25,517,o),
+(94,451,o),
+(180,451,cs),
+(260,451,o),
+(334,509,o),
+(334,588,cs),
+(334,658,o),
+(275,712,o),
+(203,712,cs),
+(173,712,o),
+(153,703,o),
+(136,689,c),
+(132,689,l),
+(144,771,o),
+(199,844,o),
+(287,854,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,599,o),
+(121,627,o),
+(126,650,c),
+(138,670,o),
+(157,688,o),
+(186,688,cs),
+(216,688,o),
+(233,669,o),
+(233,580,cs),
+(233,501,o),
+(220,472,o),
+(178,472,cs),
+(136,472,o),
+(121,500,o),
+(121,580,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,-107,o),
+(285,-32,o),
+(285,45,cs),
+(285,104,o),
+(240,155,o),
+(175,155,cs),
+(151,155,o),
+(131,147,o),
+(108,128,c),
+(105,131,l),
+(121,199,o),
+(193,271,o),
+(291,282,c),
+(291,303,l),
+(155,303,o),
+(-16,182,o),
+(-16,27,cs),
+(-16,-55,o),
+(32,-107,o),
+(110,-107,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(81,-90,o),
+(77,-69,o),
+(77,-36,cs),
+(77,15,o),
+(89,70,o),
+(99,94,c),
+(121,121,o),
+(142,133,o),
+(162,133,cs),
+(188,133,o),
+(191,114,o),
+(191,92,cs),
+(191,40,o),
+(173,-90,o),
+(108,-90,cs)
+);
+}
+);
+width = 348;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,-107,o),
+(295,-32,o),
+(295,45,cs),
+(295,104,o),
+(250,155,o),
+(185,155,cs),
+(161,155,o),
+(141,147,o),
+(118,128,c),
+(115,131,l),
+(131,199,o),
+(203,271,o),
+(301,282,c),
+(301,303,l),
+(165,303,o),
+(-6,182,o),
+(-6,27,cs),
+(-6,-55,o),
+(42,-107,o),
+(120,-107,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(91,-90,o),
+(87,-69,o),
+(87,-36,cs),
+(87,15,o),
+(99,70,o),
+(109,94,c),
+(131,121,o),
+(152,133,o),
+(172,133,cs),
+(198,133,o),
+(201,114,o),
+(201,92,cs),
+(201,40,o),
+(183,-90,o),
+(118,-90,cs)
+);
+}
+);
+width = 368;
+}
+);
+unicode = 8326;
+},
+{
+glyphname = seveninferior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(20,707,l),
+(41,707,l),
+(59,759,o),
+(57,768,o),
+(70,768,cs),
+(261,768,l),
+(166,618,ls),
+(127,557,o),
+(111,530,o),
+(111,501,cs),
+(111,471,o),
+(129,451,o),
+(166,451,cs),
+(199,451,o),
+(226,466,o),
+(226,501,cs),
+(226,528,o),
+(209,560,o),
+(209,597,cs),
+(209,621,o),
+(220,651,o),
+(245,690,cs),
+(325,818,l),
+(325,854,l),
+(60,854,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(142,-109,o),
+(166,-87,o),
+(166,-51,cs),
+(166,-32,o),
+(159,-21,o),
+(159,8,cs),
+(159,28,o),
+(162,58,o),
+(198,105,cs),
+(322,265,l),
+(323,286,l),
+(79,286,l),
+(23,168,l),
+(46,168,l),
+(61,202,o),
+(75,207,o),
+(103,207,cs),
+(242,207,l),
+(242,203,l),
+(146,81,ls),
+(64,-23,o),
+(57,-33,o),
+(57,-57,cs),
+(57,-94,o),
+(77,-109,o),
+(106,-109,cs)
+);
+}
+);
+width = 335;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,-109,o),
+(176,-87,o),
+(176,-51,cs),
+(176,-32,o),
+(169,-21,o),
+(169,8,cs),
+(169,28,o),
+(172,58,o),
+(208,105,cs),
+(332,265,l),
+(333,286,l),
+(89,286,l),
+(33,168,l),
+(56,168,l),
+(71,202,o),
+(85,207,o),
+(113,207,cs),
+(252,207,l),
+(252,203,l),
+(156,81,ls),
+(74,-23,o),
+(67,-33,o),
+(67,-57,cs),
+(67,-94,o),
+(87,-109,o),
+(116,-109,cs)
+);
+}
+);
+width = 355;
+}
+);
+unicode = 8327;
+},
+{
+glyphname = eightinferior;
+lastChange = "2016-08-22 13:57:59 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,622,o),
+(133,654,o),
+(176,654,cs),
+(219,654,o),
+(233,620,o),
+(233,559,cs),
+(233,494,o),
+(216,468,o),
+(176,468,cs),
+(135,468,o),
+(118,494,o),
+(118,559,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,815,o),
+(273,862,o),
+(175,862,cs),
+(81,862,o),
+(34,818,o),
+(34,764,cs),
+(34,702,o),
+(97,664,o),
+(176,664,cs),
+(256,664,o),
+(318,702,o),
+(318,763,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,705,o),
+(211,675,o),
+(176,675,cs),
+(142,675,o),
+(129,705,o),
+(129,762,cs),
+(129,818,o),
+(142,842,o),
+(176,842,cs),
+(211,842,o),
+(223,818,o),
+(223,762,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(17,497,o),
+(69,451,o),
+(176,451,cs),
+(283,451,o),
+(334,497,o),
+(334,555,cs),
+(334,618,o),
+(283,650,o),
+(213,664,c),
+(213,668,l),
+(140,668,l),
+(140,664,l),
+(68,651,o),
+(17,618,o),
+(17,555,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,-109,o),
+(275,-52,o),
+(275,7,cs),
+(275,47,o),
+(240,84,o),
+(182,96,c),
+(182,100,l),
+(252,111,o),
+(301,159,o),
+(301,206,cs),
+(301,251,o),
+(256,290,o),
+(183,290,cs),
+(103,290,o),
+(28,242,o),
+(28,185,cs),
+(28,148,o),
+(59,115,o),
+(108,103,c),
+(108,99,l),
+(32,88,o),
+(-26,40,o),
+(-26,-14,cs),
+(-26,-68,o),
+(29,-109,o),
+(109,-109,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(82,-88,o),
+(66,-72,o),
+(66,-33,cs),
+(66,31,o),
+(105,87,o),
+(146,87,cs),
+(170,87,o),
+(183,66,o),
+(183,28,cs),
+(183,-16,o),
+(165,-88,o),
+(108,-88,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(128,112,o),
+(120,124,o),
+(120,153,cs),
+(120,196,o),
+(137,275,o),
+(187,275,cs),
+(203,275,o),
+(215,268,o),
+(215,235,cs),
+(215,200,o),
+(201,112,o),
+(148,112,cs)
+);
+}
+);
+width = 352;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(214,-109,o),
+(285,-52,o),
+(285,7,cs),
+(285,47,o),
+(250,84,o),
+(192,96,c),
+(192,100,l),
+(262,111,o),
+(311,159,o),
+(311,206,cs),
+(311,251,o),
+(266,290,o),
+(193,290,cs),
+(113,290,o),
+(38,242,o),
+(38,185,cs),
+(38,148,o),
+(69,115,o),
+(118,103,c),
+(118,99,l),
+(42,88,o),
+(-16,40,o),
+(-16,-14,cs),
+(-16,-68,o),
+(39,-109,o),
+(119,-109,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(92,-88,o),
+(76,-72,o),
+(76,-33,cs),
+(76,31,o),
+(115,87,o),
+(156,87,cs),
+(180,87,o),
+(193,66,o),
+(193,28,cs),
+(193,-16,o),
+(175,-88,o),
+(118,-88,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(138,112,o),
+(130,124,o),
+(130,153,cs),
+(130,196,o),
+(147,275,o),
+(197,275,cs),
+(213,275,o),
+(225,268,o),
+(225,235,cs),
+(225,200,o),
+(211,112,o),
+(158,112,cs)
+);
+}
+);
+width = 372;
+}
+);
+unicode = 8328;
+},
+{
+glyphname = nineinferior;
+lastChange = "2016-08-22 13:58:11 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,455,l),
+(196,460,o),
+(325,563,o),
+(325,694,cs),
+(325,796,o),
+(256,862,o),
+(169,862,cs),
+(89,862,o),
+(16,803,o),
+(16,725,cs),
+(16,655,o),
+(74,601,o),
+(147,601,cs),
+(176,601,o),
+(195,608,o),
+(213,623,c),
+(217,623,l),
+(205,540,o),
+(145,484,o),
+(57,475,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,713,o),
+(228,686,o),
+(223,663,c),
+(212,642,o),
+(192,625,o),
+(163,625,cs),
+(133,625,o),
+(116,644,o),
+(116,732,cs),
+(116,812,o),
+(129,842,o),
+(171,842,cs),
+(213,842,o),
+(228,812,o),
+(228,733,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(139,-109,o),
+(310,12,o),
+(310,167,cs),
+(310,249,o),
+(262,301,o),
+(184,301,cs),
+(90,301,o),
+(9,226,o),
+(9,148,cs),
+(9,90,o),
+(55,39,o),
+(119,39,cs),
+(144,39,o),
+(164,46,o),
+(186,66,c),
+(188,63,l),
+(172,-6,o),
+(101,-78,o),
+(4,-88,c),
+(4,-109,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(106,60,o),
+(103,80,o),
+(103,102,cs),
+(103,154,o),
+(121,283,o),
+(187,283,cs),
+(213,283,o),
+(217,263,o),
+(217,229,cs),
+(217,178,o),
+(205,124,o),
+(195,100,c),
+(174,73,o),
+(153,60,o),
+(132,60,cs)
+);
+}
+);
+width = 348;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(149,-109,o),
+(320,12,o),
+(320,167,cs),
+(320,249,o),
+(272,301,o),
+(194,301,cs),
+(100,301,o),
+(19,226,o),
+(19,148,cs),
+(19,90,o),
+(65,39,o),
+(129,39,cs),
+(154,39,o),
+(174,46,o),
+(196,66,c),
+(198,63,l),
+(182,-6,o),
+(111,-78,o),
+(14,-88,c),
+(14,-109,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(116,60,o),
+(113,80,o),
+(113,102,cs),
+(113,154,o),
+(131,283,o),
+(197,283,cs),
+(223,283,o),
+(227,263,o),
+(227,229,cs),
+(227,178,o),
+(215,124,o),
+(205,100,c),
+(184,73,o),
+(163,60,o),
+(142,60,cs)
+);
+}
+);
+width = 368;
+}
+);
+unicode = 8329;
+},
+{
+glyphname = zerosuperior;
+lastChange = "2016-08-22 13:58:20 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(24,534,o),
+(101,451,o),
+(203,451,cs),
+(305,451,o),
+(383,534,o),
+(383,656,cs),
+(383,778,o),
+(305,862,o),
+(203,862,cs),
+(101,862,o),
+(24,778,o),
+(24,656,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,807,o),
+(144,842,o),
+(203,842,cs),
+(259,842,o),
+(280,807,o),
+(280,656,cs),
+(280,506,o),
+(259,472,o),
+(203,472,cs),
+(144,472,o),
+(126,506,o),
+(126,656,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,459,o),
+(462,602,o),
+(462,709,cs),
+(462,777,o),
+(426,854,o),
+(349,854,cs),
+(251,854,o),
+(147,728,o),
+(147,604,cs),
+(147,530,o),
+(183,459,o),
+(263,459,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(248,476,o),
+(232,483,o),
+(232,532,cs),
+(232,609,o),
+(273,836,o),
+(347,836,cs),
+(366,836,o),
+(377,822,o),
+(377,778,cs),
+(377,699,o),
+(340,476,o),
+(262,476,cs)
+);
+}
+);
+width = 391;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,459,o),
+(472,602,o),
+(472,709,cs),
+(472,777,o),
+(436,854,o),
+(359,854,cs),
+(261,854,o),
+(157,728,o),
+(157,604,cs),
+(157,530,o),
+(193,459,o),
+(273,459,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(258,476,o),
+(242,483,o),
+(242,532,cs),
+(242,609,o),
+(283,836,o),
+(357,836,cs),
+(376,836,o),
+(387,822,o),
+(387,778,cs),
+(387,699,o),
+(350,476,o),
+(272,476,cs)
+);
+}
+);
+width = 411;
+}
+);
+unicode = 8304;
+},
+{
+glyphname = onesuperior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(4,836,l),
+(91,836,l),
+(91,476,l),
+(4,476,l),
+(4,459,l),
+(266,459,l),
+(266,476,l),
+(184,476,l),
+(184,854,l),
+(4,854,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,459,l),
+(317,480,l),
+(243,480,l),
+(323,848,l),
+(152,848,l),
+(152,827,l),
+(228,827,l),
+(157,480,l),
+(86,480,l),
+(86,459,l)
+);
+}
+);
+width = 278;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(327,459,l),
+(327,480,l),
+(253,480,l),
+(333,848,l),
+(162,848,l),
+(162,827,l),
+(238,827,l),
+(167,480,l),
+(96,480,l),
+(96,459,l)
+);
+}
+);
+width = 298;
+}
+);
+unicode = 185;
+},
+{
+glyphname = twosuperior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(304,602,l),
+(304,549,o),
+(296,544,o),
+(271,544,cs),
+(89,544,l),
+(89,548,l),
+(247,643,ls),
+(303,676,o),
+(321,715,o),
+(321,755,cs),
+(321,832,o),
+(249,862,o),
+(180,862,cs),
+(107,862,o),
+(34,829,o),
+(34,762,cs),
+(34,730,o),
+(51,695,o),
+(92,695,cs),
+(117,695,o),
+(141,710,o),
+(141,743,cs),
+(141,766,o),
+(129,784,o),
+(104,784,cs),
+(88,784,o),
+(82,777,o),
+(76,777,cs),
+(71,777,o),
+(68,781,o),
+(68,788,cs),
+(68,810,o),
+(102,838,o),
+(142,838,cs),
+(190,838,o),
+(220,799,o),
+(220,735,cs),
+(220,691,o),
+(206,659,o),
+(146,614,cs),
+(17,516,l),
+(17,459,l),
+(321,459,l),
+(321,602,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(360,458,l),
+(392,584,l),
+(374,584,l),
+(365,542,o),
+(360,538,o),
+(343,538,cs),
+(188,538,l),
+(188,542,l),
+(328,622,ls),
+(402,664,o),
+(421,711,o),
+(421,745,cs),
+(421,807,o),
+(362,847,o),
+(288,847,cs),
+(196,847,o),
+(158,785,o),
+(158,738,cs),
+(158,692,o),
+(195,684,o),
+(211,684,cs),
+(234,684,o),
+(254,700,o),
+(254,727,cs),
+(254,773,o),
+(198,764,o),
+(198,782,cs),
+(198,793,o),
+(226,826,o),
+(267,826,cs),
+(300,826,o),
+(322,806,o),
+(322,752,cs),
+(322,706,o),
+(308,651,o),
+(219,589,cs),
+(114,516,l),
+(101,458,l)
+);
+}
+);
+width = 350;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,458,l),
+(402,584,l),
+(384,584,l),
+(375,542,o),
+(370,538,o),
+(353,538,cs),
+(198,538,l),
+(198,542,l),
+(338,622,ls),
+(412,664,o),
+(431,711,o),
+(431,745,cs),
+(431,807,o),
+(372,847,o),
+(298,847,cs),
+(206,847,o),
+(168,785,o),
+(168,738,cs),
+(168,692,o),
+(205,684,o),
+(221,684,cs),
+(244,684,o),
+(264,700,o),
+(264,727,cs),
+(264,773,o),
+(208,764,o),
+(208,782,cs),
+(208,793,o),
+(236,826,o),
+(277,826,cs),
+(310,826,o),
+(332,806,o),
+(332,752,cs),
+(332,706,o),
+(318,651,o),
+(229,589,cs),
+(124,516,l),
+(111,458,l)
+);
+}
+);
+width = 370;
+}
+);
+unicode = 178;
+},
+{
+glyphname = threesuperior;
+lastChange = "2016-08-22 13:58:29 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(111,663,l),
+(182,663,o),
+(208,630,o),
+(208,568,cs),
+(208,507,o),
+(183,472,o),
+(133,472,cs),
+(115,472,o),
+(74,476,o),
+(74,490,cs),
+(74,505,o),
+(111,507,o),
+(111,547,cs),
+(111,583,o),
+(83,591,o),
+(64,591,cs),
+(30,591,o),
+(13,563,o),
+(13,532,cs),
+(13,482,o),
+(61,451,o),
+(141,451,cs),
+(249,451,o),
+(317,509,o),
+(317,572,cs),
+(317,642,o),
+(253,675,o),
+(172,678,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(76,663,l),
+(172,663,l),
+(172,684,l),
+(76,684,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,678,l),
+(253,685,o),
+(299,721,o),
+(299,772,cs),
+(299,827,o),
+(247,862,o),
+(161,862,cs),
+(71,862,o),
+(36,823,o),
+(36,784,cs),
+(36,755,o),
+(55,739,o),
+(81,739,cs),
+(104,739,o),
+(130,751,o),
+(130,778,cs),
+(130,807,o),
+(99,812,o),
+(99,826,cs),
+(99,839,o),
+(123,842,o),
+(143,842,cs),
+(176,842,o),
+(197,830,o),
+(197,777,cs),
+(197,717,o),
+(170,684,o),
+(100,684,c)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(308,451,o),
+(379,502,o),
+(379,570,cs),
+(379,627,o),
+(329,665,o),
+(279,665,c),
+(279,669,l),
+(352,689,o),
+(390,725,o),
+(390,769,cs),
+(390,813,o),
+(354,850,o),
+(285,850,cs),
+(223,850,o),
+(176,818,o),
+(176,776,cs),
+(176,751,o),
+(193,740,o),
+(210,740,cs),
+(231,740,o),
+(246,756,o),
+(246,774,cs),
+(246,796,o),
+(225,795,o),
+(225,811,cs),
+(225,823,o),
+(239,832,o),
+(266,832,cs),
+(292,832,o),
+(309,825,o),
+(309,788,cs),
+(309,743,o),
+(282,677,o),
+(228,677,cs),
+(216,677,o),
+(203,680,o),
+(197,680,cs),
+(189,680,o),
+(182,674,o),
+(182,664,cs),
+(182,656,o),
+(187,649,o),
+(200,649,cs),
+(211,649,o),
+(208,654,o),
+(230,654,cs),
+(269,654,o),
+(282,630,o),
+(282,576,cs),
+(282,484,o),
+(240,468,o),
+(203,468,cs),
+(178,468,o),
+(143,478,o),
+(143,493,cs),
+(143,507,o),
+(177,505,o),
+(177,534,cs),
+(177,554,o),
+(161,567,o),
+(141,567,cs),
+(116,567,o),
+(105,544,o),
+(105,521,cs),
+(105,484,o),
+(135,451,o),
+(212,451,cs)
+);
+}
+);
+width = 337;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(318,451,o),
+(389,502,o),
+(389,570,cs),
+(389,627,o),
+(339,665,o),
+(289,665,c),
+(289,669,l),
+(362,689,o),
+(400,725,o),
+(400,769,cs),
+(400,813,o),
+(364,850,o),
+(295,850,cs),
+(233,850,o),
+(186,818,o),
+(186,776,cs),
+(186,751,o),
+(203,740,o),
+(220,740,cs),
+(241,740,o),
+(256,756,o),
+(256,774,cs),
+(256,796,o),
+(235,795,o),
+(235,811,cs),
+(235,823,o),
+(249,832,o),
+(276,832,cs),
+(302,832,o),
+(319,825,o),
+(319,788,cs),
+(319,743,o),
+(292,677,o),
+(238,677,cs),
+(226,677,o),
+(213,680,o),
+(207,680,cs),
+(199,680,o),
+(192,674,o),
+(192,664,cs),
+(192,656,o),
+(197,649,o),
+(210,649,cs),
+(221,649,o),
+(218,654,o),
+(240,654,cs),
+(279,654,o),
+(292,630,o),
+(292,576,cs),
+(292,484,o),
+(250,468,o),
+(213,468,cs),
+(188,468,o),
+(153,478,o),
+(153,493,cs),
+(153,507,o),
+(187,505,o),
+(187,534,cs),
+(187,554,o),
+(171,567,o),
+(151,567,cs),
+(126,567,o),
+(115,544,o),
+(115,521,cs),
+(115,484,o),
+(145,451,o),
+(222,451,cs)
+);
+}
+);
+width = 357;
+}
+);
+unicode = 179;
+},
+{
+glyphname = foursuperior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,588,l),
+(36,592,l),
+(171,779,l),
+(175,779,l),
+(175,588,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(338,569,l),
+(338,524,l),
+(356,524,l),
+(356,631,l),
+(338,631,l),
+(338,588,l),
+(268,588,l),
+(268,862,l),
+(208,862,l),
+(8,588,l),
+(8,569,l),
+(175,569,l),
+(175,476,l),
+(115,476,l),
+(115,459,l),
+(322,459,l),
+(322,476,l),
+(267,476,l),
+(267,569,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,459,l),
+(367,476,l),
+(324,476,l),
+(343,563,l),
+(392,563,l),
+(381,519,l),
+(398,519,l),
+(423,618,l),
+(406,618,l),
+(397,582,l),
+(347,582,l),
+(404,848,l),
+(361,848,l),
+(117,582,l),
+(117,563,l),
+(256,563,l),
+(237,476,l),
+(199,476,l),
+(199,459,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(290,750,l),
+(295,750,l),
+(260,582,l),
+(141,582,l)
+);
+}
+);
+width = 377;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,459,l),
+(377,476,l),
+(334,476,l),
+(353,563,l),
+(402,563,l),
+(391,519,l),
+(408,519,l),
+(433,618,l),
+(416,618,l),
+(407,582,l),
+(357,582,l),
+(414,848,l),
+(371,848,l),
+(127,582,l),
+(127,563,l),
+(266,563,l),
+(247,476,l),
+(209,476,l),
+(209,459,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(300,750,l),
+(305,750,l),
+(270,582,l),
+(151,582,l)
+);
+}
+);
+width = 397;
+}
+);
+unicode = 8308;
+},
+{
+glyphname = fivesuperior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,769,l),
+(292,769,l),
+(312,876,l),
+(295,876,l),
+(288,857,o),
+(281,854,o),
+(259,854,cs),
+(65,854,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(47,668,l),
+(56,661,l),
+(70,687,l),
+(84,854,l),
+(61,854,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(124,706,o),
+(73,696,o),
+(63,690,c),
+(56,661,l),
+(67,671,o),
+(101,678,o),
+(128,678,cs),
+(183,678,o),
+(222,647,o),
+(222,571,cs),
+(222,504,o),
+(192,472,o),
+(135,472,cs),
+(113,472,o),
+(81,476,o),
+(81,488,cs),
+(81,500,o),
+(117,501,o),
+(117,539,cs),
+(117,571,o),
+(92,584,o),
+(68,584,cs),
+(37,584,o),
+(15,562,o),
+(15,530,cs),
+(15,485,o),
+(62,451,o),
+(149,451,cs),
+(251,451,o),
+(333,498,o),
+(333,582,cs),
+(333,648,o),
+(282,706,o),
+(170,706,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,458,o),
+(402,529,o),
+(402,598,cs),
+(402,659,o),
+(347,701,o),
+(260,701,cs),
+(236,701,o),
+(216,698,o),
+(189,689,c),
+(187,692,l),
+(211,774,l),
+(394,774,l),
+(440,881,l),
+(424,881,l),
+(409,856,o),
+(403,854,o),
+(365,854,cs),
+(211,854,l),
+(160,672,l),
+(171,659,l),
+(194,670,o),
+(220,675,o),
+(242,675,cs),
+(277,675,o),
+(302,662,o),
+(302,612,cs),
+(302,566,o),
+(282,475,o),
+(219,475,cs),
+(193,475,o),
+(174,492,o),
+(174,501,cs),
+(174,512,o),
+(204,519,o),
+(204,551,cs),
+(204,577,o),
+(186,592,o),
+(164,592,cs),
+(133,592,o),
+(118,562,o),
+(118,535,cs),
+(118,499,o),
+(145,458,o),
+(226,458,cs)
+);
+}
+);
+width = 349;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(342,458,o),
+(412,529,o),
+(412,598,cs),
+(412,659,o),
+(357,701,o),
+(270,701,cs),
+(246,701,o),
+(226,698,o),
+(199,689,c),
+(197,692,l),
+(221,774,l),
+(404,774,l),
+(450,881,l),
+(434,881,l),
+(419,856,o),
+(413,854,o),
+(375,854,cs),
+(221,854,l),
+(170,672,l),
+(181,659,l),
+(204,670,o),
+(230,675,o),
+(252,675,cs),
+(287,675,o),
+(312,662,o),
+(312,612,cs),
+(312,566,o),
+(292,475,o),
+(229,475,cs),
+(203,475,o),
+(184,492,o),
+(184,501,cs),
+(184,512,o),
+(214,519,o),
+(214,551,cs),
+(214,577,o),
+(196,592,o),
+(174,592,cs),
+(143,592,o),
+(128,562,o),
+(128,535,cs),
+(128,499,o),
+(155,458,o),
+(236,458,cs)
+);
+}
+);
+width = 369;
+}
+);
+unicode = 8309;
+},
+{
+glyphname = sixsuperior;
+lastChange = "2016-08-22 13:58:40 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,874,l),
+(147,869,o),
+(25,747,o),
+(25,619,cs),
+(25,517,o),
+(94,451,o),
+(180,451,cs),
+(260,451,o),
+(334,509,o),
+(334,588,cs),
+(334,658,o),
+(275,712,o),
+(203,712,cs),
+(173,712,o),
+(153,703,o),
+(136,689,c),
+(132,689,l),
+(144,771,o),
+(199,844,o),
+(287,854,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(121,599,o),
+(121,627,o),
+(126,650,c),
+(138,670,o),
+(157,688,o),
+(186,688,cs),
+(216,688,o),
+(233,669,o),
+(233,580,cs),
+(233,501,o),
+(220,472,o),
+(178,472,cs),
+(136,472,o),
+(121,500,o),
+(121,580,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,450,o),
+(416,525,o),
+(416,602,cs),
+(416,661,o),
+(371,712,o),
+(306,712,cs),
+(282,712,o),
+(262,704,o),
+(239,685,c),
+(236,688,l),
+(252,756,o),
+(324,828,o),
+(422,839,c),
+(422,860,l),
+(286,860,o),
+(115,739,o),
+(115,584,cs),
+(115,502,o),
+(163,450,o),
+(241,450,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(212,467,o),
+(208,488,o),
+(208,521,cs),
+(208,572,o),
+(220,627,o),
+(230,651,c),
+(252,678,o),
+(273,690,o),
+(293,690,cs),
+(319,690,o),
+(322,671,o),
+(322,649,cs),
+(322,597,o),
+(304,467,o),
+(239,467,cs)
+);
+}
+);
+width = 348;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,450,o),
+(426,525,o),
+(426,602,cs),
+(426,661,o),
+(381,712,o),
+(316,712,cs),
+(292,712,o),
+(272,704,o),
+(249,685,c),
+(246,688,l),
+(262,756,o),
+(334,828,o),
+(432,839,c),
+(432,860,l),
+(296,860,o),
+(125,739,o),
+(125,584,cs),
+(125,502,o),
+(173,450,o),
+(251,450,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,467,o),
+(218,488,o),
+(218,521,cs),
+(218,572,o),
+(230,627,o),
+(240,651,c),
+(262,678,o),
+(283,690,o),
+(303,690,cs),
+(329,690,o),
+(332,671,o),
+(332,649,cs),
+(332,597,o),
+(314,467,o),
+(249,467,cs)
+);
+}
+);
+width = 368;
+}
+);
+unicode = 8310;
+},
+{
+glyphname = sevensuperior;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(20,707,l),
+(41,707,l),
+(59,759,o),
+(57,768,o),
+(70,768,cs),
+(261,768,l),
+(166,618,ls),
+(127,557,o),
+(111,530,o),
+(111,501,cs),
+(111,471,o),
+(129,451,o),
+(166,451,cs),
+(199,451,o),
+(226,466,o),
+(226,501,cs),
+(226,528,o),
+(209,560,o),
+(209,597,cs),
+(209,621,o),
+(220,651,o),
+(245,690,cs),
+(325,818,l),
+(325,854,l),
+(60,854,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,449,o),
+(298,471,o),
+(298,507,cs),
+(298,526,o),
+(291,537,o),
+(291,566,cs),
+(291,586,o),
+(294,616,o),
+(330,663,cs),
+(454,823,l),
+(455,844,l),
+(211,844,l),
+(155,726,l),
+(178,726,l),
+(193,760,o),
+(207,765,o),
+(235,765,cs),
+(374,765,l),
+(374,761,l),
+(278,639,ls),
+(196,535,o),
+(189,525,o),
+(189,501,cs),
+(189,464,o),
+(209,449,o),
+(238,449,cs)
+);
+}
+);
+width = 335;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,449,o),
+(308,471,o),
+(308,507,cs),
+(308,526,o),
+(301,537,o),
+(301,566,cs),
+(301,586,o),
+(304,616,o),
+(340,663,cs),
+(464,823,l),
+(465,844,l),
+(221,844,l),
+(165,726,l),
+(188,726,l),
+(203,760,o),
+(217,765,o),
+(245,765,cs),
+(384,765,l),
+(384,761,l),
+(288,639,ls),
+(206,535,o),
+(199,525,o),
+(199,501,cs),
+(199,464,o),
+(219,449,o),
+(248,449,cs)
+);
+}
+);
+width = 355;
+}
+);
+unicode = 8311;
+},
+{
+glyphname = eightsuperior;
+lastChange = "2016-08-22 13:58:54 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(118,622,o),
+(133,654,o),
+(176,654,cs),
+(219,654,o),
+(233,620,o),
+(233,559,cs),
+(233,494,o),
+(216,468,o),
+(176,468,cs),
+(135,468,o),
+(118,494,o),
+(118,559,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(318,815,o),
+(273,862,o),
+(175,862,cs),
+(81,862,o),
+(34,818,o),
+(34,764,cs),
+(34,702,o),
+(97,664,o),
+(176,664,cs),
+(256,664,o),
+(318,702,o),
+(318,763,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(223,705,o),
+(211,675,o),
+(176,675,cs),
+(142,675,o),
+(129,705,o),
+(129,762,cs),
+(129,818,o),
+(142,842,o),
+(176,842,cs),
+(211,842,o),
+(223,818,o),
+(223,762,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(17,497,o),
+(69,451,o),
+(176,451,cs),
+(283,451,o),
+(334,497,o),
+(334,555,cs),
+(334,618,o),
+(283,650,o),
+(213,664,c),
+(213,668,l),
+(140,668,l),
+(140,664,l),
+(68,651,o),
+(17,618,o),
+(17,555,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,449,o),
+(404,506,o),
+(404,565,cs),
+(404,605,o),
+(369,642,o),
+(311,654,c),
+(311,658,l),
+(381,669,o),
+(430,717,o),
+(430,764,cs),
+(430,809,o),
+(385,848,o),
+(312,848,cs),
+(232,848,o),
+(157,800,o),
+(157,743,cs),
+(157,706,o),
+(188,673,o),
+(237,661,c),
+(237,657,l),
+(161,646,o),
+(103,598,o),
+(103,544,cs),
+(103,490,o),
+(158,449,o),
+(238,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(211,470,o),
+(195,486,o),
+(195,525,cs),
+(195,589,o),
+(234,645,o),
+(275,645,cs),
+(299,645,o),
+(312,624,o),
+(312,586,cs),
+(312,542,o),
+(294,470,o),
+(237,470,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,670,o),
+(249,682,o),
+(249,711,cs),
+(249,754,o),
+(266,833,o),
+(316,833,cs),
+(332,833,o),
+(344,826,o),
+(344,793,cs),
+(344,758,o),
+(330,670,o),
+(277,670,cs)
+);
+}
+);
+width = 352;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(343,449,o),
+(414,506,o),
+(414,565,cs),
+(414,605,o),
+(379,642,o),
+(321,654,c),
+(321,658,l),
+(391,669,o),
+(440,717,o),
+(440,764,cs),
+(440,809,o),
+(395,848,o),
+(322,848,cs),
+(242,848,o),
+(167,800,o),
+(167,743,cs),
+(167,706,o),
+(198,673,o),
+(247,661,c),
+(247,657,l),
+(171,646,o),
+(113,598,o),
+(113,544,cs),
+(113,490,o),
+(168,449,o),
+(248,449,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,470,o),
+(205,486,o),
+(205,525,cs),
+(205,589,o),
+(244,645,o),
+(285,645,cs),
+(309,645,o),
+(322,624,o),
+(322,586,cs),
+(322,542,o),
+(304,470,o),
+(247,470,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,670,o),
+(259,682,o),
+(259,711,cs),
+(259,754,o),
+(276,833,o),
+(326,833,cs),
+(342,833,o),
+(354,826,o),
+(354,793,cs),
+(354,758,o),
+(340,670,o),
+(287,670,cs)
+);
+}
+);
+width = 372;
+}
+);
+unicode = 8312;
+},
+{
+glyphname = ninesuperior;
+lastChange = "2016-08-22 13:59:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(57,455,l),
+(196,460,o),
+(325,563,o),
+(325,694,cs),
+(325,796,o),
+(256,862,o),
+(169,862,cs),
+(89,862,o),
+(16,803,o),
+(16,725,cs),
+(16,655,o),
+(74,601,o),
+(147,601,cs),
+(176,601,o),
+(195,608,o),
+(213,623,c),
+(217,623,l),
+(205,540,o),
+(145,484,o),
+(57,475,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,713,o),
+(228,686,o),
+(223,663,c),
+(212,642,o),
+(192,625,o),
+(163,625,cs),
+(133,625,o),
+(116,644,o),
+(116,732,cs),
+(116,812,o),
+(129,842,o),
+(171,842,cs),
+(213,842,o),
+(228,812,o),
+(228,733,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(269,450,o),
+(440,571,o),
+(440,726,cs),
+(440,808,o),
+(392,860,o),
+(314,860,cs),
+(220,860,o),
+(139,785,o),
+(139,707,cs),
+(139,649,o),
+(185,598,o),
+(249,598,cs),
+(274,598,o),
+(294,605,o),
+(316,625,c),
+(319,622,l),
+(303,553,o),
+(231,481,o),
+(134,471,c),
+(134,450,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,619,o),
+(233,639,o),
+(233,661,cs),
+(233,713,o),
+(251,842,o),
+(317,842,cs),
+(343,842,o),
+(347,822,o),
+(347,788,cs),
+(347,737,o),
+(335,683,o),
+(325,659,c),
+(304,632,o),
+(283,619,o),
+(262,619,cs)
+);
+}
+);
+width = 348;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(279,450,o),
+(450,571,o),
+(450,726,cs),
+(450,808,o),
+(402,860,o),
+(324,860,cs),
+(230,860,o),
+(149,785,o),
+(149,707,cs),
+(149,649,o),
+(195,598,o),
+(259,598,cs),
+(284,598,o),
+(304,605,o),
+(326,625,c),
+(329,622,l),
+(313,553,o),
+(241,481,o),
+(144,471,c),
+(144,450,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,619,o),
+(243,639,o),
+(243,661,cs),
+(243,713,o),
+(261,842,o),
+(327,842,cs),
+(353,842,o),
+(357,822,o),
+(357,788,cs),
+(357,737,o),
+(345,683,o),
+(335,659,c),
+(314,632,o),
+(293,619,o),
+(272,619,cs)
+);
+}
+);
+width = 368;
+}
+);
+unicode = 8313;
+},
+{
+glyphname = fraction;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-85,0,l),
+(505,753,l),
+(446,753,l),
+(-144,0,l)
+);
+}
+);
+width = 254;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-85,0,l),
+(505,753,l),
+(446,753,l),
+(-144,0,l)
+);
+}
+);
+width = 274;
+}
+);
+unicode = 8260;
+},
+{
+glyphname = onehalf;
+lastChange = "2016-08-22 13:59:21 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+pos = (319,0);
+ref = fraction;
+},
+{
+pos = (71,0);
+ref = one.numerator;
+},
+{
+pos = (506,0);
+ref = two.denominator;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+pos = (331,0);
+ref = fraction;
+},
+{
+pos = (71,0);
+ref = one.numerator;
+},
+{
+pos = (506,0);
+ref = two.denominator;
+}
+);
+width = 933;
+}
+);
+unicode = 189;
+},
+{
+glyphname = onethird;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+pos = (532,0);
+ref = three.denominator;
+},
+{
+pos = (71,0);
+ref = one.numerator;
+},
+{
+pos = (314,0);
+ref = fraction;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (532,0);
+ref = three.denominator;
+},
+{
+pos = (71,0);
+ref = one.numerator;
+},
+{
+pos = (314,0);
+ref = fraction;
+}
+);
+width = 933;
+}
+);
+unicode = 8531;
+},
+{
+glyphname = twothirds;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+pos = (33,0);
+ref = two.numerator;
+},
+{
+pos = (542,0);
+ref = three.denominator;
+},
+{
+pos = (335,0);
+ref = fraction;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (33,0);
+ref = two.numerator;
+},
+{
+pos = (542,0);
+ref = three.denominator;
+},
+{
+pos = (335,0);
+ref = fraction;
+}
+);
+width = 933;
+}
+);
+unicode = 8532;
+},
+{
+glyphname = onequarter;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+pos = (499,0);
+ref = four.denominator;
+},
+{
+pos = (71,0);
+ref = one.numerator;
+},
+{
+pos = (329,0);
+ref = fraction;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (499,0);
+ref = four.denominator;
+},
+{
+pos = (71,0);
+ref = one.numerator;
+},
+{
+pos = (329,0);
+ref = fraction;
+}
+);
+width = 933;
+}
+);
+unicode = 188;
+},
+{
+glyphname = threequarters;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+pos = (61,0);
+ref = three.numerator;
+},
+{
+pos = (350,0);
+ref = fraction;
+},
+{
+pos = (499,0);
+ref = four.denominator;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (61,0);
+ref = three.numerator;
+},
+{
+pos = (350,0);
+ref = fraction;
+},
+{
+pos = (499,0);
+ref = four.denominator;
+}
+);
+width = 933;
+}
+);
+unicode = 190;
+},
+{
+glyphname = oneeighth;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+pos = (532,0);
+ref = eight.denominator;
+},
+{
+pos = (71,0);
+ref = one.numerator;
+},
+{
+pos = (306,0);
+ref = fraction;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (532,0);
+ref = eight.denominator;
+},
+{
+pos = (71,0);
+ref = one.numerator;
+},
+{
+pos = (306,0);
+ref = fraction;
+}
+);
+width = 933;
+}
+);
+unicode = 8539;
+},
+{
+glyphname = threeeighths;
+lastChange = "2016-08-22 13:59:47 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+pos = (327,0);
+ref = fraction;
+},
+{
+pos = (51,0);
+ref = three.numerator;
+},
+{
+pos = (532,0);
+ref = eight.denominator;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+pos = (341,0);
+ref = fraction;
+},
+{
+pos = (51,0);
+ref = three.numerator;
+},
+{
+pos = (532,0);
+ref = eight.denominator;
+}
+);
+width = 933;
+}
+);
+unicode = 8540;
+},
+{
+glyphname = fiveeighths;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+pos = (47,0);
+ref = five.numerator;
+},
+{
+pos = (326,0);
+ref = fraction;
+},
+{
+pos = (532,0);
+ref = eight.denominator;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (47,0);
+ref = five.numerator;
+},
+{
+pos = (326,0);
+ref = fraction;
+},
+{
+pos = (532,0);
+ref = eight.denominator;
+}
+);
+width = 933;
+}
+);
+unicode = 8541;
+},
+{
+glyphname = seveneighths;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+pos = (53,0);
+ref = seven.numerator;
+},
+{
+pos = (324,0);
+ref = fraction;
+},
+{
+pos = (532,0);
+ref = eight.denominator;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (53,0);
+ref = seven.numerator;
+},
+{
+pos = (324,0);
+ref = fraction;
+},
+{
+pos = (532,0);
+ref = eight.denominator;
+}
+);
+width = 933;
+}
+);
+unicode = 8542;
+},
+{
+glyphname = asterisk;
+lastChange = "2016-08-22 13:01:51 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(306,336,o),
+(324,361,o),
+(327,390,cs),
+(327,403,o),
+(312,490,o),
+(312,511,c),
+(312,520,l),
+(375,482,o),
+(379,419,o),
+(428,419,cs),
+(461,419,o),
+(480,447,o),
+(480,467,cs),
+(480,534,o),
+(412,509,o),
+(335,547,c),
+(335,551,l),
+(411,583,o),
+(500,575,o),
+(500,631,cs),
+(500,655,o),
+(489,679,o),
+(458,679,cs),
+(409,679,o),
+(390,616,o),
+(321,576,c),
+(332,643,o),
+(365,671,o),
+(365,709,cs),
+(365,742,o),
+(353,763,o),
+(323,763,cs),
+(292,763,o),
+(271,741,o),
+(271,701,cs),
+(271,670,o),
+(287,642,o),
+(287,578,c),
+(283,576,l),
+(220,618,o),
+(218,679,o),
+(168,679,cs),
+(133,679,o),
+(117,655,o),
+(117,633,cs),
+(117,612,o),
+(125,599,o),
+(140,590,cs),
+(176,568,o),
+(210,578,o),
+(264,551,c),
+(264,547,l),
+(184,512,o),
+(97,526,o),
+(97,460,cs),
+(97,437,o),
+(110,419,o),
+(138,419,cs),
+(189,419,o),
+(204,480,o),
+(276,522,c),
+(280,520,l),
+(266,455,o),
+(233,421,o),
+(233,379,cs),
+(233,354,o),
+(245,336,o),
+(273,336,cs)
+);
+}
+);
+width = 443;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(323,336,o),
+(348,361,o),
+(348,395,cs),
+(348,431,o),
+(320,459,o),
+(319,520,c),
+(322,522,l),
+(380,478,o),
+(383,409,o),
+(441,409,cs),
+(479,409,o),
+(497,439,o),
+(497,471,cs),
+(497,545,o),
+(403,513,o),
+(339,547,c),
+(346,551,l),
+(413,577,o),
+(518,563,o),
+(518,633,cs),
+(518,656,o),
+(507,689,o),
+(469,689,cs),
+(414,689,o),
+(409,624,o),
+(326,578,c),
+(339,629,o),
+(387,670,o),
+(387,716,cs),
+(387,745,o),
+(368,763,o),
+(335,763,cs),
+(300,763,o),
+(272,743,o),
+(272,704,cs),
+(272,670,o),
+(294,640,o),
+(294,578,c),
+(291,576,l),
+(228,623,o),
+(230,689,o),
+(176,689,cs),
+(145,689,o),
+(115,667,o),
+(115,631,cs),
+(115,611,o),
+(124,591,o),
+(147,580,cs),
+(179,564,o),
+(217,577,o),
+(275,551,c),
+(268,547,l),
+(212,525,o),
+(94,535,o),
+(94,459,cs),
+(94,430,o),
+(112,409,o),
+(145,409,cs),
+(203,409,o),
+(210,476,o),
+(284,522,c),
+(287,520,l),
+(272,455,o),
+(234,434,o),
+(234,390,cs),
+(234,357,o),
+(255,336,o),
+(288,336,cs)
+);
+}
+);
+width = 471;
+}
+);
+unicode = 42;
+},
+{
+glyphname = backslash;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,0,l),
+(129,753,l),
+(70,753,l),
+(149,0,l)
+);
+}
+);
+width = 205;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(207,0,l),
+(157,754,l),
+(78,754,l),
+(128,0,l)
+);
+}
+);
+width = 225;
+}
+);
+unicode = 92;
+},
+{
+glyphname = periodcentered;
+lastChange = "2016-08-22 14:00:05 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,184,o),
+(161,213,o),
+(161,251,cs),
+(161,289,o),
+(131,319,o),
+(93,319,cs),
+(55,319,o),
+(26,289,o),
+(26,251,cs),
+(26,213,o),
+(55,184,o),
+(93,184,cs)
+);
+}
+);
+width = 166;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,167,o),
+(200,206,o),
+(200,254,cs),
+(200,302,o),
+(161,341,o),
+(113,341,cs),
+(65,341,o),
+(26,302,o),
+(26,254,cs),
+(26,206,o),
+(65,167,o),
+(113,167,cs)
+);
+}
+);
+width = 214;
+}
+);
+unicode = 183;
+},
+{
+glyphname = bullet;
+lastChange = "2016-08-22 14:00:12 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(305,265,o),
+(350,317,o),
+(350,380,cs),
+(350,443,o),
+(305,495,o),
+(235,495,cs),
+(165,495,o),
+(120,443,o),
+(120,380,cs),
+(120,317,o),
+(165,265,o),
+(235,265,cs)
+);
+}
+);
+width = 410;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(320,265,o),
+(365,317,o),
+(365,380,cs),
+(365,443,o),
+(320,495,o),
+(250,495,cs),
+(180,495,o),
+(135,443,o),
+(135,380,cs),
+(135,317,o),
+(180,265,o),
+(250,265,cs)
+);
+}
+);
+width = 430;
+}
+);
+unicode = 8226;
+},
+{
+glyphname = colon;
+lastChange = "2016-08-22 14:00:26 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(208,319,o),
+(238,348,o),
+(238,386,cs),
+(238,424,o),
+(208,454,o),
+(170,454,cs),
+(132,454,o),
+(103,424,o),
+(103,386,cs),
+(103,348,o),
+(132,319,o),
+(170,319,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(146,-13,o),
+(176,16,o),
+(176,54,cs),
+(176,92,o),
+(146,122,o),
+(108,122,cs),
+(70,122,o),
+(41,92,o),
+(41,54,cs),
+(41,16,o),
+(70,-13,o),
+(108,-13,cs)
+);
+}
+);
+width = 270;
+},
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(5,26,o),
+(43,-12,o),
+(91,-12,cs),
+(140,-12,o),
+(178,26,o),
+(178,74,cs),
+(178,123,o),
+(140,161,o),
+(91,161,cs),
+(43,161,o),
+(5,123,o),
+(5,74,cs)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(198,277,o),
+(236,315,o),
+(236,363,cs),
+(236,412,o),
+(198,450,o),
+(149,450,cs),
+(101,450,o),
+(63,412,o),
+(63,363,cs),
+(63,315,o),
+(101,277,o),
+(149,277,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,-12,o),
+(178,26,o),
+(178,74,cs),
+(178,123,o),
+(140,161,o),
+(91,161,cs),
+(43,161,o),
+(5,123,o),
+(5,74,cs),
+(5,26,o),
+(43,-12,o),
+(91,-12,cs)
+);
+}
+);
+width = 240;
+}
+);
+unicode = 58;
+},
+{
+glyphname = comma;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(79,-120,o),
+(142,-51,o),
+(142,19,cs),
+(142,71,o),
+(108,113,o),
+(54,113,cs),
+(8,113,o),
+(-20,83,o),
+(-20,44,cs),
+(-20,11,o),
+(1,-11,o),
+(34,-11,cs),
+(72,-11,o),
+(75,20,o),
+(90,20,cs),
+(97,20,o),
+(106,12,o),
+(106,-6,cs),
+(106,-45,o),
+(66,-98,o),
+(-28,-145,c),
+(-15,-168,l)
+);
+}
+);
+width = 216;
+},
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(5,26,o),
+(43,-12,o),
+(91,-12,cs),
+(140,-12,o),
+(178,26,o),
+(178,74,cs),
+(178,123,o),
+(140,161,o),
+(91,161,cs),
+(43,161,o),
+(5,123,o),
+(5,74,cs)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(132,-136,o),
+(206,-49,o),
+(206,33,cs),
+(206,83,o),
+(178,156,o),
+(101,156,cs),
+(51,156,o),
+(3,125,o),
+(3,68,cs),
+(3,31,o),
+(23,-11,o),
+(72,-11,cs),
+(123,-11,o),
+(129,33,o),
+(144,33,cs),
+(150,33,o),
+(159,25,o),
+(159,5,cs),
+(159,-52,o),
+(90,-117,o),
+(-10,-173,c),
+(3,-196,l)
+);
+}
+);
+width = 240;
+}
+);
+unicode = 44;
+},
+{
+glyphname = ellipsis;
+lastChange = "2016-08-22 14:00:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-13,o),
+(495,16,o),
+(495,54,cs),
+(495,92,o),
+(465,122,o),
+(427,122,cs),
+(389,122,o),
+(360,92,o),
+(360,54,cs),
+(360,16,o),
+(389,-13,o),
+(427,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(87,-13,o),
+(117,16,o),
+(117,54,cs),
+(117,92,o),
+(87,122,o),
+(49,122,cs),
+(11,122,o),
+(-18,92,o),
+(-18,54,cs),
+(-18,16,o),
+(11,-13,o),
+(49,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(276,-13,o),
+(306,16,o),
+(306,54,cs),
+(306,92,o),
+(276,122,o),
+(238,122,cs),
+(200,122,o),
+(171,92,o),
+(171,54,cs),
+(171,16,o),
+(200,-13,o),
+(238,-13,cs)
+);
+}
+);
+width = 555;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,-12,o),
+(658,26,o),
+(658,74,cs),
+(658,123,o),
+(620,161,o),
+(571,161,cs),
+(523,161,o),
+(485,123,o),
+(485,74,cs),
+(485,26,o),
+(523,-12,o),
+(571,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(140,-12,o),
+(178,26,o),
+(178,74,cs),
+(178,123,o),
+(140,161,o),
+(91,161,cs),
+(43,161,o),
+(5,123,o),
+(5,74,cs),
+(5,26,o),
+(43,-12,o),
+(91,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,-12,o),
+(418,26,o),
+(418,74,cs),
+(418,123,o),
+(380,161,o),
+(331,161,cs),
+(283,161,o),
+(245,123,o),
+(245,74,cs),
+(245,26,o),
+(283,-12,o),
+(331,-12,cs)
+);
+}
+);
+width = 720;
+}
+);
+unicode = 8230;
+},
+{
+glyphname = exclam;
+lastChange = "2016-08-22 14:00:53 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(175,224,l),
+(226,494,o),
+(326,618,o),
+(326,693,cs),
+(326,730,o),
+(302,763,o),
+(257,763,cs),
+(212,763,o),
+(183,731,o),
+(183,661,cs),
+(183,648,o),
+(184,613,o),
+(184,579,cs),
+(184,502,o),
+(179,397,o),
+(150,224,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(163,-13,o),
+(193,17,o),
+(193,53,cs),
+(193,89,o),
+(163,119,o),
+(127,119,cs),
+(91,119,o),
+(61,89,o),
+(61,53,cs),
+(61,17,o),
+(91,-13,o),
+(127,-13,cs)
+);
+}
+);
+width = 308;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(176,224,l),
+(230,488,o),
+(337,604,o),
+(337,687,cs),
+(337,730,o),
+(309,763,o),
+(261,763,cs),
+(213,763,o),
+(170,731,o),
+(170,637,cs),
+(170,617,o),
+(172,557,o),
+(172,502,cs),
+(172,424,o),
+(167,330,o),
+(146,224,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,-12,o),
+(215,26,o),
+(215,74,cs),
+(215,123,o),
+(177,161,o),
+(128,161,cs),
+(80,161,o),
+(42,123,o),
+(42,74,cs),
+(42,26,o),
+(80,-12,o),
+(128,-12,cs)
+);
+}
+);
+width = 328;
+}
+);
+unicode = 33;
+},
+{
+glyphname = exclamdown;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+angle = 180;
+pos = (315,441);
+ref = exclam;
+}
+);
+width = 308;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+angle = 180;
+pos = (308,443);
+ref = exclam;
+}
+);
+width = 328;
+}
+);
+unicode = 161;
+},
+{
+glyphname = numbersign;
+lastChange = "2016-10-31 10:57:33 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,236,l),
+(527,276,l),
+(29,276,l),
+(29,236,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(576,475,l),
+(576,515,l),
+(78,515,l),
+(78,475,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(154,0,l),
+(274,763,l),
+(226,763,l),
+(106,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(371,0,l),
+(491,763,l),
+(443,763,l),
+(323,0,l)
+);
+}
+);
+width = 546;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(537,232,l),
+(537,281,l),
+(39,281,l),
+(39,232,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(586,470,l),
+(586,520,l),
+(88,520,l),
+(88,470,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,0,l),
+(292,763,l),
+(228,763,l),
+(108,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,0,l),
+(501,763,l),
+(445,763,l),
+(325,0,l)
+);
+}
+);
+width = 566;
+}
+);
+unicode = 35;
+},
+{
+glyphname = period;
+lastChange = "2016-08-22 14:01:07 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(87,-13,o),
+(117,16,o),
+(117,54,cs),
+(117,92,o),
+(87,122,o),
+(49,122,cs),
+(11,122,o),
+(-18,92,o),
+(-18,54,cs),
+(-18,16,o),
+(11,-13,o),
+(49,-13,cs)
+);
+}
+);
+width = 177;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(140,-12,o),
+(178,26,o),
+(178,74,cs),
+(178,123,o),
+(140,161,o),
+(91,161,cs),
+(43,161,o),
+(5,123,o),
+(5,74,cs),
+(5,26,o),
+(43,-12,o),
+(91,-12,cs)
+);
+}
+);
+width = 240;
+}
+);
+unicode = 46;
+},
+{
+glyphname = question;
+lastChange = "2016-08-22 14:01:14 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(197,224,l),
+(197,385,o),
+(495,354,o),
+(495,583,cs),
+(495,698,o),
+(420,763,o),
+(314,763,cs),
+(203,763,o),
+(137,692,o),
+(137,626,cs),
+(137,581,o),
+(168,556,o),
+(198,556,cs),
+(224,556,o),
+(251,576,o),
+(251,612,cs),
+(251,662,o),
+(197,648,o),
+(197,678,cs),
+(197,709,o),
+(254,738,o),
+(312,738,cs),
+(394,738,o),
+(441,681,o),
+(441,620,cs),
+(441,476,o),
+(174,503,o),
+(174,271,cs),
+(174,257,o),
+(175,241,o),
+(177,224,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(191,-13,o),
+(221,17,o),
+(221,53,cs),
+(221,89,o),
+(191,119,o),
+(155,119,cs),
+(119,119,o),
+(89,89,o),
+(89,53,cs),
+(89,17,o),
+(119,-13,o),
+(155,-13,cs)
+);
+}
+);
+width = 459;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(206,224,l),
+(206,366,o),
+(509,346,o),
+(509,572,cs),
+(509,685,o),
+(433,763,o),
+(312,763,cs),
+(197,763,o),
+(130,692,o),
+(130,624,cs),
+(130,577,o),
+(163,552,o),
+(198,552,cs),
+(227,552,o),
+(267,570,o),
+(267,619,cs),
+(267,673,o),
+(218,672,o),
+(218,696,cs),
+(218,716,o),
+(252,733,o),
+(302,733,cs),
+(387,733,o),
+(418,684,o),
+(418,633,cs),
+(418,490,o),
+(178,524,o),
+(178,272,cs),
+(178,256,o),
+(179,241,o),
+(181,224,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,-12,o),
+(255,26,o),
+(255,74,cs),
+(255,123,o),
+(217,161,o),
+(168,161,cs),
+(120,161,o),
+(82,123,o),
+(82,74,cs),
+(82,26,o),
+(120,-12,o),
+(168,-12,cs)
+);
+}
+);
+width = 479;
+}
+);
+unicode = 63;
+},
+{
+glyphname = questiondown;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+angle = 180;
+pos = (488,441);
+ref = question;
+}
+);
+width = 459;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+angle = 180;
+pos = (459,442);
+ref = question;
+}
+);
+width = 479;
+}
+);
+unicode = 191;
+},
+{
+glyphname = quotedbl;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,463,l),
+(394,637,o),
+(466,659,o),
+(466,716,cs),
+(466,748,o),
+(443,763,o),
+(412,763,cs),
+(367,763,o),
+(338,730,o),
+(338,686,cs),
+(338,657,o),
+(351,630,o),
+(351,573,cs),
+(351,546,o),
+(348,511,o),
+(338,463,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(193,463,l),
+(223,637,o),
+(295,659,o),
+(295,716,cs),
+(295,748,o),
+(272,763,o),
+(241,763,cs),
+(196,763,o),
+(167,730,o),
+(167,686,cs),
+(167,657,o),
+(180,630,o),
+(180,573,cs),
+(180,546,o),
+(177,511,o),
+(167,463,c)
+);
+}
+);
+width = 395;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(378,403,l),
+(417,613,o),
+(504,622,o),
+(504,697,cs),
+(504,739,o),
+(475,763,o),
+(435,763,cs),
+(384,763,o),
+(336,723,o),
+(336,670,cs),
+(336,631,o),
+(361,594,o),
+(361,518,cs),
+(361,488,o),
+(357,451,o),
+(347,403,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,403,l),
+(214,613,o),
+(301,622,o),
+(301,697,cs),
+(301,739,o),
+(272,763,o),
+(232,763,cs),
+(181,763,o),
+(133,723,o),
+(133,670,cs),
+(133,631,o),
+(158,594,o),
+(158,518,cs),
+(158,488,o),
+(154,451,o),
+(144,403,c)
+);
+}
+);
+width = 415;
+}
+);
+unicode = 34;
+},
+{
+glyphname = quotesingle;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,463,l),
+(220,637,o),
+(292,659,o),
+(292,716,cs),
+(292,748,o),
+(269,763,o),
+(238,763,cs),
+(193,763,o),
+(164,730,o),
+(164,686,cs),
+(164,657,o),
+(177,630,o),
+(177,573,cs),
+(177,546,o),
+(174,511,o),
+(164,463,c)
+);
+}
+);
+width = 224;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(185,403,l),
+(224,613,o),
+(311,622,o),
+(311,697,cs),
+(311,739,o),
+(282,763,o),
+(242,763,cs),
+(191,763,o),
+(143,723,o),
+(143,670,cs),
+(143,631,o),
+(168,594,o),
+(168,518,cs),
+(168,488,o),
+(164,451,o),
+(154,403,c)
+);
+}
+);
+width = 244;
+}
+);
+unicode = 39;
+},
+{
+glyphname = semicolon;
+lastChange = "2016-08-22 14:01:26 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(109,-120,o),
+(172,-51,o),
+(172,19,cs),
+(172,71,o),
+(138,113,o),
+(84,113,cs),
+(38,113,o),
+(10,83,o),
+(10,44,cs),
+(10,11,o),
+(31,-11,o),
+(64,-11,cs),
+(102,-11,o),
+(105,20,o),
+(120,20,cs),
+(127,20,o),
+(136,12,o),
+(136,-6,cs),
+(136,-45,o),
+(96,-98,o),
+(2,-145,c),
+(15,-168,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(182,319,o),
+(212,348,o),
+(212,386,cs),
+(212,424,o),
+(182,454,o),
+(144,454,cs),
+(106,454,o),
+(77,424,o),
+(77,386,cs),
+(77,348,o),
+(106,319,o),
+(144,319,cs)
+);
+}
+);
+width = 231;
+},
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(5,26,o),
+(43,-12,o),
+(91,-12,cs),
+(140,-12,o),
+(178,26,o),
+(178,74,cs),
+(178,123,o),
+(140,161,o),
+(91,161,cs),
+(43,161,o),
+(5,123,o),
+(5,74,cs)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,-136,o),
+(207,-49,o),
+(207,33,cs),
+(207,83,o),
+(179,156,o),
+(102,156,cs),
+(52,156,o),
+(4,125,o),
+(4,68,cs),
+(4,31,o),
+(24,-11,o),
+(73,-11,cs),
+(124,-11,o),
+(130,33,o),
+(145,33,cs),
+(151,33,o),
+(160,25,o),
+(160,5,cs),
+(160,-52,o),
+(91,-117,o),
+(-9,-173,c),
+(4,-196,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,277,o),
+(237,315,o),
+(237,363,cs),
+(237,412,o),
+(199,450,o),
+(150,450,cs),
+(102,450,o),
+(64,412,o),
+(64,363,cs),
+(64,315,o),
+(102,277,o),
+(150,277,cs)
+);
+}
+);
+width = 240;
+}
+);
+unicode = 59;
+},
+{
+glyphname = slash;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(16,0,l),
+(386,753,l),
+(327,753,l),
+(-43,0,l)
+);
+}
+);
+width = 254;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(36,0,l),
+(386,753,l),
+(307,753,l),
+(-43,0,l)
+);
+}
+);
+width = 274;
+}
+);
+unicode = 47;
+},
+{
+glyphname = underscore;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(476,-114,l),
+(476,-70,l),
+(-62,-70,l),
+(-62,-114,l)
+);
+}
+);
+width = 538;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(493,-124,l),
+(493,-70,l),
+(-91,-70,l),
+(-91,-124,l)
+);
+}
+);
+width = 558;
+}
+);
+unicode = 95;
+},
+{
+glyphname = braceleft;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,-105,l),
+(172,-105,o),
+(151,-80,o),
+(151,-46,cs),
+(151,-28,o),
+(154,-5,o),
+(161,25,cs),
+(201,205,o),
+(203,222,o),
+(203,237,cs),
+(203,283,o),
+(179,304,o),
+(122,311,c),
+(123,315,l),
+(202,324,o),
+(234,357,o),
+(253,440,cs),
+(288,599,ls),
+(308,691,o),
+(336,729,o),
+(407,729,c),
+(412,754,l),
+(239,754,o),
+(202,706,o),
+(173,572,cs),
+(145,443,ls),
+(124,349,o),
+(103,321,o),
+(51,321,c),
+(48,304,l),
+(83,304,o),
+(98,291,o),
+(98,255,cs),
+(98,237,o),
+(93,213,o),
+(58,52,cs),
+(50,13,o),
+(45,-18,o),
+(45,-42,cs),
+(45,-104,o),
+(88,-130,o),
+(217,-130,c)
+);
+}
+);
+width = 300;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,-100,l),
+(186,-100,o),
+(167,-86,o),
+(167,-39,cs),
+(167,-21,o),
+(170,-3,o),
+(177,30,cs),
+(214,205,o),
+(216,215,o),
+(216,229,cs),
+(216,276,o),
+(192,303,o),
+(134,311,c),
+(135,315,l),
+(212,324,o),
+(246,355,o),
+(264,440,cs),
+(296,594,ls),
+(317,695,o),
+(342,724,o),
+(409,724,c),
+(415,754,l),
+(221,754,o),
+(191,724,o),
+(158,572,cs),
+(130,443,ls),
+(111,353,o),
+(91,326,o),
+(39,326,c),
+(34,299,l),
+(74,299,o),
+(84,283,o),
+(84,244,cs),
+(84,227,o),
+(82,215,o),
+(47,52,cs),
+(40,19,o),
+(34,-11,o),
+(34,-34,cs),
+(34,-103,o),
+(89,-130,o),
+(228,-130,c)
+);
+}
+);
+width = 320;
+}
+);
+unicode = 123;
+},
+{
+glyphname = braceright;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(120,-130,o),
+(157,-82,o),
+(186,52,cs),
+(214,181,ls),
+(235,275,o),
+(256,303,o),
+(308,303,c),
+(311,320,l),
+(276,320,o),
+(261,333,o),
+(261,369,cs),
+(261,387,o),
+(266,411,o),
+(301,572,cs),
+(309,611,o),
+(314,642,o),
+(314,666,cs),
+(314,728,o),
+(271,754,o),
+(142,754,c),
+(137,729,l),
+(187,729,o),
+(208,704,o),
+(208,670,cs),
+(208,652,o),
+(205,629,o),
+(198,599,cs),
+(158,419,o),
+(156,402,o),
+(156,387,cs),
+(156,341,o),
+(180,320,o),
+(237,313,c),
+(236,309,l),
+(157,300,o),
+(125,267,o),
+(106,184,cs),
+(71,25,ls),
+(51,-67,o),
+(23,-105,o),
+(-48,-105,c),
+(-53,-130,l)
+);
+}
+);
+width = 300;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,-130,o),
+(182,-100,o),
+(215,52,cs),
+(243,181,ls),
+(262,271,o),
+(282,298,o),
+(334,298,c),
+(339,325,l),
+(299,325,o),
+(289,341,o),
+(289,380,cs),
+(289,397,o),
+(291,409,o),
+(326,572,cs),
+(333,605,o),
+(339,635,o),
+(339,658,cs),
+(339,727,o),
+(284,754,o),
+(145,754,c),
+(139,724,l),
+(187,724,o),
+(206,710,o),
+(206,663,cs),
+(206,645,o),
+(203,627,o),
+(196,594,cs),
+(159,419,o),
+(157,409,o),
+(157,395,cs),
+(157,348,o),
+(181,321,o),
+(239,313,c),
+(238,309,l),
+(161,300,o),
+(127,269,o),
+(109,184,cs),
+(77,30,ls),
+(56,-71,o),
+(31,-100,o),
+(-36,-100,c),
+(-42,-130,l)
+);
+}
+);
+width = 320;
+}
+);
+unicode = 125;
+},
+{
+glyphname = bracketleft;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(99,-115,l),
+(291,754,l),
+(182,754,l),
+(-9,-115,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,-130,l),
+(211,-105,l),
+(3,-105,l),
+(-9,-115,l),
+(-9,-130,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(396,729,l),
+(401,754,l),
+(182,754,l),
+(177,729,l)
+);
+}
+);
+width = 319;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(129,-115,l),
+(313,754,l),
+(179,754,l),
+(-4,-115,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,-130,l),
+(227,-100,l),
+(-1,-100,l),
+(-4,-115,l),
+(-4,-130,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(402,724,l),
+(408,754,l),
+(179,754,l),
+(173,724,l)
+);
+}
+);
+width = 339;
+}
+);
+unicode = 91;
+},
+{
+glyphname = bracketright;
+lastChange = "2016-08-22 13:05:59 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(177,-130,l),
+(372,754,l),
+(260,754,l),
+(68,-130,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(177,-130,l),
+(182,-105,l),
+(-37,-105,l),
+(-42,-130,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,729,l),
+(372,754,l),
+(153,754,l),
+(148,729,l)
+);
+}
+);
+width = 319;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(206,-130,l),
+(389,754,l),
+(259,754,l),
+(72,-130,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(206,-130,l),
+(212,-100,l),
+(-17,-100,l),
+(-23,-130,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,724,l),
+(389,754,l),
+(160,754,l),
+(154,724,l)
+);
+}
+);
+width = 339;
+}
+);
+unicode = 93;
+},
+{
+glyphname = parenleft;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,-143,l),
+(181,-66,o),
+(163,17,o),
+(163,109,cs),
+(163,298,o),
+(239,578,o),
+(429,768,c),
+(408,784,l),
+(150,568,o),
+(56,374,o),
+(56,197,cs),
+(56,82,o),
+(96,-32,o),
+(197,-156,c)
+);
+}
+);
+width = 309;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,-143,l),
+(191,-71,o),
+(179,9,o),
+(179,96,cs),
+(179,326,o),
+(264,581,o),
+(418,768,c),
+(396,784,l),
+(211,628,o),
+(50,438,o),
+(50,203,cs),
+(50,89,o),
+(88,-26,o),
+(195,-156,c)
+);
+}
+);
+width = 329;
+}
+);
+unicode = 40;
+},
+{
+glyphname = parenright;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(225,60,o),
+(319,254,o),
+(319,431,cs),
+(319,546,o),
+(279,660,o),
+(178,784,c),
+(150,771,l),
+(194,694,o),
+(212,611,o),
+(212,519,cs),
+(212,330,o),
+(136,50,o),
+(-54,-140,c),
+(-33,-156,l)
+);
+}
+);
+width = 309;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,0,o),
+(324,190,o),
+(324,425,cs),
+(324,539,o),
+(286,654,o),
+(179,784,c),
+(152,771,l),
+(183,699,o),
+(195,619,o),
+(195,532,cs),
+(195,302,o),
+(110,47,o),
+(-44,-140,c),
+(-22,-156,l)
+);
+}
+);
+width = 329;
+}
+);
+unicode = 41;
+},
+{
+glyphname = emdash;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(828,202,l),
+(828,246,l),
+(0,246,l),
+(0,202,l)
+);
+}
+);
+width = 828;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(858,192,l),
+(858,246,l),
+(-17,246,l),
+(-17,192,l)
+);
+}
+);
+width = 848;
+}
+);
+unicode = 8212;
+},
+{
+glyphname = endash;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,202,l),
+(538,246,l),
+(0,246,l),
+(0,202,l)
+);
+}
+);
+width = 538;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(570,192,l),
+(570,246,l),
+(-14,246,l),
+(-14,192,l)
+);
+}
+);
+width = 558;
+}
+);
+unicode = 8211;
+},
+{
+glyphname = hyphen;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,202,l),
+(345,246,l),
+(50,246,l),
+(50,202,l)
+);
+}
+);
+width = 395;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,182,l),
+(353,246,l),
+(58,246,l),
+(58,182,l)
+);
+}
+);
+width = 415;
+}
+);
+unicode = 45;
+},
+{
+glyphname = softhyphen;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,202,l),
+(345,246,l),
+(50,246,l),
+(50,202,l)
+);
+}
+);
+width = 395;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(355,182,l),
+(355,246,l),
+(60,246,l),
+(60,182,l)
+);
+}
+);
+width = 415;
+}
+);
+unicode = 173;
+},
+{
+glyphname = guillemetleft;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,53,l),
+(337,220,l),
+(485,391,l),
+(473,402,l),
+(235,231,l),
+(230,209,l),
+(392,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,53,l),
+(174,220,l),
+(322,391,l),
+(310,402,l),
+(72,231,l),
+(67,209,l),
+(229,38,l)
+);
+}
+);
+width = 508;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,43,l),
+(387,220,l),
+(516,401,l),
+(503,412,l),
+(245,231,l),
+(240,209,l),
+(422,28,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,43,l),
+(204,220,l),
+(333,401,l),
+(320,412,l),
+(62,231,l),
+(57,209,l),
+(239,28,l)
+);
+}
+);
+width = 528;
+}
+);
+unicode = 171;
+},
+{
+glyphname = guillemetright;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,209,l),
+(450,231,l),
+(288,402,l),
+(270,391,l),
+(344,220,l),
+(195,53,l),
+(207,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,209,l),
+(287,231,l),
+(125,402,l),
+(107,391,l),
+(181,220,l),
+(32,53,l),
+(44,38,l)
+);
+}
+);
+width = 508;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(475,209,l),
+(480,231,l),
+(298,412,l),
+(281,401,l),
+(334,220,l),
+(205,43,l),
+(217,28,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(292,209,l),
+(297,231,l),
+(115,412,l),
+(98,401,l),
+(151,220,l),
+(22,43,l),
+(34,28,l)
+);
+}
+);
+width = 528;
+}
+);
+unicode = 187;
+},
+{
+glyphname = guilsinglleft;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,53,l),
+(171,220,l),
+(319,391,l),
+(307,402,l),
+(69,231,l),
+(64,209,l),
+(226,38,l)
+);
+}
+);
+width = 345;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,43,l),
+(210,220,l),
+(329,401,l),
+(316,412,l),
+(68,231,l),
+(63,209,l),
+(235,28,l)
+);
+}
+);
+width = 365;
+}
+);
+unicode = 8249;
+},
+{
+glyphname = guilsinglright;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(281,209,l),
+(286,231,l),
+(124,402,l),
+(106,391,l),
+(180,220,l),
+(31,53,l),
+(43,38,l)
+);
+}
+);
+width = 345;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,209,l),
+(307,231,l),
+(125,412,l),
+(108,401,l),
+(161,220,l),
+(32,43,l),
+(44,28,l)
+);
+}
+);
+width = 365;
+}
+);
+unicode = 8250;
+},
+{
+glyphname = quotedblbase;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,-94,o),
+(380,-25,o),
+(380,45,cs),
+(380,97,o),
+(346,139,o),
+(292,139,cs),
+(246,139,o),
+(218,109,o),
+(218,70,cs),
+(218,37,o),
+(239,15,o),
+(272,15,cs),
+(310,15,o),
+(313,46,o),
+(328,46,cs),
+(335,46,o),
+(344,38,o),
+(344,20,cs),
+(344,-19,o),
+(304,-72,o),
+(210,-119,c),
+(223,-142,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(111,-94,o),
+(174,-25,o),
+(174,45,cs),
+(174,97,o),
+(140,139,o),
+(86,139,cs),
+(40,139,o),
+(12,109,o),
+(12,70,cs),
+(12,37,o),
+(33,15,o),
+(66,15,cs),
+(104,15,o),
+(107,46,o),
+(122,46,cs),
+(129,46,o),
+(138,38,o),
+(138,20,cs),
+(138,-19,o),
+(98,-72,o),
+(4,-119,c),
+(17,-142,l)
+);
+}
+);
+width = 459;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,-101,o),
+(423,-24,o),
+(423,49,cs),
+(423,97,o),
+(393,170,o),
+(320,170,cs),
+(273,170,o),
+(230,139,o),
+(230,90,cs),
+(230,56,o),
+(250,15,o),
+(297,15,cs),
+(343,15,o),
+(345,55,o),
+(359,55,cs),
+(365,55,o),
+(374,47,o),
+(374,27,cs),
+(374,-24,o),
+(315,-79,o),
+(217,-129,c),
+(230,-152,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(102,-101,o),
+(172,-24,o),
+(172,49,cs),
+(172,97,o),
+(142,170,o),
+(69,170,cs),
+(22,170,o),
+(-21,139,o),
+(-21,90,cs),
+(-21,56,o),
+(-1,15,o),
+(46,15,cs),
+(92,15,o),
+(94,55,o),
+(108,55,cs),
+(114,55,o),
+(123,47,o),
+(123,27,cs),
+(123,-24,o),
+(64,-79,o),
+(-34,-129,c),
+(-21,-152,l)
+);
+}
+);
+width = 479;
+}
+);
+unicode = 8222;
+},
+{
+glyphname = quotedblleft;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(463,447,o),
+(491,477,o),
+(491,516,cs),
+(491,549,o),
+(470,571,o),
+(437,571,cs),
+(399,571,o),
+(396,540,o),
+(381,540,cs),
+(374,540,o),
+(365,548,o),
+(365,566,cs),
+(365,605,o),
+(405,658,o),
+(499,705,c),
+(486,728,l),
+(392,680,o),
+(329,611,o),
+(329,541,cs),
+(329,489,o),
+(363,447,o),
+(417,447,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(257,447,o),
+(285,477,o),
+(285,516,cs),
+(285,549,o),
+(264,571,o),
+(231,571,cs),
+(193,571,o),
+(190,540,o),
+(175,540,cs),
+(168,540,o),
+(159,548,o),
+(159,566,cs),
+(159,605,o),
+(199,658,o),
+(293,705,c),
+(280,728,l),
+(186,680,o),
+(123,611,o),
+(123,541,cs),
+(123,489,o),
+(157,447,o),
+(211,447,cs)
+);
+}
+);
+width = 460;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(502,441,o),
+(545,472,o),
+(545,521,cs),
+(545,555,o),
+(525,596,o),
+(478,596,cs),
+(432,596,o),
+(430,556,o),
+(416,556,cs),
+(410,556,o),
+(401,564,o),
+(401,584,cs),
+(401,635,o),
+(460,690,o),
+(558,740,c),
+(545,763,l),
+(422,712,o),
+(352,635,o),
+(352,562,cs),
+(352,514,o),
+(382,441,o),
+(455,441,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(251,441,o),
+(294,472,o),
+(294,521,cs),
+(294,555,o),
+(274,596,o),
+(227,596,cs),
+(181,596,o),
+(179,556,o),
+(165,556,cs),
+(159,556,o),
+(150,564,o),
+(150,584,cs),
+(150,635,o),
+(209,690,o),
+(307,740,c),
+(294,763,l),
+(171,712,o),
+(101,635,o),
+(101,562,cs),
+(101,514,o),
+(131,441,o),
+(204,441,cs)
+);
+}
+);
+width = 480;
+}
+);
+unicode = 8220;
+},
+{
+glyphname = quotedblright;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(452,495,o),
+(515,564,o),
+(515,634,cs),
+(515,686,o),
+(481,728,o),
+(427,728,cs),
+(381,728,o),
+(353,698,o),
+(353,659,cs),
+(353,626,o),
+(374,604,o),
+(407,604,cs),
+(445,604,o),
+(448,635,o),
+(463,635,cs),
+(470,635,o),
+(479,627,o),
+(479,609,cs),
+(479,570,o),
+(439,517,o),
+(345,470,c),
+(358,447,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(246,495,o),
+(309,564,o),
+(309,634,cs),
+(309,686,o),
+(275,728,o),
+(221,728,cs),
+(175,728,o),
+(147,698,o),
+(147,659,cs),
+(147,626,o),
+(168,604,o),
+(201,604,cs),
+(239,604,o),
+(242,635,o),
+(257,635,cs),
+(264,635,o),
+(273,627,o),
+(273,609,cs),
+(273,570,o),
+(233,517,o),
+(139,470,c),
+(152,447,l)
+);
+}
+);
+width = 459;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(498,492,o),
+(568,569,o),
+(568,642,cs),
+(568,690,o),
+(538,763,o),
+(465,763,cs),
+(418,763,o),
+(375,732,o),
+(375,683,cs),
+(375,649,o),
+(395,608,o),
+(442,608,cs),
+(488,608,o),
+(490,648,o),
+(504,648,cs),
+(510,648,o),
+(519,640,o),
+(519,620,cs),
+(519,569,o),
+(460,514,o),
+(362,464,c),
+(375,441,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(247,492,o),
+(317,569,o),
+(317,642,cs),
+(317,690,o),
+(287,763,o),
+(214,763,cs),
+(167,763,o),
+(124,732,o),
+(124,683,cs),
+(124,649,o),
+(144,608,o),
+(191,608,cs),
+(237,608,o),
+(239,648,o),
+(253,648,cs),
+(259,648,o),
+(268,640,o),
+(268,620,cs),
+(268,569,o),
+(209,514,o),
+(111,464,c),
+(124,441,l)
+);
+}
+);
+width = 479;
+}
+);
+unicode = 8221;
+},
+{
+glyphname = quoteleft;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(253,447,o),
+(281,477,o),
+(281,516,cs),
+(281,549,o),
+(260,571,o),
+(227,571,cs),
+(189,571,o),
+(186,540,o),
+(171,540,cs),
+(164,540,o),
+(155,548,o),
+(155,566,cs),
+(155,605,o),
+(195,658,o),
+(289,705,c),
+(276,728,l),
+(182,680,o),
+(119,611,o),
+(119,541,cs),
+(119,489,o),
+(153,447,o),
+(207,447,cs)
+);
+}
+);
+width = 243;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,440,o),
+(301,471,o),
+(301,520,cs),
+(301,554,o),
+(281,595,o),
+(234,595,cs),
+(188,595,o),
+(186,555,o),
+(172,555,cs),
+(166,555,o),
+(157,563,o),
+(157,583,cs),
+(157,634,o),
+(216,689,o),
+(314,739,c),
+(301,762,l),
+(178,711,o),
+(108,634,o),
+(108,561,cs),
+(108,513,o),
+(138,440,o),
+(211,440,cs)
+);
+}
+);
+width = 263;
+}
+);
+unicode = 8216;
+},
+{
+glyphname = quoteright;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,495,o),
+(306,564,o),
+(306,634,cs),
+(306,686,o),
+(272,728,o),
+(218,728,cs),
+(172,728,o),
+(144,698,o),
+(144,659,cs),
+(144,626,o),
+(165,604,o),
+(198,604,cs),
+(236,604,o),
+(239,635,o),
+(254,635,cs),
+(261,635,o),
+(270,627,o),
+(270,609,cs),
+(270,570,o),
+(230,517,o),
+(136,470,c),
+(149,447,l)
+);
+}
+);
+width = 245;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(262,492,o),
+(332,569,o),
+(332,642,cs),
+(332,690,o),
+(302,763,o),
+(229,763,cs),
+(182,763,o),
+(139,732,o),
+(139,683,cs),
+(139,649,o),
+(159,608,o),
+(206,608,cs),
+(252,608,o),
+(254,648,o),
+(268,648,cs),
+(274,648,o),
+(283,640,o),
+(283,620,cs),
+(283,569,o),
+(224,514,o),
+(126,464,c),
+(139,441,l)
+);
+}
+);
+width = 265;
+}
+);
+unicode = 8217;
+},
+{
+glyphname = quotesinglbase;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,-94,o),
+(168,-25,o),
+(168,45,cs),
+(168,97,o),
+(134,139,o),
+(80,139,cs),
+(34,139,o),
+(6,109,o),
+(6,70,cs),
+(6,37,o),
+(27,15,o),
+(60,15,cs),
+(98,15,o),
+(101,46,o),
+(116,46,cs),
+(123,46,o),
+(132,38,o),
+(132,20,cs),
+(132,-19,o),
+(92,-72,o),
+(-2,-119,c),
+(11,-142,l)
+);
+}
+);
+width = 245;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(124,-101,o),
+(194,-24,o),
+(194,49,cs),
+(194,97,o),
+(164,170,o),
+(91,170,cs),
+(44,170,o),
+(1,139,o),
+(1,90,cs),
+(1,56,o),
+(21,15,o),
+(68,15,cs),
+(114,15,o),
+(116,55,o),
+(130,55,cs),
+(136,55,o),
+(145,47,o),
+(145,27,cs),
+(145,-24,o),
+(86,-79,o),
+(-12,-129,c),
+(1,-152,l)
+);
+}
+);
+width = 265;
+}
+);
+unicode = 8218;
+},
+{
+glyphname = space;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 206;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 206;
+}
+);
+unicode = 32;
+},
+{
+glyphname = nbspace;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 206;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 206;
+}
+);
+unicode = 160;
+},
+{
+glyphname = CR;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 206;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 206;
+}
+);
+unicode = 13;
+},
+{
+glyphname = .notdef;
+lastChange = "2016-10-31 10:58:41 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(201,899,l),
+(221,924,l),
+(608,-301,l),
+(588,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(682,-326,l),
+(682,-301,l),
+(127,-301,l),
+(127,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,-326,l),
+(221,924,l),
+(127,924,l),
+(127,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(608,899,l),
+(588,924,l),
+(201,-301,l),
+(221,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(682,-326,l),
+(682,924,l),
+(588,924,l),
+(588,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(682,899,l),
+(682,924,l),
+(127,924,l),
+(127,899,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(682,-326,l),
+(682,924,l),
+(127,924,l),
+(127,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,899,l),
+(588,899,l),
+(588,-301,l),
+(221,-301,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(608,-301,l),
+(221,924,l),
+(201,899,l),
+(588,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(608,899,l),
+(588,924,l),
+(201,-301,l),
+(221,-326,l)
+);
+}
+);
+width = 809;
+},
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,899,l),
+(231,924,l),
+(618,-301,l),
+(598,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(692,-326,l),
+(692,-301,l),
+(137,-301,l),
+(137,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,-326,l),
+(231,924,l),
+(137,924,l),
+(137,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(618,899,l),
+(598,924,l),
+(211,-301,l),
+(231,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(692,-326,l),
+(692,924,l),
+(598,924,l),
+(598,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(692,899,l),
+(692,924,l),
+(137,924,l),
+(137,899,l)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(692,-326,l),
+(692,924,l),
+(137,924,l),
+(137,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,899,l),
+(598,899,l),
+(598,-301,l),
+(231,-301,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(618,-301,l),
+(231,924,l),
+(211,899,l),
+(598,-326,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(618,899,l),
+(598,924,l),
+(211,-301,l),
+(231,-326,l)
+);
+}
+);
+width = 829;
+}
+);
+},
+{
+glyphname = cent;
+lastChange = "2016-08-22 13:06:34 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(346,137,o),
+(409,187,o),
+(453,269,c),
+(433,283,l),
+(382,194,o),
+(323,167,o),
+(264,167,cs),
+(194,167,o),
+(178,206,o),
+(178,270,cs),
+(178,383,o),
+(228,574,o),
+(356,574,cs),
+(377,574,o),
+(406,569,o),
+(406,554,cs),
+(406,540,o),
+(376,537,o),
+(376,501,cs),
+(376,470,o),
+(400,453,o),
+(431,453,cs),
+(465,453,o),
+(489,473,o),
+(489,511,cs),
+(489,567,o),
+(435,604,o),
+(355,604,cs),
+(202,604,o),
+(73,471,o),
+(73,331,cs),
+(73,233,o),
+(136,137,o),
+(258,137,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(237,5,l),
+(402,733,l),
+(372,733,l),
+(207,5,l)
+);
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,135,o),
+(450,188,o),
+(503,275,c),
+(478,294,l),
+(416,203,o),
+(344,175,o),
+(279,175,cs),
+(234,175,o),
+(206,189,o),
+(206,229,cs),
+(206,332,o),
+(261,570,o),
+(352,570,cs),
+(371,570,o),
+(386,564,o),
+(386,545,cs),
+(386,526,o),
+(370,504,o),
+(370,481,cs),
+(370,452,o),
+(394,425,o),
+(439,425,cs),
+(492,425,o),
+(514,461,o),
+(514,495,cs),
+(514,552,o),
+(449,600,o),
+(358,600,cs),
+(203,600,o),
+(63,460,o),
+(63,322,cs),
+(63,225,o),
+(132,135,o),
+(264,135,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(221,6,l),
+(411,734,l),
+(382,734,l),
+(192,6,l)
+);
+}
+);
+width = 486;
+}
+);
+unicode = 162;
+},
+{
+glyphname = colonsign;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,23,l),
+(502,733,l),
+(470,733,l),
+(161,23,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,23,l),
+(428,733,l),
+(396,733,l),
+(87,23,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,137,o),
+(406,187,o),
+(450,269,c),
+(430,283,l),
+(379,194,o),
+(320,167,o),
+(261,167,cs),
+(191,167,o),
+(175,206,o),
+(175,270,cs),
+(175,383,o),
+(224,574,o),
+(350,574,cs),
+(419,574,o),
+(449,516,o),
+(446,446,c),
+(471,446,l),
+(504,604,l),
+(492,604,l),
+(458,572,l),
+(426,595,o),
+(400,604,o),
+(358,604,cs),
+(196,604,o),
+(70,471,o),
+(70,331,cs),
+(70,233,o),
+(133,137,o),
+(255,137,cs)
+);
+}
+);
+width = 478;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,23,l),
+(513,733,l),
+(481,733,l),
+(172,23,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,23,l),
+(439,733,l),
+(407,733,l),
+(98,23,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,139,o),
+(447,192,o),
+(500,279,c),
+(475,298,l),
+(413,207,o),
+(341,179,o),
+(276,179,cs),
+(231,179,o),
+(203,193,o),
+(203,233,cs),
+(203,336,o),
+(263,572,o),
+(362,572,cs),
+(437,572,o),
+(471,514,o),
+(456,440,c),
+(492,440,l),
+(527,603,l),
+(510,603,l),
+(480,568,l),
+(453,591,o),
+(411,604,o),
+(362,604,cs),
+(207,604,o),
+(60,464,o),
+(60,326,cs),
+(60,229,o),
+(129,139,o),
+(261,139,cs)
+);
+}
+);
+width = 498;
+}
+);
+unicode = 8353;
+},
+{
+glyphname = currency;
+lastChange = "2016-08-22 14:01:47 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(494,135,o),
+(599,240,o),
+(599,368,cs),
+(599,496,o),
+(494,602,o),
+(364,602,cs),
+(234,602,o),
+(130,496,o),
+(130,368,cs),
+(130,240,o),
+(234,135,o),
+(364,135,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,235,l),
+(224,262,l),
+(130,152,l),
+(152,135,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,500,l),
+(152,601,l),
+(130,584,l),
+(224,474,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(270,200,o),
+(195,275,o),
+(195,368,c),
+(195,461,o),
+(270,537,o),
+(364,537,cs),
+(458,537,o),
+(534,461,o),
+(534,368,cs),
+(534,275,o),
+(458,200,o),
+(364,200,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(599,152,l),
+(505,262,l),
+(488,235,l),
+(577,135,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(599,584,l),
+(577,601,l),
+(487,500,l),
+(505,474,l)
+);
+}
+);
+width = 669;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(514,135,o),
+(619,240,o),
+(619,368,cs),
+(619,496,o),
+(514,602,o),
+(384,602,cs),
+(254,602,o),
+(150,496,o),
+(150,368,cs),
+(150,240,o),
+(254,135,o),
+(384,135,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(281,225,l),
+(234,282,l),
+(140,172,l),
+(192,125,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(282,510,l),
+(192,611,l),
+(140,564,l),
+(234,454,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(298,215,o),
+(230,283,o),
+(230,368,c),
+(230,453,o),
+(298,522,o),
+(384,522,cs),
+(470,522,o),
+(539,453,o),
+(539,368,cs),
+(539,283,o),
+(470,215,o),
+(384,215,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(629,172,l),
+(535,282,l),
+(488,225,l),
+(577,125,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(629,564,l),
+(577,611,l),
+(487,510,l),
+(535,454,l)
+);
+}
+);
+width = 689;
+}
+);
+unicode = 164;
+},
+{
+glyphname = dollar;
+lastChange = "2016-08-22 14:01:54 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(407,-13,o),
+(516,87,o),
+(516,219,cs),
+(516,445,o),
+(194,358,o),
+(194,517,cs),
+(194,607,o),
+(296,658,o),
+(384,658,cs),
+(459,658,o),
+(523,620,o),
+(523,592,cs),
+(523,564,o),
+(462,569,o),
+(462,522,cs),
+(462,491,o),
+(488,477,o),
+(512,477,cs),
+(549,477,o),
+(570,509,o),
+(570,551,cs),
+(570,639,o),
+(479,683,o),
+(383,683,cs),
+(239,683,o),
+(135,584,o),
+(135,469,cs),
+(135,267,o),
+(459,336,o),
+(459,166,cs),
+(459,92,o),
+(397,12,o),
+(257,12,cs),
+(148,12,o),
+(86,61,o),
+(86,94,cs),
+(86,132,o),
+(167,104,o),
+(167,166,cs),
+(167,195,o),
+(150,218,o),
+(113,218,cs),
+(76,218,o),
+(42,195,o),
+(42,139,cs),
+(42,51,o),
+(124,-13,o),
+(250,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(171,-115,l),
+(366,754,l),
+(336,754,l),
+(141,-115,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(287,-115,l),
+(482,754,l),
+(452,754,l),
+(257,-115,l)
+);
+}
+);
+width = 594;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(433,-13,o),
+(535,91,o),
+(535,224,cs),
+(535,470,o),
+(190,374,o),
+(190,524,cs),
+(190,604,o),
+(290,653,o),
+(376,653,cs),
+(448,653,o),
+(507,618,o),
+(507,594,cs),
+(507,570,o),
+(449,573,o),
+(449,520,cs),
+(449,484,o),
+(477,460,o),
+(515,460,cs),
+(557,460,o),
+(579,490,o),
+(579,537,cs),
+(579,634,o),
+(483,683,o),
+(377,683,cs),
+(223,683,o),
+(111,581,o),
+(111,454,cs),
+(111,232,o),
+(456,320,o),
+(456,155,cs),
+(456,83,o),
+(389,22,o),
+(245,22,cs),
+(151,22,o),
+(103,48,o),
+(103,71,cs),
+(103,99,o),
+(175,83,o),
+(175,149,cs),
+(175,190,o),
+(148,218,o),
+(103,218,cs),
+(50,218,o),
+(24,180,o),
+(24,133,cs),
+(24,58,o),
+(91,-13,o),
+(246,-13,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(175,-115,l),
+(370,754,l),
+(340,754,l),
+(145,-115,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(289,-115,l),
+(484,754,l),
+(454,754,l),
+(259,-115,l)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 36;
+},
+{
+glyphname = euro;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(377,-13,o),
+(418,10,o),
+(444,32,c),
+(460,0,l),
+(485,0,l),
+(533,179,l),
+(499,179,l),
+(468,83,o),
+(400,14,o),
+(323,14,cs),
+(262,14,o),
+(242,58,o),
+(242,134,cs),
+(242,180,o),
+(249,232,o),
+(259,279,c),
+(513,279,l),
+(523,325,l),
+(269,325,l),
+(291,407,l),
+(540,407,l),
+(550,451,l),
+(302,451,l),
+(347,586,o),
+(412,680,o),
+(485,680,cs),
+(549,680,o),
+(586,608,o),
+(586,512,c),
+(617,512,l),
+(649,706,l),
+(627,706,l),
+(586,651,l),
+(570,672,o),
+(540,706,o),
+(474,706,cs),
+(345,706,o),
+(235,574,o),
+(181,451,c),
+(91,451,l),
+(81,407,l),
+(163,407,l),
+(143,325,l),
+(64,325,l),
+(54,279,l),
+(136,279,l),
+(136,117,o),
+(185,-13,o),
+(320,-13,cs)
+);
+}
+);
+width = 614;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,-13,o),
+(448,8,o),
+(477,32,c),
+(493,0,l),
+(518,0,l),
+(566,179,l),
+(522,179,l),
+(493,88,o),
+(430,19,o),
+(355,19,cs),
+(295,19,o),
+(275,63,o),
+(275,136,cs),
+(275,179,o),
+(282,232,o),
+(292,279,c),
+(546,279,l),
+(556,325,l),
+(302,325,l),
+(324,407,l),
+(573,407,l),
+(583,451,l),
+(335,451,l),
+(376,576,o),
+(438,675,o),
+(507,675,cs),
+(566,675,o),
+(599,604,o),
+(599,512,c),
+(640,512,l),
+(672,706,l),
+(645,706,l),
+(609,651,l),
+(593,672,o),
+(564,706,o),
+(496,706,cs),
+(361,706,o),
+(242,574,o),
+(184,451,c),
+(94,451,l),
+(84,407,l),
+(166,407,l),
+(146,325,l),
+(67,325,l),
+(57,279,l),
+(139,279,l),
+(139,117,o),
+(199,-13,o),
+(350,-13,cs)
+);
+}
+);
+width = 634;
+}
+);
+unicode = 8364;
+},
+{
+glyphname = florin;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(52,-314,o),
+(164,-249,o),
+(214,45,cs),
+(291,501,ls),
+(320,676,o),
+(355,724,o),
+(405,724,cs),
+(427,724,o),
+(440,715,o),
+(440,705,cs),
+(440,693,o),
+(422,682,o),
+(422,658,cs),
+(422,633,o),
+(440,613,o),
+(473,613,cs),
+(508,613,o),
+(525,636,o),
+(525,666,cs),
+(525,721,o),
+(467,754,o),
+(408,754,cs),
+(300,754,o),
+(180,644,o),
+(150,440,cs),
+(64,-140,ls),
+(48,-247,o),
+(21,-284,o),
+(-20,-284,cs),
+(-39,-284,o),
+(-44,-276,o),
+(-44,-265,cs),
+(-44,-259,o),
+(-43,-246,o),
+(-43,-240,cs),
+(-43,-210,o),
+(-66,-193,o),
+(-92,-193,cs),
+(-119,-193,o),
+(-139,-211,o),
+(-139,-240,cs),
+(-139,-292,o),
+(-73,-314,o),
+(-27,-314,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(382,396,l),
+(382,440,l),
+(61,440,l),
+(61,396,l)
+);
+}
+);
+width = 435;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,-314,o),
+(206,-250,o),
+(256,45,cs),
+(333,501,ls),
+(362,673,o),
+(396,724,o),
+(445,724,cs),
+(465,724,o),
+(477,715,o),
+(477,705,cs),
+(477,691,o),
+(455,676,o),
+(455,643,cs),
+(455,614,o),
+(473,588,o),
+(515,588,cs),
+(559,588,o),
+(582,615,o),
+(582,654,cs),
+(582,721,o),
+(515,754,o),
+(451,754,cs),
+(337,754,o),
+(203,649,o),
+(164,387,cs),
+(86,-140,ls),
+(70,-247,o),
+(38,-284,o),
+(-8,-284,cs),
+(-27,-284,o),
+(-32,-276,o),
+(-32,-265,cs),
+(-32,-257,o),
+(-26,-238,o),
+(-26,-230,cs),
+(-26,-194,o),
+(-53,-173,o),
+(-80,-173,cs),
+(-119,-173,o),
+(-147,-195,o),
+(-147,-230,cs),
+(-147,-289,o),
+(-70,-314,o),
+(-14,-314,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,391,l),
+(444,440,l),
+(83,440,l),
+(83,391,l)
+);
+}
+);
+width = 455;
+}
+);
+unicode = 402;
+},
+{
+glyphname = franc;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(199,0,l),
+(358,706,l),
+(241,706,l),
+(86,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(309,0,l),
+(309,25,l),
+(-10,25,l),
+(-10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,155,l),
+(372,199,l),
+(10,199,l),
+(-2,155,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(438,224,l),
+(494,528,l),
+(469,528,l),
+(438,428,o),
+(403,401,o),
+(326,401,cs),
+(223,401,l),
+(223,376,l),
+(310,376,ls),
+(393,376,o),
+(408,349,o),
+(408,224,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(660,481,l),
+(691,706,l),
+(132,706,l),
+(132,681,l),
+(462,681,ls),
+(601,681,o),
+(630,644,o),
+(630,481,c)
+);
+}
+);
+width = 635;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(236,0,l),
+(404,754,l),
+(253,754,l),
+(89,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(371,0,l),
+(371,31,l),
+(2,31,l),
+(2,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(387,150,l),
+(399,199,l),
+(17,199,l),
+(5,150,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(488,227,l),
+(553,535,l),
+(518,535,l),
+(488,441,o),
+(439,404,o),
+(372,404,cs),
+(269,404,l),
+(269,374,l),
+(356,374,ls),
+(416,374,o),
+(454,348,o),
+(454,227,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(699,548,l),
+(735,754,l),
+(138,754,l),
+(138,724,l),
+(498,724,ls),
+(622,724,o),
+(659,687,o),
+(659,548,c)
+);
+}
+);
+width = 655;
+}
+);
+unicode = 8355;
+},
+{
+glyphname = lira;
+lastChange = "2016-08-22 14:02:04 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(125,-20,o),
+(171,13,o),
+(198,54,c),
+(254,-7,o),
+(291,-20,o),
+(335,-20,cs),
+(468,-20,o),
+(513,101,o),
+(535,204,c),
+(508,204,l),
+(485,113,o),
+(429,79,o),
+(355,79,cs),
+(313,79,o),
+(269,90,o),
+(234,111,c),
+(276,177,o),
+(295,229,o),
+(308,286,cs),
+(319,334,o),
+(320,348,o),
+(320,471,cs),
+(320,584,o),
+(350,676,o),
+(468,676,cs),
+(501,676,o),
+(520,669,o),
+(520,656,cs),
+(520,640,o),
+(490,633,o),
+(490,600,cs),
+(490,581,o),
+(500,550,o),
+(544,550,cs),
+(587,550,o),
+(603,579,o),
+(603,611,cs),
+(603,670,o),
+(551,706,o),
+(467,706,cs),
+(279,706,o),
+(185,528,o),
+(185,369,cs),
+(185,307,o),
+(199,251,o),
+(199,202,cs),
+(199,183,o),
+(197,170,o),
+(194,154,cs),
+(193,146,o),
+(192,140,o),
+(187,126,c),
+(161,135,o),
+(135,144,o),
+(104,144,cs),
+(36,144,o),
+(-12,101,o),
+(-12,50,cs),
+(-12,6,o),
+(24,-20,o),
+(72,-20,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(46,10,o),
+(26,26,o),
+(26,54,cs),
+(26,88,o),
+(54,110,o),
+(90,110,cs),
+(119,110,o),
+(153,96,o),
+(168,78,c),
+(152,49,o),
+(120,10,o),
+(75,10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(420,276,l),
+(432,320,l),
+(58,320,l),
+(46,276,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,396,l),
+(462,440,l),
+(88,440,l),
+(76,396,l)
+);
+}
+);
+width = 559;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(133,-20,o),
+(188,13,o),
+(219,54,c),
+(255,1,o),
+(298,-20,o),
+(352,-20,cs),
+(483,-20,o),
+(529,106,o),
+(551,204,c),
+(512,204,l),
+(489,129,o),
+(435,99,o),
+(352,99,cs),
+(322,99,o),
+(284,103,o),
+(255,111,c),
+(297,177,o),
+(313,221,o),
+(329,286,cs),
+(340,329,o),
+(341,337,o),
+(341,471,cs),
+(341,579,o),
+(367,666,o),
+(471,666,cs),
+(502,666,o),
+(521,658,o),
+(521,646,cs),
+(521,630,o),
+(486,621,o),
+(486,583,cs),
+(486,558,o),
+(502,530,o),
+(543,530,cs),
+(591,530,o),
+(614,568,o),
+(614,608,cs),
+(614,671,o),
+(559,706,o),
+(468,706,cs),
+(268,706,o),
+(168,538,o),
+(168,389,cs),
+(168,324,o),
+(187,265,o),
+(187,212,cs),
+(187,195,o),
+(185,179,o),
+(182,164,cs),
+(178,141,o),
+(178,146,o),
+(175,136,c),
+(155,140,o),
+(127,144,o),
+(106,144,cs),
+(36,144,o),
+(-11,101,o),
+(-11,50,cs),
+(-11,6,o),
+(24,-20,o),
+(75,-20,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(52,15,o),
+(32,31,o),
+(32,55,cs),
+(32,83,o),
+(60,105,o),
+(91,105,cs),
+(114,105,o),
+(142,94,o),
+(154,83,c),
+(141,52,o),
+(114,15,o),
+(76,15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,271,l),
+(456,320,l),
+(62,320,l),
+(51,271,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(472,395,l),
+(483,444,l),
+(89,444,l),
+(78,395,l)
+);
+}
+);
+width = 579;
+}
+);
+unicode = 8356;
+},
+{
+glyphname = liraTurkish;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(179,0,l),
+(347,754,l),
+(230,754,l),
+(66,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,0,ls),
+(435,0,o),
+(582,96,o),
+(582,257,cs),
+(582,322,o),
+(558,349,o),
+(518,349,cs),
+(483,349,o),
+(456,328,o),
+(456,295,cs),
+(456,274,o),
+(467,259,o),
+(491,259,cs),
+(523,259,o),
+(523,286,o),
+(539,286,cs),
+(550,286,o),
+(554,275,o),
+(554,251,cs),
+(554,114,o),
+(425,25,o),
+(248,25,c),
+(0,25,l),
+(-6,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,427,l),
+(450,474,l),
+(15,318,l),
+(15,271,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(450,555,l),
+(450,602,l),
+(15,446,l),
+(15,399,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(430,729,l),
+(430,754,l),
+(141,754,l),
+(141,729,l)
+);
+}
+);
+width = 598;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,0,l),
+(397,754,l),
+(246,754,l),
+(82,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(249,0,ls),
+(445,0,o),
+(592,90,o),
+(592,233,cs),
+(592,296,o),
+(568,339,o),
+(512,339,cs),
+(467,339,o),
+(436,311,o),
+(436,272,cs),
+(436,245,o),
+(450,224,o),
+(481,224,cs),
+(519,224,o),
+(520,256,o),
+(539,256,cs),
+(550,256,o),
+(554,245,o),
+(554,222,cs),
+(554,107,o),
+(428,35,o),
+(258,35,c),
+(10,35,l),
+(4,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(478,412,l),
+(478,464,l),
+(43,308,l),
+(43,256,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(478,545,l),
+(478,597,l),
+(43,441,l),
+(43,389,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(505,724,l),
+(505,754,l),
+(126,754,l),
+(126,724,l)
+);
+}
+);
+width = 618;
+}
+);
+unicode = 8378;
+},
+{
+glyphname = naira;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(565,-13,l),
+(598,228,l),
+(594,228,l),
+(378,706,l),
+(254,706,l),
+(254,657,l),
+(258,657,l),
+(545,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(222,25,l),
+(-20,25,l),
+(-20,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(107,0,l),
+(265,706,l),
+(235,706,l),
+(77,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(753,359,l),
+(765,403,l),
+(63,403,l),
+(51,359,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(378,681,l),
+(378,706,l),
+(126,706,l),
+(126,681,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(786,485,l),
+(798,529,l),
+(96,529,l),
+(84,485,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(575,-13,l),
+(736,706,l),
+(706,706,l),
+(545,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(833,681,l),
+(833,706,l),
+(591,706,l),
+(591,681,l)
+);
+}
+);
+width = 743;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(589,-13,l),
+(633,285,l),
+(621,285,l),
+(380,683,l),
+(266,683,l),
+(247,566,l),
+(251,566,l),
+(569,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,0,l),
+(236,30,l),
+(-1,30,l),
+(-1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(126,0,l),
+(272,683,l),
+(232,683,l),
+(86,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(772,336,l),
+(784,385,l),
+(32,385,l),
+(20,336,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(380,653,l),
+(380,683,l),
+(123,683,l),
+(123,653,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(804,467,l),
+(816,515,l),
+(64,515,l),
+(52,467,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(600,-13,l),
+(749,683,l),
+(709,683,l),
+(569,-13,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(826,653,l),
+(826,683,l),
+(608,683,l),
+(608,653,l)
+);
+}
+);
+width = 763;
+}
+);
+unicode = 8358;
+},
+{
+glyphname = rupeeIndian;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,371,ls),
+(421,371,o),
+(541,437,o),
+(541,537,cs),
+(541,637,o),
+(451,706,o),
+(282,706,cs),
+(67,706,l),
+(67,681,l),
+(270,681,ls),
+(383,681,o),
+(405,652,o),
+(405,572,cs),
+(405,456,o),
+(343,396,o),
+(233,396,cs),
+(70,396,l),
+(70,371,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(529,-10,o),
+(549,4,o),
+(568,25,c),
+(552,39,l),
+(540,27,o),
+(527,23,o),
+(506,23,cs),
+(446,23,o),
+(444,56,o),
+(441,138,cs),
+(435,271,o),
+(417,319,o),
+(279,369,c),
+(279,373,l),
+(156,370,l),
+(239,370,o),
+(292,331,o),
+(299,233,cs),
+(304,154,o),
+(287,-10,o),
+(474,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(619,534,l),
+(619,578,l),
+(67,578,l),
+(67,534,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(619,662,l),
+(619,706,l),
+(67,706,l),
+(67,662,l)
+);
+}
+);
+width = 570;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(183,371,ls),
+(418,371,o),
+(557,435,o),
+(557,542,cs),
+(557,635,o),
+(451,706,o),
+(253,706,cs),
+(134,706,l),
+(134,671,l),
+(241,671,ls),
+(348,671,o),
+(372,645,o),
+(372,574,cs),
+(372,461,o),
+(310,406,o),
+(204,406,cs),
+(87,406,l),
+(77,371,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(511,-10,o),
+(536,4,o),
+(559,25,c),
+(543,49,l),
+(531,37,o),
+(516,33,o),
+(501,33,cs),
+(473,33,o),
+(458,49,o),
+(454,142,cs),
+(449,275,o),
+(442,317,o),
+(292,373,c),
+(292,377,l),
+(127,370,l),
+(198,370,o),
+(244,331,o),
+(250,233,cs),
+(256,150,o),
+(235,-10,o),
+(448,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(645,545,l),
+(656,594,l),
+(99,594,l),
+(88,545,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(672,671,l),
+(683,720,l),
+(126,720,l),
+(115,671,l)
+);
+}
+);
+width = 590;
+}
+);
+unicode = 8377;
+},
+{
+glyphname = sterling;
+lastChange = "2016-08-22 14:02:17 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(108,-20,o),
+(154,13,o),
+(181,54,c),
+(237,-7,o),
+(274,-20,o),
+(318,-20,cs),
+(451,-20,o),
+(496,101,o),
+(518,204,c),
+(494,204,l),
+(471,113,o),
+(412,79,o),
+(338,79,cs),
+(296,79,o),
+(252,90,o),
+(217,111,c),
+(259,177,o),
+(278,229,o),
+(291,286,cs),
+(302,334,o),
+(303,357,o),
+(303,471,cs),
+(303,584,o),
+(333,676,o),
+(451,676,cs),
+(484,676,o),
+(503,669,o),
+(503,656,cs),
+(503,640,o),
+(473,633,o),
+(473,600,cs),
+(473,581,o),
+(483,550,o),
+(527,550,cs),
+(570,550,o),
+(586,579,o),
+(586,611,cs),
+(586,670,o),
+(534,706,o),
+(450,706,cs),
+(262,706,o),
+(168,528,o),
+(168,369,cs),
+(168,308,o),
+(182,249,o),
+(182,202,cs),
+(182,184,o),
+(180,169,o),
+(177,154,c),
+(176,145,o),
+(173,135,o),
+(170,126,c),
+(144,135,o),
+(118,144,o),
+(87,144,cs),
+(19,144,o),
+(-29,101,o),
+(-29,50,cs),
+(-29,6,o),
+(7,-20,o),
+(55,-20,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(29,10,o),
+(9,26,o),
+(9,54,cs),
+(9,88,o),
+(37,110,o),
+(73,110,cs),
+(102,110,o),
+(136,96,o),
+(151,78,c),
+(135,49,o),
+(103,10,o),
+(58,10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(434,355,l),
+(444,399,l),
+(70,399,l),
+(60,355,l)
+);
+}
+);
+width = 559;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(121,-20,o),
+(176,13,o),
+(207,54,c),
+(243,1,o),
+(286,-20,o),
+(340,-20,cs),
+(471,-20,o),
+(517,106,o),
+(539,204,c),
+(500,204,l),
+(477,129,o),
+(423,99,o),
+(340,99,cs),
+(310,99,o),
+(272,103,o),
+(243,111,c),
+(285,177,o),
+(301,221,o),
+(317,286,cs),
+(328,329,o),
+(329,337,o),
+(329,471,cs),
+(329,579,o),
+(355,666,o),
+(459,666,cs),
+(490,666,o),
+(509,658,o),
+(509,646,cs),
+(509,630,o),
+(474,621,o),
+(474,583,cs),
+(474,558,o),
+(490,530,o),
+(531,530,cs),
+(579,530,o),
+(602,568,o),
+(602,608,cs),
+(602,671,o),
+(547,706,o),
+(456,706,cs),
+(256,706,o),
+(156,538,o),
+(156,389,cs),
+(156,324,o),
+(175,265,o),
+(175,212,cs),
+(175,195,o),
+(173,179,o),
+(170,164,cs),
+(166,141,o),
+(166,146,o),
+(163,136,c),
+(143,140,o),
+(115,144,o),
+(94,144,cs),
+(24,144,o),
+(-23,101,o),
+(-23,50,cs),
+(-23,6,o),
+(12,-20,o),
+(63,-20,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(40,15,o),
+(20,31,o),
+(20,55,cs),
+(20,83,o),
+(48,105,o),
+(79,105,cs),
+(102,105,o),
+(130,94,o),
+(142,83,c),
+(129,52,o),
+(102,15,o),
+(64,15,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(460,355,l),
+(471,404,l),
+(77,404,l),
+(66,355,l)
+);
+}
+);
+width = 591;
+}
+);
+unicode = 163;
+},
+{
+glyphname = won;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(1023,686,l),
+(990,686,l),
+(582,196,l),
+(472,-12,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(544,458,l),
+(511,458,l),
+(308,198,l),
+(194,-12,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(194,-12,l),
+(311,202,l),
+(307,202,l),
+(351,696,l),
+(228,696,l),
+(173,-12,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(472,-12,l),
+(585,200,l),
+(581,200,l),
+(629,696,l),
+(506,696,l),
+(451,-12,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(954,376,l),
+(966,420,l),
+(48,420,l),
+(36,376,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(990,502,l),
+(1002,546,l),
+(84,546,l),
+(72,502,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(840,681,l),
+(840,706,l),
+(149,706,l),
+(149,681,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(777,690,l),
+(744,690,l),
+(541,478,l),
+(575,467,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(1096,681,l),
+(1096,706,l),
+(882,706,l),
+(882,681,l)
+);
+}
+);
+width = 966;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(1065,663,l),
+(1026,663,l),
+(616,210,l),
+(488,-12,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(514,388,l),
+(501,424,l),
+(317,206,l),
+(186,-12,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(186,-12,l),
+(320,210,l),
+(316,210,l),
+(351,673,l),
+(188,673,l),
+(153,-12,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(488,-12,l),
+(616,210,l),
+(612,210,l),
+(647,673,l),
+(484,673,l),
+(449,-12,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(1005,341,l),
+(1017,390,l),
+(59,390,l),
+(47,341,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(1017,467,l),
+(1029,516,l),
+(71,516,l),
+(59,467,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(862,653,l),
+(862,683,l),
+(104,683,l),
+(104,653,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(751,663,l),
+(714,663,l),
+(536,430,l),
+(547,393,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(1119,653,l),
+(1119,683,l),
+(899,683,l),
+(899,653,l)
+);
+}
+);
+width = 986;
+}
+);
+unicode = 8361;
+},
+{
+glyphname = yen;
+lastChange = "2016-08-22 13:13:54 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(402,318,l),
+(258,707,l),
+(133,707,l),
+(293,287,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(465,0,l),
+(465,25,l),
+(113,25,l),
+(113,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(335,0,l),
+(410,329,l),
+(293,329,l),
+(222,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(570,208,l),
+(582,252,l),
+(90,252,l),
+(78,208,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(602,334,l),
+(613,378,l),
+(121,378,l),
+(110,334,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(385,682,l),
+(385,707,l),
+(51,707,l),
+(51,682,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(381,270,l),
+(673,687,l),
+(638,687,l),
+(397,343,l),
+(393,343,l),
+(346,270,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(764,682,l),
+(764,707,l),
+(519,707,l),
+(519,682,l)
+);
+}
+);
+width = 607;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(418,308,l),
+(267,683,l),
+(112,683,l),
+(272,254,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(464,0,l),
+(464,31,l),
+(85,31,l),
+(85,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,0,l),
+(418,307,l),
+(267,307,l),
+(192,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(557,153,l),
+(569,202,l),
+(77,202,l),
+(65,153,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(583,279,l),
+(595,328,l),
+(103,328,l),
+(91,279,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(394,653,l),
+(394,683,l),
+(40,683,l),
+(40,653,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(403,260,l),
+(674,663,l),
+(639,663,l),
+(412,334,l),
+(408,334,l),
+(357,260,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(745,653,l),
+(745,683,l),
+(520,683,l),
+(520,653,l)
+);
+}
+);
+width = 627;
+}
+);
+unicode = 165;
+},
+{
+glyphname = colonsign.001;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,23,l),
+(502,733,l),
+(470,733,l),
+(161,23,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(119,23,l),
+(428,733,l),
+(396,733,l),
+(87,23,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(343,137,o),
+(406,187,o),
+(450,269,c),
+(430,283,l),
+(379,194,o),
+(320,167,o),
+(261,167,cs),
+(191,167,o),
+(175,206,o),
+(175,270,cs),
+(175,383,o),
+(224,574,o),
+(350,574,cs),
+(419,574,o),
+(449,516,o),
+(446,446,c),
+(471,446,l),
+(504,604,l),
+(492,604,l),
+(458,572,l),
+(426,595,o),
+(400,604,o),
+(358,604,cs),
+(196,604,o),
+(70,471,o),
+(70,331,cs),
+(70,233,o),
+(133,137,o),
+(255,137,cs)
+);
+}
+);
+width = 478;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(204,23,l),
+(513,733,l),
+(481,733,l),
+(172,23,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(130,23,l),
+(439,733,l),
+(407,733,l),
+(98,23,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(362,139,o),
+(447,192,o),
+(500,279,c),
+(475,298,l),
+(413,207,o),
+(341,179,o),
+(276,179,cs),
+(231,179,o),
+(203,193,o),
+(203,233,cs),
+(203,336,o),
+(263,572,o),
+(362,572,cs),
+(437,572,o),
+(471,514,o),
+(456,440,c),
+(492,440,l),
+(527,603,l),
+(510,603,l),
+(480,568,l),
+(453,591,o),
+(411,604,o),
+(362,604,cs),
+(207,604,o),
+(60,464,o),
+(60,326,cs),
+(60,229,o),
+(129,139,o),
+(261,139,cs)
+);
+}
+);
+width = 498;
+}
+);
+},
+{
+glyphname = bulletoperator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(135,184,o),
+(165,213,o),
+(165,251,cs),
+(165,289,o),
+(135,319,o),
+(97,319,cs),
+(59,319,o),
+(30,289,o),
+(30,251,cs),
+(30,251,ls),
+(30,213,o),
+(59,184,o),
+(97,184,cs)
+);
+}
+);
+width = 166;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(161,167,o),
+(200,206,o),
+(200,254,cs),
+(200,302,o),
+(161,341,o),
+(113,341,cs),
+(65,341,o),
+(26,302,o),
+(26,254,cs),
+(26,254,ls),
+(26,206,o),
+(65,167,o),
+(113,167,cs)
+);
+}
+);
+width = 214;
+}
+);
+unicode = 8729;
+},
+{
+glyphname = divisionslash;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-85,0,l),
+(505,753,l),
+(446,753,l),
+(-144,0,l)
+);
+}
+);
+width = 254;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-85,0,l),
+(505,753,l),
+(446,753,l),
+(-144,0,l)
+);
+}
+);
+width = 274;
+}
+);
+unicode = 8725;
+},
+{
+glyphname = plus;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(332,74,l),
+(332,612,l),
+(288,612,l),
+(288,74,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(559,321,l),
+(559,365,l),
+(61,365,l),
+(61,321,l)
+);
+}
+);
+width = 578;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(347,74,l),
+(347,612,l),
+(293,612,l),
+(293,74,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(569,316,l),
+(569,370,l),
+(71,370,l),
+(71,316,l)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 43;
+},
+{
+glyphname = minus;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(559,321,l),
+(559,365,l),
+(61,365,l),
+(61,321,l)
+);
+}
+);
+width = 578;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(569,316,l),
+(569,370,l),
+(71,370,l),
+(71,316,l)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 8722;
+},
+{
+glyphname = multiply;
+lastChange = "2016-10-31 10:59:24 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(536,534,l),
+(506,564,l),
+(98,156,l),
+(126,124,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(538,154,l),
+(128,564,l),
+(96,532,l),
+(506,122,l)
+);
+}
+);
+width = 578;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(556,532,l),
+(512,575,l),
+(102,165,l),
+(146,122,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(546,164,l),
+(136,574,l),
+(96,527,l),
+(506,117,l)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 215;
+},
+{
+glyphname = divide;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(568,321,l),
+(568,365,l),
+(70,365,l),
+(70,321,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,97,o),
+(383,124,o),
+(383,156,cs),
+(383,188,o),
+(356,215,o),
+(324,215,cs),
+(292,215,o),
+(265,188,o),
+(265,156,cs),
+(265,156,ls),
+(265,124,o),
+(292,97,o),
+(324,97,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(356,471,o),
+(383,498,o),
+(383,530,cs),
+(383,563,o),
+(356,589,o),
+(324,589,cs),
+(292,589,o),
+(265,563,o),
+(265,530,cs),
+(265,530,ls),
+(265,498,o),
+(292,471,o),
+(324,471,cs)
+);
+}
+);
+width = 578;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(578,316,l),
+(578,370,l),
+(80,370,l),
+(80,316,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(376,65,o),
+(411,100,o),
+(411,142,cs),
+(411,184,o),
+(376,219,o),
+(334,219,cs),
+(292,219,o),
+(257,184,o),
+(257,142,cs),
+(257,142,ls),
+(257,100,o),
+(292,65,o),
+(334,65,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(376,467,o),
+(411,502,o),
+(411,544,cs),
+(411,586,o),
+(376,621,o),
+(334,621,cs),
+(292,621,o),
+(257,586,o),
+(257,544,cs),
+(257,544,ls),
+(257,502,o),
+(292,467,o),
+(334,467,cs)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 247;
+},
+{
+glyphname = equal;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,402,l),
+(593,450,l),
+(95,450,l),
+(95,402,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(544,235,l),
+(544,283,l),
+(46,283,l),
+(46,235,l)
+);
+}
+);
+width = 598;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(611,420,l),
+(611,474,l),
+(113,474,l),
+(113,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(561,224,l),
+(561,278,l),
+(63,278,l),
+(63,224,l)
+);
+}
+);
+width = 618;
+}
+);
+unicode = 61;
+},
+{
+glyphname = notequal;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(182,72,l),
+(495,604,l),
+(443,604,l),
+(130,72,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(554,235,l),
+(554,283,l),
+(56,283,l),
+(56,235,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(603,402,l),
+(603,450,l),
+(105,450,l),
+(105,402,l)
+);
+}
+);
+width = 598;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,72,l),
+(438,604,l),
+(392,604,l),
+(243,72,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(585,234,l),
+(585,288,l),
+(87,288,l),
+(87,234,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(585,400,l),
+(585,454,l),
+(87,454,l),
+(87,400,l)
+);
+}
+);
+width = 618;
+}
+);
+unicode = 8800;
+},
+{
+glyphname = greater;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(595,316,l),
+(595,373,l),
+(127,139,l),
+(127,82,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(595,373,l),
+(127,607,l),
+(127,553,l),
+(595,319,l)
+);
+}
+);
+width = 588;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(593,311,l),
+(593,378,l),
+(125,144,l),
+(125,77,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(593,378,l),
+(125,612,l),
+(125,548,l),
+(593,314,l)
+);
+}
+);
+width = 608;
+}
+);
+unicode = 62;
+},
+{
+glyphname = less;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,139,l),
+(70,373,l),
+(70,316,l),
+(538,82,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(538,553,l),
+(538,607,l),
+(70,373,l),
+(70,319,l)
+);
+}
+);
+width = 588;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(538,144,l),
+(70,378,l),
+(70,311,l),
+(538,77,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(538,548,l),
+(538,612,l),
+(70,378,l),
+(70,314,l)
+);
+}
+);
+width = 608;
+}
+);
+unicode = 60;
+},
+{
+glyphname = greaterequal;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(576,408,l),
+(576,465,l),
+(108,231,l),
+(108,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,43,l),
+(516,87,l),
+(18,87,l),
+(18,43,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(576,465,l),
+(108,699,l),
+(108,645,l),
+(576,411,l)
+);
+}
+);
+width = 578;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(516,402,l),
+(516,469,l),
+(48,235,l),
+(48,168,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(536,38,l),
+(536,92,l),
+(38,92,l),
+(38,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(516,469,l),
+(48,703,l),
+(48,639,l),
+(516,405,l)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 8805;
+},
+{
+glyphname = lessequal;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(548,231,l),
+(80,465,l),
+(80,408,l),
+(548,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(518,43,l),
+(518,87,l),
+(20,87,l),
+(20,43,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(548,645,l),
+(548,699,l),
+(80,465,l),
+(80,411,l)
+);
+}
+);
+width = 578;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(527,235,l),
+(59,469,l),
+(59,402,l),
+(527,168,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(537,38,l),
+(537,92,l),
+(39,92,l),
+(39,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(527,639,l),
+(527,703,l),
+(59,469,l),
+(59,405,l)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 8804;
+},
+{
+glyphname = plusminus;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,164,l),
+(370,702,l),
+(326,702,l),
+(326,164,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(557,43,l),
+(557,87,l),
+(59,87,l),
+(59,43,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(597,411,l),
+(597,455,l),
+(99,455,l),
+(99,411,l)
+);
+}
+);
+width = 578;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,164,l),
+(345,702,l),
+(291,702,l),
+(291,164,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(567,38,l),
+(567,92,l),
+(69,92,l),
+(69,38,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(567,406,l),
+(567,460,l),
+(69,460,l),
+(69,406,l)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 177;
+},
+{
+glyphname = approxequal;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(153,400,o),
+(179,436,o),
+(224,436,cs),
+(294,436,o),
+(360,375,o),
+(435,375,cs),
+(507,375,o),
+(541,412,o),
+(576,458,c),
+(538,487,l),
+(511,455,o),
+(481,423,o),
+(431,423,cs),
+(364,423,o),
+(298,484,o),
+(222,484,cs),
+(155,484,o),
+(123,445,o),
+(92,397,c),
+(131,366,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(153,233,o),
+(179,269,o),
+(224,269,cs),
+(294,269,o),
+(360,208,o),
+(435,208,cs),
+(507,208,o),
+(541,245,o),
+(576,291,c),
+(538,320,l),
+(511,288,o),
+(481,256,o),
+(431,256,cs),
+(364,256,o),
+(298,317,o),
+(222,317,cs),
+(155,317,o),
+(123,278,o),
+(92,230,c),
+(131,199,l)
+);
+}
+);
+width = 585;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(159,399,o),
+(184,436,o),
+(229,436,cs),
+(299,436,o),
+(365,375,o),
+(440,375,cs),
+(514,375,o),
+(556,419,o),
+(586,458,c),
+(542,503,l),
+(509,464,o),
+(486,438,o),
+(436,438,cs),
+(369,438,o),
+(303,499,o),
+(227,499,cs),
+(158,499,o),
+(119,452,o),
+(91,410,c),
+(137,365,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,219,o),
+(184,256,o),
+(229,256,cs),
+(299,256,o),
+(365,195,o),
+(440,195,cs),
+(514,195,o),
+(556,239,o),
+(586,278,c),
+(542,323,l),
+(509,284,o),
+(486,258,o),
+(436,258,cs),
+(369,258,o),
+(303,319,o),
+(227,319,cs),
+(158,319,o),
+(119,272,o),
+(91,230,c),
+(137,185,l)
+);
+}
+);
+width = 605;
+}
+);
+unicode = 8776;
+},
+{
+glyphname = asciitilde;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(95,260,o),
+(117,291,o),
+(167,291,cs),
+(231,291,o),
+(291,230,o),
+(358,230,cs),
+(420,230,o),
+(453,274,o),
+(485,320,c),
+(444,345,l),
+(420,309,o),
+(399,282,o),
+(354,282,cs),
+(293,282,o),
+(233,343,o),
+(165,343,cs),
+(98,343,o),
+(61,296,o),
+(30,248,c),
+(70,221,l)
+);
+}
+);
+width = 475;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(102,250,o),
+(124,281,o),
+(174,281,cs),
+(238,281,o),
+(298,220,o),
+(365,220,cs),
+(432,220,o),
+(467,264,o),
+(502,310,c),
+(451,355,l),
+(427,319,o),
+(406,292,o),
+(361,292,cs),
+(300,292,o),
+(240,353,o),
+(172,353,cs),
+(100,353,o),
+(60,306,o),
+(27,258,c),
+(77,211,l)
+);
+}
+);
+width = 495;
+}
+);
+unicode = 126;
+},
+{
+glyphname = logicalnot;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(518,282,l),
+(518,326,l),
+(20,326,l),
+(20,282,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(518,72,l),
+(518,307,l),
+(441,307,l),
+(441,72,l)
+);
+}
+);
+width = 538;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(528,277,l),
+(528,326,l),
+(30,326,l),
+(30,277,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(528,55,l),
+(528,307,l),
+(435,307,l),
+(435,55,l)
+);
+}
+);
+width = 558;
+}
+);
+unicode = 172;
+},
+{
+glyphname = infinity;
+lastChange = "2016-08-22 14:02:58 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(309,117,o),
+(365,168,o),
+(415,231,c),
+(481,141,o),
+(539,117,o),
+(592,117,cs),
+(680,117,o),
+(761,183,o),
+(761,296,cs),
+(761,401,o),
+(691,468,o),
+(600,468,cs),
+(508,468,o),
+(454,401,o),
+(419,357,c),
+(367,425,o),
+(312,468,o),
+(237,468,cs),
+(140,468,o),
+(66,396,o),
+(66,291,cs),
+(66,186,o),
+(141,117,o),
+(231,117,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(173,172,o),
+(123,223,o),
+(123,293,cs),
+(123,355,o),
+(162,414,o),
+(235,414,cs),
+(309,414,o),
+(350,354,o),
+(393,287,c),
+(325,198,o),
+(285,172,o),
+(238,172,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(540,172,o),
+(500,210,o),
+(437,294,c),
+(493,374,o),
+(536,414,o),
+(592,414,cs),
+(660,414,o),
+(703,358,o),
+(703,294,cs),
+(703,238,o),
+(670,172,o),
+(596,172,cs)
+);
+}
+);
+width = 789;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(317,106,o),
+(371,153,o),
+(424,221,c),
+(492,125,o),
+(553,106,o),
+(609,106,cs),
+(697,106,o),
+(783,175,o),
+(783,297,cs),
+(783,406,o),
+(706,477,o),
+(614,477,cs),
+(540,477,o),
+(495,443,o),
+(429,366,c),
+(376,437,o),
+(321,477,o),
+(244,477,cs),
+(142,477,o),
+(64,401,o),
+(64,290,cs),
+(64,178,o),
+(146,106,o),
+(234,106,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,183,o),
+(143,232,o),
+(143,289,cs),
+(143,357,o),
+(183,401,o),
+(243,401,cs),
+(299,401,o),
+(327,374,o),
+(387,286,c),
+(347,234,o),
+(304,183,o),
+(246,183,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(558,183,o),
+(526,207,o),
+(463,294,c),
+(528,376,o),
+(561,401,o),
+(605,401,cs),
+(666,401,o),
+(704,352,o),
+(704,289,cs),
+(704,244,o),
+(670,183,o),
+(611,183,cs)
+);
+}
+);
+width = 809;
+}
+);
+unicode = 8734;
+},
+{
+glyphname = integral;
+lastChange = "2016-08-22 14:03:04 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(210,-202,o),
+(313,-138,o),
+(313,159,cs),
+(313,261,o),
+(301,560,o),
+(301,658,cs),
+(301,802,o),
+(327,841,o),
+(373,841,cs),
+(394,841,o),
+(410,833,o),
+(410,815,cs),
+(410,801,o),
+(400,793,o),
+(400,772,cs),
+(400,744,o),
+(419,719,o),
+(456,719,cs),
+(490,719,o),
+(504,741,o),
+(504,771,cs),
+(504,833,o),
+(445,866,o),
+(376,866,cs),
+(266,866,o),
+(171,782,o),
+(171,545,cs),
+(171,414,o),
+(200,111,o),
+(200,-37,cs),
+(200,-139,o),
+(186,-177,o),
+(143,-177,cs),
+(115,-177,o),
+(114,-161,o),
+(112,-128,cs),
+(110,-96,o),
+(100,-71,o),
+(65,-71,cs),
+(33,-71,o),
+(17,-91,o),
+(17,-120,cs),
+(17,-176,o),
+(79,-202,o),
+(130,-202,cs)
+);
+}
+);
+width = 446;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,-202,o),
+(340,-140,o),
+(340,161,cs),
+(340,259,o),
+(328,560,o),
+(328,659,cs),
+(328,793,o),
+(350,831,o),
+(390,831,cs),
+(408,831,o),
+(422,823,o),
+(422,806,cs),
+(422,788,o),
+(407,781,o),
+(407,757,cs),
+(407,729,o),
+(426,704,o),
+(464,704,cs),
+(501,704,o),
+(516,728,o),
+(516,762,cs),
+(516,830,o),
+(458,866,o),
+(384,866,cs),
+(271,866,o),
+(168,782,o),
+(168,543,cs),
+(168,416,o),
+(197,112,o),
+(197,-39,cs),
+(197,-132,o),
+(186,-167,o),
+(154,-167,cs),
+(132,-167,o),
+(131,-151,o),
+(129,-118,cs),
+(127,-86,o),
+(116,-61,o),
+(77,-61,cs),
+(38,-61,o),
+(19,-86,o),
+(19,-118,cs),
+(19,-177,o),
+(86,-202,o),
+(141,-202,cs)
+);
+}
+);
+width = 466;
+}
+);
+unicode = 8747;
+},
+{
+glyphname = Ohm;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(335,0,l),
+(345,23,l),
+(257,156,o),
+(222,257,o),
+(222,412,cs),
+(222,636,o),
+(295,702,o),
+(380,702,cs),
+(471,702,o),
+(545,625,o),
+(545,408,cs),
+(545,267,o),
+(514,160,o),
+(421,23,c),
+(430,0,l),
+(701,0,l),
+(730,174,l),
+(707,174,l),
+(686,109,o),
+(672,95,o),
+(630,95,cs),
+(508,99,l),
+(607,187,o),
+(694,269,o),
+(694,421,cs),
+(694,607,o),
+(565,733,o),
+(387,733,cs),
+(208,733,o),
+(72,606,o),
+(72,412,cs),
+(72,249,o),
+(168,165,o),
+(251,100,c),
+(144,96,ls),
+(100,96,o),
+(84,112,o),
+(62,174,c),
+(38,174,l),
+(63,0,l)
+);
+}
+);
+width = 762;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(365,0,l),
+(375,26,l),
+(326,132,o),
+(263,268,o),
+(263,399,cs),
+(263,626,o),
+(323,694,o),
+(415,694,cs),
+(506,694,o),
+(572,615,o),
+(572,402,cs),
+(572,267,o),
+(500,123,o),
+(458,26,c),
+(468,0,l),
+(756,0,l),
+(788,189,l),
+(747,189,l),
+(724,127,o),
+(709,116,o),
+(665,116,cs),
+(552,116,l),
+(644,188,o),
+(751,274,o),
+(751,414,cs),
+(751,612,o),
+(615,733,o),
+(419,733,cs),
+(226,733,o),
+(83,609,o),
+(83,408,cs),
+(83,253,o),
+(195,171,o),
+(274,116,c),
+(176,116,ls),
+(127,116,o),
+(111,128,o),
+(87,189,c),
+(48,189,l),
+(75,0,l)
+);
+}
+);
+width = 782;
+}
+);
+unicode = 8486;
+},
+{
+glyphname = increment;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(641,0,l),
+(641,37,l),
+(359,729,l),
+(302,715,l),
+(31,37,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(279,570,l),
+(478,37,l),
+(67,37,l)
+);
+}
+);
+width = 680;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(653,0,l),
+(653,43,l),
+(356,733,l),
+(286,716,l),
+(1,43,l),
+(1,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(268,527,l),
+(459,73,l),
+(83,73,l)
+);
+}
+);
+width = 700;
+}
+);
+unicode = 8710;
+},
+{
+glyphname = product;
+lastChange = "2016-08-22 13:15:33 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(604,-64,l),
+(604,734,l),
+(470,734,l),
+(470,-64,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(321,-79,l),
+(321,-54,l),
+(17,-54,l),
+(17,-79,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(694,-79,l),
+(694,-54,l),
+(390,-54,l),
+(390,-79,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(241,-64,l),
+(241,734,l),
+(107,734,l),
+(107,-64,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(694,709,l),
+(694,734,l),
+(17,734,l),
+(17,709,l)
+);
+}
+);
+width = 711;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(666,-71,l),
+(666,733,l),
+(508,733,l),
+(508,-71,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(357,-86,l),
+(357,-56,l),
+(27,-56,l),
+(27,-86,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(765,-86,l),
+(765,-56,l),
+(435,-56,l),
+(435,-86,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(284,-71,l),
+(284,733,l),
+(126,733,l),
+(126,-71,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(765,703,l),
+(765,733,l),
+(27,733,l),
+(27,703,l)
+);
+}
+);
+width = 731;
+}
+);
+unicode = 8719;
+},
+{
+glyphname = summation;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(571,-87,l),
+(618,141,l),
+(592,148,l),
+(547,31,o),
+(533,25,o),
+(440,25,cs),
+(195,25,l),
+(427,370,l),
+(252,701,l),
+(440,701,ls),
+(510,701,o),
+(539,660,o),
+(560,542,c),
+(591,550,l),
+(579,733,l),
+(92,733,l),
+(92,709,l),
+(315,278,l),
+(88,-53,l),
+(88,-87,l)
+);
+}
+);
+width = 726;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(622,-96,l),
+(676,149,l),
+(630,149,l),
+(585,43,o),
+(572,34,o),
+(473,34,cs),
+(224,34,l),
+(464,370,l),
+(293,684,l),
+(436,684,ls),
+(528,684,o),
+(559,659,o),
+(592,534,c),
+(635,534,l),
+(621,730,l),
+(103,730,l),
+(103,690,l),
+(331,264,l),
+(98,-56,l),
+(98,-96,l)
+);
+}
+);
+width = 746;
+}
+);
+unicode = 8721;
+},
+{
+glyphname = radical;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(307,-172,l),
+(668,915,l),
+(639,915,l),
+(350,50,l),
+(346,50,l),
+(257,440,l),
+(54,440,l),
+(54,415,l),
+(148,415,l),
+(293,-175,l)
+);
+}
+);
+width = 602;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,-175,l),
+(637,914,l),
+(576,914,l),
+(430,81,l),
+(426,81,l),
+(290,440,l),
+(64,440,l),
+(64,405,l),
+(162,405,l),
+(401,-183,l)
+);
+}
+);
+width = 622;
+}
+);
+unicode = 8730;
+},
+{
+glyphname = micro;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(226,-12,o),
+(285,41,o),
+(327,96,c),
+(334,96,l),
+(356,216,l),
+(327,113,o),
+(257,32,o),
+(195,32,cs),
+(174,32,o),
+(158,42,o),
+(158,65,cs),
+(158,73,o),
+(160,81,o),
+(162,91,cs),
+(248,450,l),
+(144,450,l),
+(62,114,ls),
+(58,97,o),
+(56,82,o),
+(56,70,cs),
+(56,12,o),
+(99,-12,o),
+(150,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(37,-261,o),
+(68,-236,o),
+(68,-174,cs),
+(68,-143,o),
+(60,-118,o),
+(60,-69,cs),
+(60,-45,o),
+(62,-16,o),
+(68,21,c),
+(72,21,l),
+(65,126,l),
+(29,-59,o),
+(-41,-153,o),
+(-41,-217,cs),
+(-41,-248,o),
+(-24,-261,o),
+(1,-261,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,425,l),
+(224,450,l),
+(65,450,l),
+(65,425,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(477,-12,o),
+(523,45,o),
+(564,142,c),
+(544,151,l),
+(507,73,o),
+(472,30,o),
+(444,30,cs),
+(430,30,o),
+(424,41,o),
+(424,60,cs),
+(424,77,o),
+(429,106,o),
+(439,147,cs),
+(514,450,l),
+(412,450,l),
+(341,154,ls),
+(334,125,o),
+(331,101,o),
+(331,82,cs),
+(331,9,o),
+(373,-12,o),
+(412,-12,cs)
+);
+}
+);
+width = 571;
+},
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(41,420,l),
+(215,420,l),
+(215,450,l),
+(41,450,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(559,450,l),
+(425,450,l),
+(351,153,ls),
+(338,100,o),
+(335,86,o),
+(335,70,cs),
+(335,15,o),
+(370,-11,o),
+(422,-11,cs),
+(513,-11,o),
+(576,69,o),
+(602,152,c),
+(577,161,l),
+(540,69,o),
+(499,41,o),
+(479,41,cs),
+(472,41,o),
+(467,45,o),
+(467,54,cs),
+(467,58,o),
+(468,70,o),
+(472,87,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(370,220,l),
+(339,108,o),
+(239,35,o),
+(203,35,cs),
+(191,35,o),
+(184,43,o),
+(184,57,cs),
+(184,67,o),
+(187,86,o),
+(189,95,cs),
+(280,450,l),
+(143,450,l),
+(56,113,ls),
+(52,96,o),
+(50,81,o),
+(50,69,cs),
+(50,13,o),
+(99,-11,o),
+(152,-11,cs),
+(232,-11,o),
+(292,43,o),
+(332,98,c),
+(339,98,l)
+);
+}
+);
+};
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(232,-11,o),
+(292,43,o),
+(332,98,c),
+(339,98,l),
+(370,220,l),
+(339,108,o),
+(239,35,o),
+(203,35,cs),
+(191,35,o),
+(184,43,o),
+(184,57,cs),
+(184,67,o),
+(187,86,o),
+(189,95,cs),
+(280,450,l),
+(143,450,l),
+(56,113,ls),
+(52,96,o),
+(50,81,o),
+(50,69,cs),
+(50,13,o),
+(99,-11,o),
+(152,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(48,-277,o),
+(81,-246,o),
+(81,-174,cs),
+(81,-145,o),
+(76,-108,o),
+(76,-57,cs),
+(76,-38,o),
+(76,-17,o),
+(78,8,c),
+(82,8,l),
+(54,104,l),
+(13,-90,o),
+(-49,-153,o),
+(-49,-220,cs),
+(-49,-252,o),
+(-34,-277,o),
+(5,-277,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(215,420,l),
+(215,450,l),
+(41,450,l),
+(41,420,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(513,-11,o),
+(576,69,o),
+(602,152,c),
+(577,161,l),
+(540,69,o),
+(499,41,o),
+(479,41,cs),
+(472,41,o),
+(467,45,o),
+(467,54,cs),
+(467,58,o),
+(468,70,o),
+(472,87,cs),
+(559,450,l),
+(425,450,l),
+(351,153,ls),
+(338,100,o),
+(335,86,o),
+(335,70,cs),
+(335,15,o),
+(370,-11,o),
+(422,-11,cs)
+);
+}
+);
+width = 598;
+}
+);
+unicode = 181;
+},
+{
+glyphname = partialdiff;
+lastChange = "2016-08-22 13:16:12 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,-11,o),
+(530,129,o),
+(530,391,cs),
+(530,657,o),
+(407,779,o),
+(242,779,cs),
+(175,779,o),
+(127,759,o),
+(91,738,c),
+(131,668,l),
+(172,713,o),
+(216,741,o),
+(273,741,cs),
+(368,741,o),
+(427,664,o),
+(427,528,cs),
+(427,482,o),
+(420,434,o),
+(413,390,c),
+(385,429,o),
+(343,451,o),
+(286,451,cs),
+(151,451,o),
+(49,341,o),
+(49,193,cs),
+(49,67,o),
+(129,-11,o),
+(249,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(199,19,o),
+(176,58,o),
+(176,138,cs),
+(176,224,o),
+(202,411,o),
+(314,411,c),
+(365,411,o),
+(392,372,o),
+(403,350,c),
+(391,260,o),
+(377,202,o),
+(352,136,cs),
+(320,52,o),
+(295,19,o),
+(249,19,cs)
+);
+}
+);
+width = 569;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(465,-12,o),
+(580,162,o),
+(580,384,cs),
+(580,593,o),
+(478,779,o),
+(263,779,cs),
+(191,779,o),
+(143,758,o),
+(104,738,c),
+(153,633,l),
+(193,678,o),
+(252,709,o),
+(314,709,cs),
+(420,709,o),
+(453,620,o),
+(453,519,cs),
+(453,476,o),
+(447,442,o),
+(439,397,c),
+(408,437,o),
+(362,455,o),
+(306,455,c),
+(164,455,o),
+(59,339,o),
+(59,197,cs),
+(59,69,o),
+(144,-12,o),
+(274,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(233,31,o),
+(211,63,o),
+(211,136,cs),
+(211,210,o),
+(234,399,o),
+(345,399,cs),
+(391,399,o),
+(416,366,o),
+(428,343,c),
+(415,257,o),
+(401,199,o),
+(375,138,cs),
+(350,79,o),
+(319,31,o),
+(272,31,cs)
+);
+}
+);
+width = 589;
+}
+);
+unicode = 8706;
+},
+{
+glyphname = percent;
+lastChange = "2016-08-22 14:03:19 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+pos = (323,0);
+ref = fraction;
+},
+{
+pos = (23,0);
+ref = zero.numerator;
+},
+{
+pos = (483,0);
+ref = zero.denominator;
+}
+);
+width = 913;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+pos = (317,0);
+ref = fraction;
+},
+{
+pos = (23,0);
+ref = zero.numerator;
+},
+{
+pos = (483,0);
+ref = zero.denominator;
+}
+);
+width = 933;
+}
+);
+unicode = 37;
+},
+{
+glyphname = perthousand;
+lastChange = "2016-08-22 14:03:34 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+alignment = -1;
+pos = (312,0);
+ref = fraction;
+},
+{
+pos = (23,0);
+ref = zero.numerator;
+},
+{
+pos = (483,0);
+ref = zero.denominator;
+},
+{
+pos = (863,0);
+ref = zero.denominator;
+}
+);
+width = 1289;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+alignment = -1;
+pos = (322,0);
+ref = fraction;
+},
+{
+pos = (23,0);
+ref = zero.numerator;
+},
+{
+pos = (483,0);
+ref = zero.denominator;
+},
+{
+pos = (863,0);
+ref = zero.denominator;
+}
+);
+width = 1309;
+}
+);
+unicode = 8240;
+},
+{
+glyphname = lozenge;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(375,-74,l),
+(575,347,l),
+(375,771,l),
+(279,771,l),
+(76,347,l),
+(276,-74,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,348,l),
+(325,717,l),
+(329,717,l),
+(504,347,l),
+(329,-24,l),
+(325,-24,l)
+);
+}
+);
+width = 595;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(401,-77,l),
+(612,347,l),
+(402,774,l),
+(289,774,l),
+(76,347,l),
+(286,-77,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(172,348,l),
+(343,700,l),
+(347,700,l),
+(516,347,l),
+(347,-7,l),
+(343,-7,l)
+);
+}
+);
+width = 615;
+}
+);
+unicode = 9674;
+},
+{
+glyphname = at;
+lastChange = "2016-08-22 14:03:43 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(487,-152,o),
+(569,-119,o),
+(654,-32,c),
+(636,-7,l),
+(556,-101,o),
+(463,-122,o),
+(389,-122,cs),
+(202,-122,o),
+(97,11,o),
+(97,199,cs),
+(97,437,o),
+(264,600,o),
+(468,600,cs),
+(623,600,o),
+(746,506,o),
+(746,331,cs),
+(746,190,o),
+(666,94,o),
+(599,94,cs),
+(582,94,o),
+(573,100,o),
+(573,114,cs),
+(573,118,o),
+(574,124,o),
+(576,131,cs),
+(650,443,l),
+(542,443,l),
+(479,189,ls),
+(468,144,o),
+(465,127,o),
+(465,112,cs),
+(465,65,o),
+(494,44,o),
+(546,44,cs),
+(675,44,o),
+(779,175,o),
+(779,335,cs),
+(779,501,o),
+(668,630,o),
+(471,630,cs),
+(255,630,o),
+(64,474,o),
+(64,199,cs),
+(64,-40,o),
+(208,-152,o),
+(389,-152,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(402,44,o),
+(439,82,o),
+(458,115,c),
+(465,115,l),
+(493,237,l),
+(466,118,o),
+(402,80,o),
+(365,80,cs),
+(340,80,o),
+(329,97,o),
+(329,148,cs),
+(329,273,o),
+(395,420,o),
+(459,420,cs),
+(492,420,o),
+(512,382,o),
+(512,341,cs),
+(512,329,o),
+(510,322,o),
+(510,309,c),
+(530,390,l),
+(524,390,l),
+(506,435,o),
+(485,454,o),
+(443,454,cs),
+(338,454,o),
+(219,336,o),
+(219,194,cs),
+(219,90,o),
+(282,44,o),
+(345,44,cs)
+);
+}
+);
+width = 803;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,-152,o),
+(589,-119,o),
+(674,-32,c),
+(651,3,l),
+(573,-91,o),
+(482,-112,o),
+(409,-112,cs),
+(228,-112,o),
+(127,17,o),
+(127,199,cs),
+(127,431,o),
+(289,590,o),
+(488,590,cs),
+(637,590,o),
+(756,501,o),
+(756,327,cs),
+(756,196,o),
+(688,104,o),
+(629,104,cs),
+(614,104,o),
+(605,110,o),
+(605,124,cs),
+(605,129,o),
+(606,134,o),
+(608,141,cs),
+(680,443,l),
+(552,443,l),
+(489,189,ls),
+(478,144,o),
+(475,127,o),
+(475,113,cs),
+(475,65,o),
+(509,44,o),
+(563,44,cs),
+(697,44,o),
+(799,176,o),
+(799,335,cs),
+(799,501,o),
+(688,630,o),
+(491,630,cs),
+(275,630,o),
+(84,474,o),
+(84,199,cs),
+(84,-40,o),
+(228,-152,o),
+(409,-152,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(412,44,o),
+(451,79,o),
+(468,110,c),
+(475,110,l),
+(503,237,l),
+(479,130,o),
+(423,90,o),
+(385,90,cs),
+(361,90,o),
+(349,105,o),
+(349,158,cs),
+(349,275,o),
+(409,410,o),
+(471,410,cs),
+(502,410,o),
+(522,376,o),
+(522,341,cs),
+(522,329,o),
+(520,322,o),
+(520,309,c),
+(541,395,l),
+(535,395,l),
+(517,436,o),
+(496,454,o),
+(453,454,cs),
+(345,454,o),
+(224,335,o),
+(224,195,cs),
+(224,90,o),
+(292,44,o),
+(356,44,cs)
+);
+}
+);
+width = 823;
+}
+);
+unicode = 64;
+},
+{
+glyphname = ampersand;
+lastChange = "2016-08-22 13:16:30 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(719,0,o),
+(798,42,o),
+(841,124,c),
+(823,139,l),
+(786,83,o),
+(738,50,o),
+(695,50,cs),
+(646,50,o),
+(588,94,o),
+(490,305,cs),
+(441,411,o),
+(378,566,o),
+(378,647,cs),
+(378,703,o),
+(408,738,o),
+(474,738,cs),
+(542,738,o),
+(555,700,o),
+(555,662,cs),
+(555,577,o),
+(490,504,o),
+(397,482,c),
+(406,457,l),
+(536,494,o),
+(646,568,o),
+(646,654,cs),
+(646,717,o),
+(585,763,o),
+(482,763,cs),
+(332,763,o),
+(276,665,o),
+(276,581,cs),
+(276,516,o),
+(310,401,o),
+(363,277,cs),
+(455,61,o),
+(528,0,o),
+(632,0,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(383,-11,o),
+(443,48,o),
+(494,101,c),
+(469,123,l),
+(432,68,o),
+(375,33,o),
+(321,33,cs),
+(241,33,o),
+(183,111,o),
+(183,230,cs),
+(183,318,o),
+(215,384,o),
+(325,416,c),
+(319,441,l),
+(145,395,o),
+(53,297,o),
+(53,178,cs),
+(53,61,o),
+(142,-11,o),
+(268,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(629,283,o),
+(678,430,o),
+(726,430,cs),
+(750,430,o),
+(740,413,o),
+(740,383,cs),
+(740,359,o),
+(760,340,o),
+(790,340,cs),
+(826,340,o),
+(844,368,o),
+(844,397,cs),
+(844,438,o),
+(810,470,o),
+(759,470,cs),
+(641,470,o),
+(609,302,o),
+(529,193,c),
+(550,172,l)
+);
+}
+);
+width = 864;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(735,-10,o),
+(808,42,o),
+(853,129,c),
+(830,149,l),
+(792,86,o),
+(741,61,o),
+(699,61,cs),
+(648,61,o),
+(603,99,o),
+(509,305,cs),
+(453,428,o),
+(399,567,o),
+(399,646,cs),
+(399,700,o),
+(425,733,o),
+(483,733,cs),
+(543,733,o),
+(556,697,o),
+(556,659,cs),
+(556,578,o),
+(499,501,o),
+(385,477,c),
+(394,447,l),
+(560,489,o),
+(680,549,o),
+(680,643,cs),
+(680,717,o),
+(606,768,o),
+(494,768,cs),
+(335,768,o),
+(256,664,o),
+(256,570,cs),
+(256,508,o),
+(290,399,o),
+(340,277,cs),
+(439,36,o),
+(504,-10,o),
+(616,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,-11,o),
+(432,41,o),
+(476,91,c),
+(451,123,l),
+(420,78,o),
+(380,47,o),
+(340,47,cs),
+(262,47,o),
+(205,161,o),
+(205,269,cs),
+(205,343,o),
+(232,383,o),
+(302,408,c),
+(291,438,l),
+(133,393,o),
+(27,300,o),
+(27,175,cs),
+(27,62,o),
+(115,-11,o),
+(245,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(633,280,o),
+(673,413,o),
+(711,413,cs),
+(726,413,o),
+(723,391,o),
+(724,375,cs),
+(726,334,o),
+(750,316,o),
+(784,316,cs),
+(835,316,o),
+(856,355,o),
+(856,392,cs),
+(856,440,o),
+(820,476,o),
+(762,476,cs),
+(635,476,o),
+(605,305,o),
+(527,199,c),
+(554,178,l)
+);
+}
+);
+width = 868;
+}
+);
+unicode = 38;
+},
+{
+glyphname = paragraph;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,-157,l),
+(429,685,l),
+(521,685,l),
+(335,-157,l),
+(407,-157,l),
+(593,685,l),
+(688,685,l),
+(703,754,l),
+(372,754,ls),
+(193,754,o),
+(86,632,o),
+(86,496,cs),
+(86,392,o),
+(148,317,o),
+(274,309,c),
+(171,-157,l)
+);
+}
+);
+width = 608;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(268,-157,l),
+(446,680,l),
+(543,680,l),
+(365,-157,l),
+(447,-157,l),
+(625,680,l),
+(720,680,l),
+(735,754,l),
+(379,754,ls),
+(230,754,o),
+(96,654,o),
+(96,498,cs),
+(96,391,o),
+(158,318,o),
+(285,309,c),
+(186,-157,l)
+);
+}
+);
+width = 628;
+}
+);
+unicode = 182;
+},
+{
+glyphname = section;
+lastChange = "2016-08-22 13:16:52 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(295,-156,o),
+(359,-61,o),
+(359,37,cs),
+(359,218,o),
+(140,270,o),
+(140,376,cs),
+(140,442,o),
+(223,439,o),
+(240,467,c),
+(248,480,l),
+(140,475,o),
+(61,412,o),
+(61,314,cs),
+(61,147,o),
+(292,62,o),
+(292,-45,cs),
+(292,-96,o),
+(241,-126,o),
+(163,-126,cs),
+(106,-126,o),
+(80,-110,o),
+(80,-91,cs),
+(80,-65,o),
+(133,-62,o),
+(133,-13,cs),
+(133,8,o),
+(123,32,o),
+(86,32,cs),
+(46,32,o),
+(17,3,o),
+(17,-48,cs),
+(17,-113,o),
+(64,-156,o),
+(157,-156,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(398,122,o),
+(468,193,o),
+(468,287,cs),
+(468,458,o),
+(234,517,o),
+(234,625,cs),
+(234,683,o),
+(300,724,o),
+(366,724,cs),
+(408,724,o),
+(441,708,o),
+(441,691,cs),
+(441,670,o),
+(387,663,o),
+(387,618,cs),
+(387,590,o),
+(408,575,o),
+(434,575,cs),
+(472,575,o),
+(505,608,o),
+(505,655,cs),
+(505,712,o),
+(455,754,o),
+(371,754,cs),
+(244,754,o),
+(172,658,o),
+(172,556,cs),
+(172,378,o),
+(390,324,o),
+(390,217,cs),
+(390,153,o),
+(313,168,o),
+(290,131,c),
+(282,118,l)
+);
+}
+);
+width = 499;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(298,-161,o),
+(396,-76,o),
+(396,36,cs),
+(396,203,o),
+(175,267,o),
+(175,379,cs),
+(175,437,o),
+(235,438,o),
+(253,466,cs),
+(262,480,l),
+(149,475,o),
+(64,402,o),
+(64,293,cs),
+(64,116,o),
+(291,58,o),
+(291,-48,cs),
+(291,-111,o),
+(211,-126,o),
+(168,-126,cs),
+(140,-126,o),
+(113,-120,o),
+(113,-98,cs),
+(113,-69,o),
+(159,-70,o),
+(159,-24,cs),
+(159,4,o),
+(142,24,o),
+(108,24,cs),
+(63,24,o),
+(35,-12,o),
+(35,-56,cs),
+(35,-109,o),
+(75,-161,o),
+(173,-161,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(414,123,o),
+(497,200,o),
+(497,303,cs),
+(497,474,o),
+(267,518,o),
+(267,634,cs),
+(267,691,o),
+(323,719,o),
+(387,719,cs),
+(417,719,o),
+(443,713,o),
+(443,691,cs),
+(443,663,o),
+(397,661,o),
+(397,619,cs),
+(397,592,o),
+(416,574,o),
+(450,574,cs),
+(497,574,o),
+(521,609,o),
+(521,650,cs),
+(521,702,o),
+(481,754,o),
+(383,754,cs),
+(261,754,o),
+(165,674,o),
+(165,566,cs),
+(165,402,o),
+(386,324,o),
+(386,222,cs),
+(386,177,o),
+(343,143,o),
+(301,143,c),
+(300,118,l)
+);
+}
+);
+width = 519;
+}
+);
+unicode = 167;
+},
+{
+glyphname = copyright;
+lastChange = "2016-08-22 14:03:58 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(636,-10,o),
+(849,201,o),
+(849,442,cs),
+(849,626,o),
+(726,754,o),
+(539,754,cs),
+(302,754,o),
+(79,548,o),
+(79,295,cs),
+(79,113,o),
+(195,-10,o),
+(386,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(465,152,o),
+(511,164,o),
+(551,187,c),
+(565,160,l),
+(580,160,l),
+(607,285,l),
+(587,285,l),
+(558,222,o),
+(511,175,o),
+(424,175,cs),
+(356,175,o),
+(334,203,o),
+(334,277,cs),
+(334,380,o),
+(376,587,o),
+(519,587,cs),
+(593,587,o),
+(622,532,o),
+(622,471,c),
+(641,471,l),
+(669,604,l),
+(655,604,l),
+(626,575,l),
+(596,600,o),
+(561,609,o),
+(521,609,cs),
+(369,609,o),
+(235,476,o),
+(235,337,cs),
+(235,235,o),
+(307,152,o),
+(421,152,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(224,29,o),
+(118,145,o),
+(118,299,cs),
+(118,515,o),
+(325,715,o),
+(537,715,cs),
+(697,715,o),
+(809,601,o),
+(809,441,cs),
+(809,228,o),
+(609,29,o),
+(391,29,cs)
+);
+}
+);
+width = 833;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(642,-10,o),
+(855,201,o),
+(855,442,cs),
+(855,626,o),
+(732,754,o),
+(545,754,cs),
+(308,754,o),
+(85,548,o),
+(85,295,cs),
+(85,113,o),
+(201,-10,o),
+(392,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(471,152,o),
+(517,164,o),
+(557,187,c),
+(571,160,l),
+(586,160,l),
+(613,285,l),
+(593,285,l),
+(568,228,o),
+(526,185,o),
+(452,185,cs),
+(390,185,o),
+(370,215,o),
+(370,281,cs),
+(370,378,o),
+(413,577,o),
+(542,577,cs),
+(607,577,o),
+(628,526,o),
+(628,471,c),
+(647,471,l),
+(675,604,l),
+(661,604,l),
+(632,575,l),
+(602,600,o),
+(567,609,o),
+(527,609,cs),
+(375,609,o),
+(241,476,o),
+(241,337,cs),
+(241,235,o),
+(313,152,o),
+(427,152,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(236,39,o),
+(134,151,o),
+(134,300,cs),
+(134,509,o),
+(336,705,o),
+(543,705,cs),
+(697,705,o),
+(805,595,o),
+(805,441,cs),
+(805,233,o),
+(610,39,o),
+(397,39,cs)
+);
+}
+);
+width = 853;
+}
+);
+unicode = 169;
+},
+{
+glyphname = registered;
+lastChange = "2016-08-22 14:04:06 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(620,-10,o),
+(833,201,o),
+(833,442,cs),
+(833,626,o),
+(710,754,o),
+(523,754,cs),
+(286,754,o),
+(63,548,o),
+(63,295,cs),
+(63,113,o),
+(179,-10,o),
+(370,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(424,161,l),
+(428,183,l),
+(211,183,l),
+(207,161,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(345,167,l),
+(442,602,l),
+(349,602,l),
+(255,167,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(630,161,o),
+(639,169,o),
+(650,181,c),
+(641,195,l),
+(634,188,o),
+(626,185,o),
+(613,185,cs),
+(580,185,o),
+(579,204,o),
+(577,247,cs),
+(573,328,o),
+(563,358,o),
+(483,390,c),
+(483,394,l),
+(412,394,ls),
+(459,394,o),
+(468,345,o),
+(470,301,cs),
+(474,228,o),
+(478,161,o),
+(591,161,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(208,29,o),
+(102,145,o),
+(102,299,cs),
+(102,515,o),
+(309,715,o),
+(521,715,cs),
+(681,715,o),
+(793,601,o),
+(793,441,cs),
+(793,228,o),
+(593,29,o),
+(375,29,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(445,393,ls),
+(571,393,o),
+(645,438,o),
+(645,505,cs),
+(645,562,o),
+(590,602,o),
+(485,602,cs),
+(297,602,l),
+(294,580,l),
+(478,580,ls),
+(536,580,o),
+(546,557,o),
+(546,519,cs),
+(546,451,o),
+(514,407,o),
+(457,407,cs),
+(350,407,l),
+(350,393,l)
+);
+}
+);
+width = 833;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(631,-10,o),
+(844,201,o),
+(844,442,cs),
+(844,626,o),
+(721,754,o),
+(534,754,cs),
+(297,754,o),
+(74,548,o),
+(74,295,cs),
+(74,113,o),
+(190,-10,o),
+(381,-10,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(435,161,l),
+(439,193,l),
+(222,193,l),
+(218,161,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(366,167,l),
+(463,602,l),
+(350,602,l),
+(256,167,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(642,161,o),
+(650,169,o),
+(661,181,c),
+(652,200,l),
+(645,193,o),
+(636,190,o),
+(627,190,cs),
+(600,190,o),
+(599,218,o),
+(598,247,cs),
+(594,324,o),
+(591,346,o),
+(494,380,c),
+(494,384,l),
+(423,384,ls),
+(462,384,o),
+(468,344,o),
+(471,301,cs),
+(476,226,o),
+(481,161,o),
+(600,161,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(225,39,o),
+(123,151,o),
+(123,300,cs),
+(123,509,o),
+(325,705,o),
+(532,705,cs),
+(686,705,o),
+(794,595,o),
+(794,441,cs),
+(794,233,o),
+(599,39,o),
+(386,39,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(456,383,ls),
+(585,383,o),
+(661,433,o),
+(661,503,cs),
+(661,563,o),
+(604,602,o),
+(496,602,cs),
+(308,602,l),
+(305,570,l),
+(489,570,ls),
+(537,570,o),
+(547,547,o),
+(547,510,cs),
+(547,449,o),
+(519,412,o),
+(468,412,cs),
+(361,412,l),
+(361,383,l)
+);
+}
+);
+width = 853;
+}
+);
+unicode = 174;
+},
+{
+glyphname = trademark;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(629,376,l),
+(802,710,l),
+(806,710,l),
+(825,749,l),
+(818,754,l),
+(807,754,l),
+(652,459,l),
+(612,376,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(336,380,l),
+(341,403,l),
+(126,403,l),
+(121,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(274,388,l),
+(352,754,l),
+(265,754,l),
+(187,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(539,380,l),
+(544,403,l),
+(416,403,l),
+(411,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(147,633,l),
+(160,691,o),
+(198,732,o),
+(247,732,c),
+(242,754,l),
+(146,754,l),
+(120,633,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(462,732,l),
+(467,754,l),
+(146,754,l),
+(141,732,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(486,388,l),
+(564,754,l),
+(535,754,l),
+(457,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(441,633,l),
+(467,754,l),
+(372,754,l),
+(357,732,l),
+(397,732,o),
+(417,705,o),
+(417,663,cs),
+(417,654,o),
+(416,644,o),
+(414,633,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(857,380,l),
+(862,403,l),
+(686,403,l),
+(681,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(626,376,l),
+(668,459,l),
+(670,494,l),
+(666,494,l),
+(645,754,l),
+(559,754,l),
+(554,710,l),
+(558,710,l),
+(592,376,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(614,732,l),
+(619,754,l),
+(491,754,l),
+(486,732,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(824,388,l),
+(902,754,l),
+(816,754,l),
+(738,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(932,732,l),
+(937,754,l),
+(823,754,l),
+(818,732,l)
+);
+}
+);
+width = 845;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(632,376,l),
+(805,710,l),
+(809,710,l),
+(828,749,l),
+(821,754,l),
+(810,754,l),
+(655,459,l),
+(615,376,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,380,l),
+(344,403,l),
+(129,403,l),
+(124,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(277,388,l),
+(355,754,l),
+(268,754,l),
+(190,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(542,380,l),
+(547,403,l),
+(419,403,l),
+(414,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(150,633,l),
+(163,691,o),
+(201,732,o),
+(250,732,c),
+(245,754,l),
+(149,754,l),
+(123,633,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(465,732,l),
+(470,754,l),
+(149,754,l),
+(144,732,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(489,388,l),
+(567,754,l),
+(538,754,l),
+(460,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(444,633,l),
+(470,754,l),
+(375,754,l),
+(360,732,l),
+(400,732,o),
+(420,705,o),
+(420,663,cs),
+(420,654,o),
+(419,644,o),
+(417,633,c)
+);
+},
+{
+closed = 1;
+nodes = (
+(860,380,l),
+(865,403,l),
+(689,403,l),
+(684,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(629,376,l),
+(671,459,l),
+(673,494,l),
+(669,494,l),
+(648,754,l),
+(562,754,l),
+(557,710,l),
+(561,710,l),
+(595,376,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(617,732,l),
+(622,754,l),
+(494,754,l),
+(489,732,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(827,388,l),
+(905,754,l),
+(819,754,l),
+(741,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(935,732,l),
+(940,754,l),
+(826,754,l),
+(821,732,l)
+);
+}
+);
+width = 865;
+}
+);
+unicode = 8482;
+},
+{
+glyphname = degree;
+lastChange = "2016-08-22 14:04:14 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,459,o),
+(427,515,o),
+(427,608,cs),
+(427,693,o),
+(369,763,o),
+(279,763,cs),
+(197,763,o),
+(129,705,o),
+(129,610,cs),
+(129,515,o),
+(197,459,o),
+(278,459,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,503,o),
+(182,549,o),
+(182,612,cs),
+(182,675,o),
+(219,718,o),
+(280,718,cs),
+(343,718,o),
+(375,671,o),
+(375,611,cs),
+(375,547,o),
+(339,503,o),
+(280,503,cs)
+);
+}
+);
+width = 363;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(367,459,o),
+(435,515,o),
+(435,608,cs),
+(435,693,o),
+(377,763,o),
+(287,763,cs),
+(205,763,o),
+(137,705,o),
+(137,610,cs),
+(137,515,o),
+(205,459,o),
+(286,459,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,513,o),
+(200,555,o),
+(200,612,cs),
+(200,669,o),
+(233,708,o),
+(288,708,cs),
+(344,708,o),
+(373,665,o),
+(373,611,cs),
+(373,553,o),
+(341,513,o),
+(288,513,cs)
+);
+}
+);
+width = 383;
+}
+);
+unicode = 176;
+},
+{
+glyphname = bar;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(233,-157,l),
+(233,763,l),
+(174,763,l),
+(174,-157,l)
+);
+}
+);
+width = 367;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(263,-157,l),
+(263,763,l),
+(184,763,l),
+(184,-157,l)
+);
+}
+);
+width = 387;
+}
+);
+unicode = 124;
+},
+{
+glyphname = brokenbar;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,347,l),
+(242,763,l),
+(183,763,l),
+(183,347,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(242,-157,l),
+(242,249,l),
+(183,249,l),
+(183,-157,l)
+);
+}
+);
+width = 367;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(272,347,l),
+(272,763,l),
+(193,763,l),
+(193,347,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(272,-157,l),
+(272,249,l),
+(193,249,l),
+(193,-157,l)
+);
+}
+);
+width = 387;
+}
+);
+unicode = 166;
+},
+{
+glyphname = dagger;
+lastChange = "2016-08-22 13:17:14 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(171,-290,l),
+(215,-92,o),
+(283,147,o),
+(345,255,c),
+(332,287,o),
+(326,320,o),
+(326,355,cs),
+(326,391,o),
+(332,430,o),
+(341,469,c),
+(442,469,o),
+(474,435,o),
+(522,435,cs),
+(561,435,o),
+(583,457,o),
+(583,487,cs),
+(583,514,o),
+(564,529,o),
+(531,529,cs),
+(480,529,o),
+(451,493,o),
+(346,493,c),
+(377,631,o),
+(430,655,o),
+(430,717,cs),
+(430,753,o),
+(412,763,o),
+(389,763,cs),
+(345,763,o),
+(330,728,o),
+(330,669,cs),
+(330,595,o),
+(330,550,o),
+(320,493,c),
+(218,493,o),
+(195,529,o),
+(143,529,cs),
+(103,529,o),
+(78,507,o),
+(78,477,cs),
+(78,448,o),
+(102,435,o),
+(134,435,cs),
+(185,435,o),
+(208,469,o),
+(315,469,c),
+(298,392,o),
+(272,321,o),
+(217,255,c),
+(219,239,o),
+(220,221,o),
+(220,200,cs),
+(220,79,o),
+(187,-120,o),
+(149,-290,c)
+);
+}
+);
+width = 541;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(193,-290,l),
+(235,-92,o),
+(302,147,o),
+(366,255,c),
+(352,287,o),
+(347,322,o),
+(347,357,cs),
+(347,391,o),
+(352,427,o),
+(360,464,c),
+(436,459,o),
+(463,420,o),
+(517,420,cs),
+(564,420,o),
+(594,450,o),
+(594,491,cs),
+(594,527,o),
+(570,544,o),
+(538,544,cs),
+(489,544,o),
+(445,506,o),
+(367,498,c),
+(391,573,o),
+(454,651,o),
+(454,707,cs),
+(454,736,o),
+(437,763,o),
+(396,763,cs),
+(343,763,o),
+(316,716,o),
+(316,667,cs),
+(316,602,o),
+(333,576,o),
+(321,498,c),
+(246,506,o),
+(221,544,o),
+(167,544,cs),
+(121,544,o),
+(88,517,o),
+(88,474,cs),
+(88,439,o),
+(110,420,o),
+(144,420,cs),
+(193,420,o),
+(236,459,o),
+(314,464,c),
+(298,389,o),
+(273,319,o),
+(218,255,c),
+(221,234,o),
+(223,210,o),
+(223,178,cs),
+(223,58,o),
+(195,-130,o),
+(161,-290,c)
+);
+}
+);
+width = 561;
+}
+);
+unicode = 8224;
+},
+{
+glyphname = literSign;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,-11,o),
+(412,41,o),
+(455,123,c),
+(435,136,l),
+(403,84,o),
+(369,38,o),
+(312,38,cs),
+(254,38,o),
+(231,87,o),
+(231,216,cs),
+(231,331,l),
+(328,424,o),
+(385,511,o),
+(385,623,cs),
+(385,710,o),
+(351,772,o),
+(278,772,cs),
+(186,772,o),
+(104,672,o),
+(104,447,cs),
+(104,293,l),
+(31,240,l),
+(45,217,l),
+(104,256,l),
+(104,186,ls),
+(104,65,o),
+(150,-11,o),
+(259,-11,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(231,503,ls),
+(231,710,o),
+(248,742,o),
+(284,742,cs),
+(314,742,o),
+(343,719,o),
+(343,629,cs),
+(343,527,o),
+(306,457,o),
+(231,390,c)
+);
+}
+);
+width = 465;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(387,-12,o),
+(450,34,o),
+(507,135,c),
+(479,161,l),
+(441,106,o),
+(408,78,o),
+(359,78,cs),
+(292,78,o),
+(269,129,o),
+(269,257,cs),
+(269,334,l),
+(375,427,o),
+(436,509,o),
+(436,623,cs),
+(436,710,o),
+(401,779,o),
+(308,779,cs),
+(194,779,o),
+(119,675,o),
+(119,498,cs),
+(119,302,l),
+(41,251,l),
+(57,213,l),
+(119,250,l),
+(119,193,ls),
+(119,67,o),
+(178,-12,o),
+(297,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(269,505,ls),
+(269,683,o),
+(274,736,o),
+(319,736,cs),
+(362,736,o),
+(380,686,o),
+(380,624,cs),
+(380,524,o),
+(334,452,o),
+(269,400,c)
+);
+}
+);
+width = 485;
+}
+);
+unicode = 8467;
+},
+{
+glyphname = daggerdbl;
+lastChange = "2016-08-22 13:17:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(197,-290,o),
+(220,-265,o),
+(220,-195,cs),
+(220,-174,o),
+(218,-159,o),
+(218,-132,cs),
+(218,-105,o),
+(220,-70,o),
+(229,-20,c),
+(330,-20,o),
+(357,-56,o),
+(407,-56,cs),
+(440,-56,o),
+(472,-40,o),
+(472,-6,cs),
+(472,20,o),
+(453,38,o),
+(420,38,cs),
+(376,38,o),
+(330,4,o),
+(234,4,c),
+(253,89,o),
+(280,165,o),
+(337,237,c),
+(325,271,o),
+(320,304,o),
+(320,340,cs),
+(320,381,o),
+(327,424,o),
+(337,469,c),
+(441,469,o),
+(467,435,o),
+(517,435,cs),
+(556,435,o),
+(579,456,o),
+(579,487,cs),
+(579,514,o),
+(561,529,o),
+(528,529,cs),
+(478,529,o),
+(449,493,o),
+(342,493,c),
+(373,632,o),
+(426,655,o),
+(426,714,cs),
+(426,745,o),
+(412,763,o),
+(384,763,cs),
+(349,763,o),
+(326,736,o),
+(326,669,cs),
+(326,605,o),
+(326,550,o),
+(316,493,c),
+(215,493,o),
+(187,529,o),
+(137,529,cs),
+(98,529,o),
+(74,507,o),
+(74,477,cs),
+(74,449,o),
+(97,435,o),
+(127,435,cs),
+(175,435,o),
+(216,469,o),
+(311,469,c),
+(292,384,o),
+(266,309,o),
+(209,237,c),
+(220,204,o),
+(225,171,o),
+(225,136,cs),
+(225,94,o),
+(218,50,o),
+(208,4,c),
+(105,4,o),
+(78,38,o),
+(29,38,cs),
+(-9,38,o),
+(-33,17,o),
+(-33,-13,cs),
+(-33,-42,o),
+(-12,-56,o),
+(16,-56,cs),
+(62,-56,o),
+(100,-20,o),
+(203,-20,c),
+(172,-158,o),
+(119,-184,o),
+(119,-242,cs),
+(119,-276,o),
+(137,-290,o),
+(163,-290,cs)
+);
+}
+);
+width = 541;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(228,-290,o),
+(255,-243,o),
+(255,-194,cs),
+(255,-165,o),
+(246,-123,o),
+(246,-78,cs),
+(246,-63,o),
+(247,-45,o),
+(250,-25,c),
+(325,-33,o),
+(350,-71,o),
+(404,-71,cs),
+(450,-71,o),
+(483,-44,o),
+(483,-1,cs),
+(483,34,o),
+(461,53,o),
+(427,53,cs),
+(378,53,o),
+(335,14,o),
+(257,9,c),
+(273,88,o),
+(298,170,o),
+(356,237,c),
+(346,275,o),
+(341,316,o),
+(341,357,cs),
+(341,391,o),
+(346,427,o),
+(354,464,c),
+(430,459,o),
+(457,420,o),
+(511,420,cs),
+(558,420,o),
+(588,450,o),
+(588,491,cs),
+(588,527,o),
+(564,544,o),
+(532,544,cs),
+(483,544,o),
+(439,506,o),
+(361,498,c),
+(385,573,o),
+(448,651,o),
+(448,707,cs),
+(448,736,o),
+(431,763,o),
+(390,763,cs),
+(337,763,o),
+(310,716,o),
+(310,667,cs),
+(310,602,o),
+(327,576,o),
+(315,498,c),
+(240,506,o),
+(215,544,o),
+(161,544,cs),
+(115,544,o),
+(82,517,o),
+(82,474,cs),
+(82,439,o),
+(104,420,o),
+(138,420,cs),
+(187,420,o),
+(230,459,o),
+(308,464,c),
+(292,381,o),
+(267,307,o),
+(208,237,c),
+(219,202,o),
+(224,154,o),
+(224,116,cs),
+(224,82,o),
+(219,46,o),
+(211,9,c),
+(135,14,o),
+(108,53,o),
+(54,53,cs),
+(7,53,o),
+(-23,23,o),
+(-23,-18,cs),
+(-23,-54,o),
+(1,-71,o),
+(33,-71,cs),
+(82,-71,o),
+(126,-33,o),
+(204,-25,c),
+(180,-100,o),
+(117,-178,o),
+(117,-234,cs),
+(117,-263,o),
+(134,-290,o),
+(175,-290,cs)
+);
+}
+);
+width = 561;
+}
+);
+unicode = 8225;
+},
+{
+glyphname = numero;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = N;
+},
+{
+pos = (769,0);
+ref = ordmasculine;
+}
+);
+width = 1115;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = N;
+},
+{
+pos = (749,0);
+ref = ordmasculine;
+}
+);
+width = 1123;
+}
+);
+unicode = 8470;
+},
+{
+glyphname = estimated;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(614,-12,o),
+(734,45,o),
+(808,132,c),
+(749,132,l),
+(684,57,o),
+(589,9,o),
+(482,9,cs),
+(383,9,o),
+(294,52,o),
+(229,119,cs),
+(223,125,o),
+(220,133,o),
+(220,142,cs),
+(220,345,ls),
+(220,348,o),
+(222,349,o),
+(225,349,cs),
+(895,349,l),
+(895,559,o),
+(718,731,o),
+(481,731,cs),
+(253,731,o),
+(68,565,o),
+(68,359,cs),
+(68,154,o),
+(253,-12,o),
+(481,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(222,369,o),
+(220,373,o),
+(220,375,cs),
+(220,575,ls),
+(220,585,o),
+(223,594,o),
+(230,600,c),
+(295,666,o),
+(384,709,o),
+(482,709,cs),
+(580,709,o),
+(668,667,o),
+(733,604,cs),
+(740,597,o),
+(743,588,o),
+(743,579,cs),
+(743,375,ls),
+(743,373,o),
+(742,369,o),
+(739,369,cs),
+(225,369,ls)
+);
+}
+);
+width = 898;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(624,-12,o),
+(744,45,o),
+(818,132,c),
+(759,132,l),
+(694,57,o),
+(599,9,o),
+(492,9,cs),
+(393,9,o),
+(304,52,o),
+(239,119,cs),
+(233,125,o),
+(230,133,o),
+(230,142,cs),
+(230,345,ls),
+(230,348,o),
+(232,349,o),
+(235,349,cs),
+(905,349,l),
+(905,559,o),
+(728,731,o),
+(491,731,cs),
+(263,731,o),
+(78,565,o),
+(78,359,cs),
+(78,154,o),
+(263,-12,o),
+(491,-12,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(232,369,o),
+(230,373,o),
+(230,375,cs),
+(230,575,ls),
+(230,585,o),
+(233,594,o),
+(240,600,c),
+(305,666,o),
+(394,709,o),
+(492,709,cs),
+(590,709,o),
+(678,667,o),
+(743,604,cs),
+(750,597,o),
+(753,588,o),
+(753,579,cs),
+(753,375,ls),
+(753,373,o),
+(752,369,o),
+(749,369,cs),
+(235,369,ls)
+);
+}
+);
+width = 918;
+}
+);
+unicode = 8494;
+},
+{
+glyphname = asciicircum;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(62,173,l),
+(247,581,l),
+(435,173,l),
+(489,173,l),
+(272,645,l),
+(223,645,l),
+(8,173,l)
+);
+}
+);
+width = 501;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(89,173,l),
+(254,541,l),
+(422,173,l),
+(496,173,l),
+(279,645,l),
+(230,645,l),
+(15,173,l)
+);
+}
+);
+width = 521;
+}
+);
+unicode = 94;
+},
+{
+glyphname = servicemark;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(277,372,o),
+(346,412,o),
+(346,506,cs),
+(346,648,o),
+(186,625,o),
+(186,691,cs),
+(186,723,o),
+(224,741,o),
+(258,741,cs),
+(303,741,o),
+(337,708,o),
+(337,659,c),
+(360,659,l),
+(377,759,l),
+(354,759,l),
+(334,736,l),
+(318,752,o),
+(293,763,o),
+(257,763,cs),
+(182,763,o),
+(145,717,o),
+(145,651,cs),
+(145,516,o),
+(302,543,o),
+(302,468,cs),
+(302,435,o),
+(271,395,o),
+(210,395,cs),
+(156,395,o),
+(123,426,o),
+(110,486,c),
+(88,486,l),
+(69,379,l),
+(92,379,l),
+(119,406,l),
+(139,386,o),
+(166,372,o),
+(207,372,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(469,380,l),
+(474,403,l),
+(346,403,l),
+(341,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(415,388,l),
+(493,754,l),
+(464,754,l),
+(386,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(787,380,l),
+(792,403,l),
+(616,403,l),
+(611,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(556,376,l),
+(598,459,l),
+(600,494,l),
+(596,494,l),
+(574,754,l),
+(488,754,l),
+(484,710,l),
+(488,710,l),
+(522,376,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(559,376,l),
+(732,710,l),
+(736,710,l),
+(754,749,l),
+(747,754,l),
+(736,754,l),
+(582,459,l),
+(542,376,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(544,732,l),
+(548,754,l),
+(420,754,l),
+(416,732,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(753,388,l),
+(831,754,l),
+(745,754,l),
+(667,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(862,732,l),
+(866,754,l),
+(752,754,l),
+(748,732,l)
+);
+}
+);
+width = 785;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(287,372,o),
+(356,412,o),
+(356,506,cs),
+(356,648,o),
+(196,625,o),
+(196,691,cs),
+(196,723,o),
+(234,741,o),
+(268,741,cs),
+(313,741,o),
+(347,708,o),
+(347,659,c),
+(370,659,l),
+(387,759,l),
+(364,759,l),
+(344,736,l),
+(328,752,o),
+(303,763,o),
+(267,763,cs),
+(192,763,o),
+(155,717,o),
+(155,651,cs),
+(155,516,o),
+(312,543,o),
+(312,468,cs),
+(312,435,o),
+(281,395,o),
+(220,395,cs),
+(166,395,o),
+(133,426,o),
+(120,486,c),
+(98,486,l),
+(79,379,l),
+(102,379,l),
+(129,406,l),
+(149,386,o),
+(176,372,o),
+(217,372,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(479,380,l),
+(484,403,l),
+(356,403,l),
+(351,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(425,388,l),
+(503,754,l),
+(474,754,l),
+(396,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(797,380,l),
+(802,403,l),
+(626,403,l),
+(621,380,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(566,376,l),
+(608,459,l),
+(610,494,l),
+(606,494,l),
+(584,754,l),
+(498,754,l),
+(494,710,l),
+(498,710,l),
+(532,376,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(569,376,l),
+(742,710,l),
+(746,710,l),
+(764,749,l),
+(757,754,l),
+(746,754,l),
+(592,459,l),
+(552,376,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(554,732,l),
+(558,754,l),
+(430,754,l),
+(426,732,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(763,388,l),
+(841,754,l),
+(755,754,l),
+(677,388,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(872,732,l),
+(876,754,l),
+(762,754,l),
+(758,732,l)
+);
+}
+);
+width = 805;
+}
+);
+unicode = 8480;
+},
+{
+glyphname = gravecomb;
+lastChange = "2016-08-22 13:36:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (348,450);
+},
+{
+name = top;
+pos = (403,688);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,548,l),
+(328,652,ls),
+(291,680,o),
+(279,688,o),
+(262,688,cs),
+(230,688,o),
+(208,663,o),
+(208,635,cs),
+(208,614,o),
+(221,599,o),
+(248,592,cs),
+(414,548,l)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (316,450);
+},
+{
+name = top;
+pos = (371,691);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(515,550,l),
+(339,659,ls),
+(301,682,o),
+(281,691,o),
+(253,691,cs),
+(216,691,o),
+(195,667,o),
+(195,642,cs),
+(195,620,o),
+(211,596,o),
+(248,589,cs),
+(446,550,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 768;
+},
+{
+glyphname = acutecomb;
+lastChange = "2016-08-22 13:36:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (359,450);
+},
+{
+name = top;
+pos = (419,707);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(359,567,l),
+(533,606,ls),
+(581,617,o),
+(602,639,o),
+(602,668,cs),
+(602,693,o),
+(587,707,o),
+(564,707,cs),
+(544,707,o),
+(522,697,o),
+(479,671,cs),
+(307,567,l)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (405,450);
+},
+{
+name = top;
+pos = (458,682);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,541,l),
+(549,580,ls),
+(586,587,o),
+(602,611,o),
+(602,633,cs),
+(602,658,o),
+(581,682,o),
+(544,682,cs),
+(516,682,o),
+(496,673,o),
+(458,650,cs),
+(282,541,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 769;
+},
+{
+glyphname = circumflexcomb;
+lastChange = "2016-08-22 13:40:39 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (372,450);
+},
+{
+name = top;
+pos = (388,569);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,539,l),
+(390,580,l),
+(476,539,l),
+(519,539,l),
+(427,639,l),
+(365,639,l),
+(236,539,l)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (345,450);
+},
+{
+name = top;
+pos = (390,646);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(255,534,l),
+(387,579,l),
+(499,534,l),
+(546,534,l),
+(423,646,l),
+(367,646,l),
+(209,534,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 770;
+},
+{
+glyphname = brevecomb;
+lastChange = "2016-08-22 13:40:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (374,450);
+},
+{
+name = top;
+pos = (410,586);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(480,543,o),
+(530,587,o),
+(544,658,c),
+(514,658,l),
+(502,618,o),
+(465,609,o),
+(393,609,cs),
+(334,609,o),
+(309,612,o),
+(309,658,c),
+(278,658,l),
+(260,584,o),
+(299,543,o),
+(386,543,cs)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (381,450);
+},
+{
+name = top;
+pos = (425,680);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(466,546,o),
+(541,589,o),
+(559,680,c),
+(520,680,l),
+(509,632,o),
+(450,621,o),
+(397,621,cs),
+(348,621,o),
+(292,632,o),
+(304,680,c),
+(265,680,l),
+(243,586,o),
+(295,546,o),
+(382,546,cs)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 774;
+},
+{
+glyphname = tildecomb;
+lastChange = "2016-08-22 13:36:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (359,450);
+},
+{
+name = top;
+pos = (411,675);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(244,547,l),
+(257,575,o),
+(284,596,o),
+(317,596,cs),
+(365,596,o),
+(385,548,o),
+(447,548,cs),
+(503,548,o),
+(554,588,o),
+(580,675,c),
+(546,675,l),
+(533,652,o),
+(508,624,o),
+(472,624,cs),
+(425,624,o),
+(401,672,o),
+(344,672,cs),
+(284,672,o),
+(232,619,o),
+(212,547,c)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (365,450);
+},
+{
+name = top;
+pos = (418,680);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(242,546,l),
+(254,571,o),
+(285,591,o),
+(321,591,cs),
+(374,591,o),
+(390,547,o),
+(453,547,cs),
+(523,547,o),
+(570,600,o),
+(598,680,c),
+(562,680,l),
+(552,662,o),
+(522,635,o),
+(481,635,cs),
+(430,635,o),
+(414,679,o),
+(351,679,cs),
+(276,679,o),
+(229,615,o),
+(208,546,c)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 771;
+},
+{
+glyphname = hookabovecomb;
+lastChange = "2016-08-22 14:06:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (323,450);
+},
+{
+name = top;
+pos = (377,683);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(370,524,l),
+(387,550,o),
+(447,560,o),
+(454,600,cs),
+(465,657,o),
+(430,683,o),
+(370,683,cs),
+(326,683,o),
+(273,662,o),
+(262,603,cs),
+(258,583,o),
+(271,568,o),
+(294,568,cs),
+(315,568,o),
+(328,576,o),
+(330,590,cs),
+(334,608,o),
+(320,606,o),
+(323,618,cs),
+(326,633,o),
+(344,643,o),
+(364,643,cs),
+(385,643,o),
+(402,636,o),
+(395,598,cs),
+(390,574,o),
+(350,560,o),
+(343,524,c)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (332,450);
+},
+{
+name = top;
+pos = (390,700);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(381,507,l),
+(391,557,o),
+(461,538,o),
+(473,600,cs),
+(487,671,o),
+(458,700,o),
+(385,700,cs),
+(325,700,o),
+(273,673,o),
+(260,608,cs),
+(254,578,o),
+(270,559,o),
+(294,559,cs),
+(311,559,o),
+(335,566,o),
+(338,585,cs),
+(342,613,o),
+(322,601,o),
+(325,625,cs),
+(327,639,o),
+(348,657,o),
+(376,657,cs),
+(405,657,o),
+(420,641,o),
+(413,609,cs),
+(408,585,o),
+(356,577,o),
+(342,507,c)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 777;
+},
+{
+glyphname = dblgravecomb;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(519,554,l),
+(401,714,ls),
+(378,745,o),
+(358,754,o),
+(337,754,cs),
+(308,754,o),
+(291,736,o),
+(291,712,cs),
+(291,695,o),
+(299,677,o),
+(341,648,cs),
+(476,554,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(341,554,l),
+(223,714,ls),
+(200,745,o),
+(180,754,o),
+(159,754,cs),
+(130,754,o),
+(113,736,o),
+(113,712,cs),
+(113,695,o),
+(121,677,o),
+(163,648,cs),
+(298,554,l)
+);
+}
+);
+width = 426;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(560,554,l),
+(443,718,ls),
+(420,750,o),
+(402,760,o),
+(377,760,cs),
+(343,760,o),
+(315,742,o),
+(315,704,cs),
+(315,692,o),
+(318,669,o),
+(350,649,cs),
+(497,554,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(360,554,l),
+(243,718,ls),
+(220,750,o),
+(202,760,o),
+(177,760,cs),
+(143,760,o),
+(115,742,o),
+(115,704,cs),
+(115,692,o),
+(118,669,o),
+(150,649,cs),
+(297,554,l)
+);
+}
+);
+width = 476;
+}
+);
+unicode = 783;
+},
+{
+glyphname = breveinvertedcomb;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(134,576,l),
+(158,630,o),
+(205,655,o),
+(272,655,cs),
+(332,655,o),
+(380,635,o),
+(380,588,cs),
+(380,584,o),
+(380,580,o),
+(379,576,c),
+(413,576,l),
+(416,589,o),
+(417,603,o),
+(417,614,cs),
+(417,687,o),
+(371,733,o),
+(287,733,cs),
+(181,733,o),
+(127,660,o),
+(100,576,c)
+);
+}
+);
+width = 337;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(141,556,l),
+(156,614,o),
+(213,635,o),
+(278,635,cs),
+(340,635,o),
+(383,616,o),
+(383,570,cs),
+(383,566,o),
+(383,561,o),
+(382,556,c),
+(426,556,l),
+(430,574,o),
+(432,591,o),
+(432,606,cs),
+(432,684,o),
+(379,733,o),
+(293,733,cs),
+(187,733,o),
+(114,659,o),
+(93,556,c)
+);
+}
+);
+width = 357;
+}
+);
+unicode = 785;
+},
+{
+glyphname = horncomb;
+lastChange = "2016-08-22 14:06:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = _topright;
+pos = (305,450);
+},
+{
+name = topright;
+pos = (305,450);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(334,476,o),
+(372,499,o),
+(388,582,c),
+(324,582,l),
+(311,527,o),
+(295,503,o),
+(224,503,c),
+(221,476,l)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _topright;
+pos = (313,450);
+},
+{
+name = topright;
+pos = (313,450);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,465,o),
+(386,481,o),
+(405,582,c),
+(329,582,l),
+(316,527,o),
+(296,503,o),
+(225,503,c),
+(220,465,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 795;
+},
+{
+glyphname = dotbelowcomb;
+lastChange = "2016-08-22 13:47:05 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+pos = (241,0);
+},
+{
+name = bottom;
+pos = (194,-203);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(247,-203,o),
+(277,-174,o),
+(277,-136,cs),
+(277,-98,o),
+(247,-68,o),
+(209,-68,cs),
+(171,-68,o),
+(142,-98,o),
+(142,-136,cs),
+(142,-174,o),
+(171,-203,o),
+(209,-203,cs)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _bottom;
+pos = (250,0);
+},
+{
+name = bottom;
+pos = (196,-233);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(258,-233,o),
+(295,-196,o),
+(295,-153,cs),
+(295,-109,o),
+(258,-72,o),
+(214,-72,cs),
+(171,-72,o),
+(134,-109,o),
+(134,-153,cs),
+(134,-196,o),
+(171,-233,o),
+(214,-233,cs)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 803;
+},
+{
+glyphname = commaaccentcomb;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(24,-274,o),
+(70,-220,o),
+(70,-164,cs),
+(70,-120,o),
+(41,-81,o),
+(-4,-81,cs),
+(-39,-81,o),
+(-72,-104,o),
+(-72,-145,cs),
+(-72,-175,o),
+(-54,-195,o),
+(-26,-195,cs),
+(5,-195,o),
+(13,-169,o),
+(23,-169,cs),
+(27,-169,o),
+(34,-174,o),
+(34,-186,cs),
+(34,-211,o),
+(4,-247,o),
+(-90,-287,c),
+(-77,-310,l)
+);
+}
+);
+width = 180;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(32,-280,o),
+(93,-235,o),
+(93,-167,cs),
+(93,-124,o),
+(69,-69,o),
+(6,-69,cs),
+(-39,-69,o),
+(-79,-98,o),
+(-79,-144,cs),
+(-79,-174,o),
+(-62,-204,o),
+(-25,-204,cs),
+(17,-204,o),
+(23,-166,o),
+(34,-166,cs),
+(39,-166,o),
+(47,-174,o),
+(47,-188,cs),
+(47,-226,o),
+(-9,-260,o),
+(-90,-286,c),
+(-76,-315,l)
+);
+}
+);
+width = 200;
+}
+);
+unicode = 806;
+},
+{
+glyphname = strokeshortcomb;
+lastChange = "2016-08-22 13:44:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _center;
+pos = (92,262);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(274,244,l),
+(274,279,l),
+(-91,279,l),
+(-91,244,l)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _center;
+pos = (304,221);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(486,201,l),
+(486,241,l),
+(121,241,l),
+(121,201,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 821;
+},
+{
+glyphname = dblgravecomb.cap;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(626,784,l),
+(487,888,ls),
+(450,916,o),
+(438,924,o),
+(421,924,cs),
+(389,924,o),
+(367,899,o),
+(367,871,cs),
+(367,850,o),
+(380,835,o),
+(407,828,cs),
+(573,784,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(422,784,l),
+(283,888,ls),
+(246,916,o),
+(234,924,o),
+(217,924,cs),
+(185,924,o),
+(163,899,o),
+(163,871,cs),
+(163,850,o),
+(176,835,o),
+(203,828,cs),
+(369,784,l)
+);
+}
+);
+width = 483;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(659,794,l),
+(528,895,ls),
+(496,919,o),
+(474,924,o),
+(448,924,cs),
+(415,924,o),
+(396,902,o),
+(396,879,cs),
+(396,859,o),
+(411,838,o),
+(445,830,cs),
+(596,794,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(428,794,l),
+(297,895,ls),
+(265,919,o),
+(243,924,o),
+(217,924,cs),
+(184,924,o),
+(165,902,o),
+(165,879,cs),
+(165,859,o),
+(180,838,o),
+(214,830,cs),
+(365,794,l)
+);
+}
+);
+width = 540;
+}
+);
+},
+{
+glyphname = breveinvertedcomb.cap;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(190,787,l),
+(203,831,o),
+(253,851,o),
+(333,851,cs),
+(398,851,o),
+(435,838,o),
+(435,787,c),
+(469,787,l),
+(472,799,o),
+(473,809,o),
+(473,818,cs),
+(473,877,o),
+(422,924,o),
+(336,924,cs),
+(239,924,o),
+(171,864,o),
+(156,787,c)
+);
+}
+);
+width = 337;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(212,780,l),
+(223,828,o),
+(272,849,o),
+(335,849,cs),
+(394,849,o),
+(440,828,o),
+(428,780,c),
+(467,780,l),
+(471,797,o),
+(473,811,o),
+(473,824,cs),
+(473,894,o),
+(426,924,o),
+(350,924,cs),
+(256,924,o),
+(191,871,o),
+(173,780,c)
+);
+}
+);
+width = 357;
+}
+);
+},
+{
+glyphname = apostrophemod;
+lastChange = "2016-10-31 09:56:54 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(217,549,o),
+(276,613,o),
+(276,679,cs),
+(276,725,o),
+(247,763,o),
+(202,763,cs),
+(167,763,o),
+(134,740,o),
+(134,699,cs),
+(134,669,o),
+(152,649,o),
+(180,649,cs),
+(211,649,o),
+(219,675,o),
+(229,675,cs),
+(233,675,o),
+(240,670,o),
+(240,658,cs),
+(240,627,o),
+(200,579,o),
+(116,527,c),
+(129,504,l)
+);
+}
+);
+width = 180;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,514,o),
+(316,577,o),
+(316,653,cs),
+(316,702,o),
+(289,763,o),
+(221,763,cs),
+(175,763,o),
+(134,736,o),
+(134,686,cs),
+(134,654,o),
+(152,618,o),
+(194,618,cs),
+(238,618,o),
+(245,656,o),
+(257,656,cs),
+(262,656,o),
+(270,649,o),
+(270,633,cs),
+(270,588,o),
+(210,535,o),
+(123,502,c),
+(142,473,l)
+);
+}
+);
+width = 248;
+}
+);
+unicode = 700;
+},
+{
+glyphname = firsttonechinese;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(445,637,l),
+(460,703,l),
+(140,703,l),
+(125,637,l)
+);
+}
+);
+width = 355;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(456,627,l),
+(475,713,l),
+(135,713,l),
+(116,627,l)
+);
+}
+);
+width = 375;
+}
+);
+unicode = 713;
+},
+{
+glyphname = acute;
+lastChange = "2016-08-22 10:35:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(152,554,l),
+(329,661,ls),
+(357,678,o),
+(369,698,o),
+(369,716,cs),
+(369,735,o),
+(357,754,o),
+(323,754,cs),
+(298,754,o),
+(276,744,o),
+(241,704,cs),
+(110,554,l)
+);
+}
+);
+width = 279;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(164,554,l),
+(339,643,ls),
+(377,662,o),
+(390,676,o),
+(390,702,cs),
+(390,734,o),
+(370,760,o),
+(331,760,cs),
+(312,760,o),
+(290,754,o),
+(256,718,cs),
+(102,554,l)
+);
+}
+);
+width = 300;
+}
+);
+unicode = 180;
+},
+{
+glyphname = breve;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,576,o),
+(418,649,o),
+(445,733,c),
+(411,733,l),
+(387,679,o),
+(340,654,o),
+(273,654,cs),
+(213,654,o),
+(165,674,o),
+(165,721,cs),
+(165,725,o),
+(165,729,o),
+(166,733,c),
+(132,733,l),
+(129,720,o),
+(128,706,o),
+(128,695,cs),
+(128,622,o),
+(174,576,o),
+(258,576,cs)
+);
+}
+);
+width = 337;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(373,556,o),
+(446,630,o),
+(467,733,c),
+(419,733,l),
+(404,675,o),
+(347,654,o),
+(282,654,cs),
+(220,654,o),
+(177,673,o),
+(177,719,cs),
+(177,723,o),
+(177,728,o),
+(178,733,c),
+(134,733,l),
+(130,715,o),
+(128,698,o),
+(128,683,cs),
+(128,605,o),
+(181,556,o),
+(267,556,cs)
+);
+}
+);
+width = 357;
+}
+);
+unicode = 728;
+},
+{
+glyphname = caron;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(280,554,l),
+(454,754,l),
+(411,754,l),
+(269,648,l),
+(173,754,l),
+(130,754,l),
+(218,554,l)
+);
+}
+);
+width = 344;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(300,554,l),
+(494,754,l),
+(451,754,l),
+(293,668,l),
+(173,754,l),
+(130,754,l),
+(238,554,l)
+);
+}
+);
+width = 364;
+}
+);
+unicode = 711;
+},
+{
+glyphname = cedilla;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(75,-226,o),
+(163,-196,o),
+(163,-130,cs),
+(163,-91,o),
+(133,-66,o),
+(81,-66,cs),
+(62,-66,l),
+(105,10,l),
+(75,10,l),
+(16,-90,l),
+(60,-91,o),
+(79,-109,o),
+(79,-138,cs),
+(79,-177,o),
+(43,-195,o),
+(5,-195,cs),
+(-15,-195,o),
+(-40,-190,o),
+(-48,-184,c),
+(-65,-209,l),
+(-55,-216,o),
+(-29,-226,o),
+(9,-226,cs)
+);
+}
+);
+width = 245;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(67,-235,o),
+(160,-202,o),
+(160,-131,cs),
+(160,-91,o),
+(131,-66,o),
+(78,-66,cs),
+(59,-66,l),
+(102,10,l),
+(55,10,l),
+(-11,-100,l),
+(44,-101,o),
+(59,-117,o),
+(59,-140,cs),
+(59,-172,o),
+(31,-190,o),
+(-13,-190,cs),
+(-36,-190,o),
+(-61,-185,o),
+(-68,-179,c),
+(-85,-218,l),
+(-75,-225,o),
+(-50,-235,o),
+(-8,-235,cs)
+);
+}
+);
+width = 265;
+}
+);
+unicode = 184;
+},
+{
+glyphname = circumflex;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(127,554,l),
+(269,660,l),
+(365,554,l),
+(408,554,l),
+(320,754,l),
+(258,754,l),
+(85,554,l)
+);
+}
+);
+width = 343;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(122,554,l),
+(280,640,l),
+(400,554,l),
+(443,554,l),
+(335,754,l),
+(273,754,l),
+(80,554,l)
+);
+}
+);
+width = 363;
+}
+);
+unicode = 710;
+},
+{
+glyphname = dieresis;
+lastChange = "2016-08-22 14:04:36 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(397,612,o),
+(422,636,o),
+(422,667,cs),
+(422,697,o),
+(397,722,o),
+(367,722,cs),
+(336,722,o),
+(312,697,o),
+(312,667,cs),
+(312,636,o),
+(336,612,o),
+(367,612,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(207,612,o),
+(232,636,o),
+(232,667,cs),
+(232,697,o),
+(207,722,o),
+(177,722,cs),
+(146,722,o),
+(122,697,o),
+(122,667,cs),
+(122,636,o),
+(146,612,o),
+(177,612,cs)
+);
+}
+);
+width = 320;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(410,601,o),
+(440,631,o),
+(440,667,cs),
+(440,703,o),
+(410,733,o),
+(374,733,cs),
+(338,733,o),
+(308,703,o),
+(308,667,cs),
+(308,631,o),
+(338,601,o),
+(374,601,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(220,601,o),
+(250,631,o),
+(250,667,cs),
+(250,703,o),
+(220,733,o),
+(184,733,cs),
+(148,733,o),
+(118,703,o),
+(118,667,cs),
+(118,631,o),
+(148,601,o),
+(184,601,cs)
+);
+}
+);
+width = 340;
+}
+);
+unicode = 168;
+},
+{
+glyphname = dotaccent;
+lastChange = "2016-08-22 13:46:54 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(223,598,o),
+(253,627,o),
+(253,665,cs),
+(253,703,o),
+(223,733,o),
+(185,733,cs),
+(147,733,o),
+(118,703,o),
+(118,665,cs),
+(118,627,o),
+(147,598,o),
+(185,598,cs)
+);
+}
+);
+width = 155;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,573,o),
+(271,610,o),
+(271,653,cs),
+(271,697,o),
+(234,734,o),
+(190,734,cs),
+(147,734,o),
+(110,697,o),
+(110,653,cs),
+(110,610,o),
+(147,573,o),
+(190,573,cs)
+);
+}
+);
+width = 175;
+}
+);
+unicode = 729;
+},
+{
+glyphname = grave;
+lastChange = "2016-08-16 11:12:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(361,554,l),
+(243,714,ls),
+(220,745,o),
+(200,754,o),
+(179,754,cs),
+(150,754,o),
+(133,736,o),
+(133,712,cs),
+(133,695,o),
+(141,677,o),
+(183,648,cs),
+(318,554,l)
+);
+}
+);
+width = 248;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(368,554,l),
+(251,718,ls),
+(228,750,o),
+(210,760,o),
+(185,760,cs),
+(151,760,o),
+(123,742,o),
+(123,704,cs),
+(123,692,o),
+(126,669,o),
+(158,649,cs),
+(305,554,l)
+);
+}
+);
+width = 300;
+}
+);
+unicode = 96;
+},
+{
+glyphname = hungarumlaut;
+lastChange = "2016-08-22 10:35:44 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(336,554,l),
+(513,661,ls),
+(541,678,o),
+(553,698,o),
+(553,716,cs),
+(553,735,o),
+(541,754,o),
+(507,754,cs),
+(482,754,o),
+(460,744,o),
+(425,704,cs),
+(294,554,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(159,554,l),
+(336,661,ls),
+(364,678,o),
+(376,698,o),
+(376,716,cs),
+(376,735,o),
+(364,754,o),
+(330,754,cs),
+(305,754,o),
+(283,744,o),
+(248,704,cs),
+(117,554,l)
+);
+}
+);
+width = 456;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,554,l),
+(520,643,ls),
+(558,662,o),
+(571,676,o),
+(571,702,cs),
+(571,734,o),
+(551,760,o),
+(512,760,cs),
+(493,760,o),
+(471,754,o),
+(437,718,cs),
+(283,554,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(139,554,l),
+(314,643,ls),
+(352,662,o),
+(365,676,o),
+(365,702,cs),
+(365,734,o),
+(345,760,o),
+(306,760,cs),
+(287,760,o),
+(265,754,o),
+(231,718,cs),
+(77,554,l)
+);
+}
+);
+width = 476;
+}
+);
+unicode = 733;
+},
+{
+glyphname = macron;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(440,637,l),
+(455,703,l),
+(135,703,l),
+(120,637,l)
+);
+}
+);
+width = 355;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(455,627,l),
+(474,713,l),
+(134,713,l),
+(115,627,l)
+);
+}
+);
+width = 375;
+}
+);
+unicode = 175;
+},
+{
+glyphname = ogonek;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,-232,o),
+(56,-212,o),
+(81,-186,c),
+(69,-170,l),
+(45,-185,o),
+(28,-191,o),
+(12,-191,cs),
+(-12,-191,o),
+(-26,-177,o),
+(-26,-151,cs),
+(-26,-111,o),
+(7,-73,o),
+(114,12,c),
+(78,12,l),
+(-40,-41,o),
+(-102,-103,o),
+(-102,-167,cs),
+(-102,-208,o),
+(-75,-232,o),
+(-31,-232,cs)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(9,-232,o),
+(54,-213,o),
+(81,-186,c),
+(69,-170,l),
+(45,-185,o),
+(28,-191,o),
+(12,-191,cs),
+(-12,-191,o),
+(-26,-177,o),
+(-26,-151,cs),
+(-26,-102,o),
+(25,-43,o),
+(114,12,c),
+(78,18,l),
+(-35,-41,o),
+(-109,-116,o),
+(-109,-172,cs),
+(-109,-208,o),
+(-78,-232,o),
+(-32,-232,cs),
+(-32,-232,ls)
+);
+}
+);
+width = 215;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,-237,o),
+(114,-214,o),
+(142,-186,c),
+(127,-155,l),
+(94,-170,o),
+(70,-176,o),
+(51,-176,cs),
+(21,-176,o),
+(2,-161,o),
+(2,-136,cs),
+(2,-91,o),
+(59,-33,o),
+(145,12,c),
+(99,12,l),
+(-34,-57,o),
+(-91,-111,o),
+(-91,-168,cs),
+(-91,-211,o),
+(-58,-237,o),
+(-2,-237,cs),
+(-2,-237,ls)
+);
+}
+);
+width = 247;
+}
+);
+unicode = 731;
+},
+{
+glyphname = ring;
+lastChange = "2016-08-22 11:15:51 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(275,560,o),
+(320,603,o),
+(320,660,cs),
+(320,717,o),
+(275,762,o),
+(218,762,cs),
+(161,762,o),
+(118,717,o),
+(118,660,cs),
+(118,603,o),
+(161,560,o),
+(218,560,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(187,603,o),
+(161,629,o),
+(161,660,c),
+(161,692,o),
+(187,717,o),
+(218,717,cs),
+(250,717,o),
+(275,692,o),
+(275,660,cs),
+(275,629,o),
+(250,603,o),
+(218,603,cs)
+);
+}
+);
+width = 222;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(284,560,o),
+(330,606,o),
+(330,662,cs),
+(330,718,o),
+(283,763,o),
+(228,763,cs),
+(173,763,o),
+(126,717,o),
+(126,662,cs),
+(126,606,o),
+(173,560,o),
+(228,560,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(203,616,o),
+(183,638,o),
+(183,662,cs),
+(183,686,o),
+(204,706,o),
+(228,706,cs),
+(252,706,o),
+(273,686,o),
+(273,662,cs),
+(273,637,o),
+(253,616,o),
+(228,616,cs)
+);
+}
+);
+width = 242;
+}
+);
+unicode = 730;
+},
+{
+glyphname = tilde;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(156,603,l),
+(169,631,o),
+(196,652,o),
+(229,652,cs),
+(277,652,o),
+(297,604,o),
+(359,604,cs),
+(415,604,o),
+(466,644,o),
+(492,731,c),
+(458,731,l),
+(445,708,o),
+(420,680,o),
+(384,680,cs),
+(337,680,o),
+(313,728,o),
+(256,728,cs),
+(196,728,o),
+(144,675,o),
+(124,603,c)
+);
+}
+);
+width = 388;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,583,l),
+(145,610,o),
+(178,632,o),
+(217,632,cs),
+(275,632,o),
+(291,584,o),
+(360,584,cs),
+(436,584,o),
+(487,643,o),
+(517,731,c),
+(479,731,l),
+(467,711,o),
+(435,680,o),
+(390,680,cs),
+(335,680,o),
+(317,728,o),
+(250,728,cs),
+(168,728,o),
+(117,658,o),
+(95,583,c)
+);
+}
+);
+width = 408;
+}
+);
+unicode = 732;
+},
+{
+glyphname = caron.alt;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(211,549,o),
+(270,613,o),
+(270,679,cs),
+(270,725,o),
+(241,763,o),
+(196,763,cs),
+(161,763,o),
+(128,740,o),
+(128,699,cs),
+(128,669,o),
+(146,649,o),
+(174,649,cs),
+(205,649,o),
+(213,675,o),
+(223,675,cs),
+(227,675,o),
+(234,670,o),
+(234,658,cs),
+(234,627,o),
+(194,579,o),
+(110,527,c),
+(123,504,l)
+);
+}
+);
+width = 180;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(252,514,o),
+(316,577,o),
+(316,653,cs),
+(316,702,o),
+(289,763,o),
+(221,763,cs),
+(175,763,o),
+(134,736,o),
+(134,686,cs),
+(134,654,o),
+(152,618,o),
+(194,618,cs),
+(238,618,o),
+(245,656,o),
+(257,656,cs),
+(262,656,o),
+(270,649,o),
+(270,633,cs),
+(270,588,o),
+(210,535,o),
+(123,502,c),
+(142,473,l)
+);
+}
+);
+width = 248;
+}
+);
+},
+{
+glyphname = acute.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(221,784,l),
+(395,823,ls),
+(443,834,o),
+(464,856,o),
+(464,885,cs),
+(464,910,o),
+(449,924,o),
+(426,924,cs),
+(406,924,o),
+(384,914,o),
+(341,888,cs),
+(169,784,l)
+);
+}
+);
+width = 315;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,783,l),
+(417,822,ls),
+(454,829,o),
+(470,853,o),
+(470,875,cs),
+(470,900,o),
+(449,924,o),
+(412,924,cs),
+(384,924,o),
+(364,915,o),
+(326,892,cs),
+(150,783,l)
+);
+}
+);
+width = 335;
+}
+);
+},
+{
+glyphname = breve.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(422,787,o),
+(487,846,o),
+(503,924,c),
+(469,924,l),
+(456,880,o),
+(406,860,o),
+(326,860,cs),
+(261,860,o),
+(224,873,o),
+(224,924,c),
+(190,924,l),
+(170,842,o),
+(223,787,o),
+(319,787,cs)
+);
+}
+);
+width = 337;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(413,780,o),
+(478,833,o),
+(496,924,c),
+(457,924,l),
+(446,876,o),
+(397,855,o),
+(334,855,cs),
+(275,855,o),
+(229,876,o),
+(241,924,c),
+(202,924,l),
+(180,830,o),
+(222,780,o),
+(319,780,cs)
+);
+}
+);
+width = 357;
+}
+);
+},
+{
+glyphname = caron.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(353,784,l),
+(513,924,l),
+(470,924,l),
+(338,863,l),
+(232,924,l),
+(189,924,l),
+(291,784,l)
+);
+}
+);
+width = 344;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(352,791,l),
+(530,923,l),
+(484,923,l),
+(342,878,l),
+(220,923,l),
+(173,923,l),
+(296,791,l)
+);
+}
+);
+width = 364;
+}
+);
+},
+{
+glyphname = circumflex.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(196,784,l),
+(328,845,l),
+(434,784,l),
+(477,784,l),
+(375,924,l),
+(313,924,l),
+(154,784,l)
+);
+}
+);
+width = 343;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(183,791,l),
+(325,836,l),
+(447,791,l),
+(494,791,l),
+(371,923,l),
+(315,923,l),
+(137,791,l)
+);
+}
+);
+width = 363;
+}
+);
+},
+{
+glyphname = dieresis.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,814,o),
+(475,838,o),
+(475,869,cs),
+(475,899,o),
+(450,924,o),
+(420,924,cs),
+(389,924,o),
+(365,899,o),
+(365,869,cs),
+(365,838,o),
+(389,814,o),
+(420,814,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(260,814,o),
+(285,838,o),
+(285,869,cs),
+(285,899,o),
+(260,924,o),
+(230,924,cs),
+(199,924,o),
+(175,899,o),
+(175,869,cs),
+(175,838,o),
+(199,814,o),
+(230,814,cs)
+);
+}
+);
+width = 320;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(450,797,o),
+(479,825,o),
+(479,860,cs),
+(479,895,o),
+(450,923,o),
+(415,923,cs),
+(381,923,o),
+(352,895,o),
+(352,860,cs),
+(352,825,o),
+(381,797,o),
+(415,797,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(267,797,o),
+(296,825,o),
+(296,860,cs),
+(296,895,o),
+(267,923,o),
+(233,923,cs),
+(198,923,o),
+(169,895,o),
+(169,860,cs),
+(169,825,o),
+(198,797,o),
+(233,797,cs)
+);
+}
+);
+width = 340;
+}
+);
+},
+{
+glyphname = dotaccent.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(276,789,o),
+(306,818,o),
+(306,856,cs),
+(306,894,o),
+(276,924,o),
+(238,924,cs),
+(200,924,o),
+(171,894,o),
+(171,856,cs),
+(171,818,o),
+(200,789,o),
+(238,789,cs)
+);
+}
+);
+width = 155;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(278,793,o),
+(309,823,o),
+(309,858,cs),
+(309,893,o),
+(278,924,o),
+(243,924,cs),
+(208,924,o),
+(178,893,o),
+(178,858,cs),
+(178,823,o),
+(208,793,o),
+(243,793,cs)
+);
+}
+);
+width = 175;
+}
+);
+},
+{
+glyphname = grave.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,784,l),
+(284,888,ls),
+(247,916,o),
+(235,924,o),
+(218,924,cs),
+(186,924,o),
+(164,899,o),
+(164,871,cs),
+(164,850,o),
+(177,835,o),
+(204,828,cs),
+(370,784,l)
+);
+}
+);
+width = 279;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(470,783,l),
+(294,892,ls),
+(256,915,o),
+(236,924,o),
+(208,924,cs),
+(171,924,o),
+(150,900,o),
+(150,875,cs),
+(150,853,o),
+(166,829,o),
+(203,822,cs),
+(401,783,l)
+);
+}
+);
+width = 335;
+}
+);
+},
+{
+glyphname = hungarumlaut.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(423,774,l),
+(597,823,ls),
+(644,836,o),
+(666,856,o),
+(666,885,cs),
+(666,911,o),
+(651,924,o),
+(628,924,cs),
+(608,924,o),
+(585,916,o),
+(552,894,cs),
+(371,774,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(217,774,l),
+(391,823,ls),
+(438,836,o),
+(460,856,o),
+(460,885,cs),
+(460,911,o),
+(445,924,o),
+(422,924,cs),
+(402,924,o),
+(379,916,o),
+(346,894,cs),
+(165,774,l)
+);
+}
+);
+width = 521;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(459,794,l),
+(610,830,ls),
+(644,838,o),
+(659,859,o),
+(659,879,cs),
+(659,902,o),
+(640,924,o),
+(607,924,cs),
+(581,924,o),
+(559,919,o),
+(527,895,cs),
+(396,794,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(228,794,l),
+(379,830,ls),
+(413,838,o),
+(428,859,o),
+(428,879,cs),
+(428,902,o),
+(409,924,o),
+(376,924,cs),
+(350,924,o),
+(328,919,o),
+(296,895,cs),
+(165,794,l)
+);
+}
+);
+width = 540;
+}
+);
+},
+{
+glyphname = macron.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(499,858,l),
+(514,924,l),
+(194,924,l),
+(179,858,l)
+);
+}
+);
+width = 355;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(507,837,l),
+(526,923,l),
+(186,923,l),
+(167,837,l)
+);
+}
+);
+width = 375;
+}
+);
+},
+{
+glyphname = ring.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,777,o),
+(334,811,o),
+(334,852,cs),
+(334,893,o),
+(301,924,o),
+(261,924,cs),
+(221,924,o),
+(187,892,o),
+(187,852,cs),
+(187,811,o),
+(221,777,o),
+(261,777,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(239,810,o),
+(220,830,o),
+(220,852,cs),
+(220,873,o),
+(240,891,o),
+(261,891,cs),
+(282,891,o),
+(301,873,o),
+(301,852,cs),
+(301,830,o),
+(283,810,o),
+(261,810,cs)
+);
+}
+);
+width = 200;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(302,783,o),
+(329,810,o),
+(329,854,cs),
+(329,898,o),
+(302,924,o),
+(258,924,cs),
+(214,924,o),
+(187,898,o),
+(187,854,cs),
+(187,810,o),
+(214,783,o),
+(258,783,cs)
+);
+},
+{
+closed = 1;
+nodes = (
+(234,813,o),
+(222,830,o),
+(222,854,cs),
+(222,878,o),
+(234,893,o),
+(258,893,cs),
+(282,893,o),
+(294,878,o),
+(294,854,cs),
+(294,830,o),
+(282,813,o),
+(258,813,cs)
+);
+}
+);
+width = 220;
+}
+);
+},
+{
+glyphname = tilde.case;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(205,796,l),
+(218,824,o),
+(245,845,o),
+(278,845,cs),
+(326,845,o),
+(346,797,o),
+(408,797,cs),
+(464,797,o),
+(515,837,o),
+(541,924,c),
+(507,924,l),
+(494,901,o),
+(469,873,o),
+(433,873,cs),
+(386,873,o),
+(362,921,o),
+(305,921,cs),
+(245,921,o),
+(193,868,o),
+(173,796,c)
+);
+}
+);
+width = 388;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(194,789,l),
+(206,814,o),
+(237,834,o),
+(273,834,cs),
+(326,834,o),
+(342,790,o),
+(405,790,cs),
+(475,790,o),
+(522,843,o),
+(550,923,c),
+(514,923,l),
+(504,905,o),
+(474,878,o),
+(433,878,cs),
+(382,878,o),
+(366,922,o),
+(303,922,cs),
+(228,922,o),
+(181,858,o),
+(160,789,c)
+);
+}
+);
+width = 408;
+}
+);
+},
+{
+glyphname = brevecomb_acutecomb;
+lastChange = "2016-08-22 14:12:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (359,450);
+},
+{
+name = top;
+pos = (402,713);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = brevecomb;
+},
+{
+alignment = -1;
+pos = (63,108);
+ref = acutecomb;
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (357,450);
+},
+{
+name = top;
+pos = (497,863);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = brevecomb;
+},
+{
+alignment = -1;
+pos = (58,181);
+ref = acutecomb;
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_gravecomb;
+lastChange = "2016-08-22 14:12:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (373,450);
+},
+{
+name = top;
+pos = (403,824);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = brevecomb;
+},
+{
+alignment = -1;
+pos = (-11,136);
+ref = gravecomb;
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (370,450);
+},
+{
+name = top;
+pos = (416,860);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = brevecomb;
+},
+{
+alignment = -1;
+pos = (5,169);
+ref = gravecomb;
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_hookabovecomb;
+lastChange = "2016-08-22 14:12:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (377,450);
+},
+{
+name = top;
+pos = (441,821);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = brevecomb;
+},
+{
+alignment = -1;
+pos = (51,136);
+ref = hookabovecomb;
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (350,450);
+},
+{
+name = top;
+pos = (447,867);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = brevecomb;
+},
+{
+alignment = -1;
+pos = (51,180);
+ref = hookabovecomb;
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_tildecomb;
+lastChange = "2016-08-22 14:12:44 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (374,450);
+},
+{
+name = top;
+pos = (478,811);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = brevecomb;
+},
+{
+pos = (51,136);
+ref = tildecomb;
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (380,450);
+},
+{
+name = top;
+pos = (474,854);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+pos = (19,0);
+ref = brevecomb;
+},
+{
+alignment = -1;
+pos = (63,174);
+ref = tildecomb;
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_acutecomb;
+lastChange = "2016-08-22 14:12:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (368,450);
+},
+{
+name = top;
+pos = (426,813);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = circumflexcomb;
+},
+{
+alignment = -1;
+pos = (-49,106);
+ref = acutecomb;
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (367,450);
+},
+{
+name = top;
+pos = (422,820);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = circumflexcomb;
+},
+{
+alignment = -1;
+pos = (-34,138);
+ref = acutecomb;
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_gravecomb;
+lastChange = "2016-08-22 14:12:55 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (364,450);
+},
+{
+name = top;
+pos = (425,825);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = circumflexcomb;
+},
+{
+alignment = -1;
+pos = (80,137);
+ref = gravecomb;
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (363,450);
+},
+{
+name = top;
+pos = (431,814);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = circumflexcomb;
+},
+{
+alignment = -1;
+pos = (74,123);
+ref = gravecomb;
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_hookabovecomb;
+lastChange = "2016-08-22 14:13:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (370,450);
+},
+{
+name = top;
+pos = (459,785);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = circumflexcomb;
+},
+{
+alignment = -1;
+pos = (140,97);
+ref = hookabovecomb;
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (366,450);
+},
+{
+name = top;
+pos = (465,806);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = circumflexcomb;
+},
+{
+alignment = -1;
+pos = (167,123);
+ref = hookabovecomb;
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_tildecomb;
+lastChange = "2016-08-22 14:13:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (368,450);
+},
+{
+name = top;
+pos = (452,794);
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+ref = circumflexcomb;
+},
+{
+pos = (29,119);
+ref = tildecomb;
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+pos = (369,450);
+},
+{
+name = top;
+pos = (463,800);
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+ref = circumflexcomb;
+},
+{
+alignment = -1;
+pos = (31,120);
+ref = tildecomb;
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = NULL;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 0;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 0;
+}
+);
+},
+{
+glyphname = espaciador;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(234,754,l),
+(127,754,l),
+(-54,0,l),
+(53,0,l)
+);
+}
+);
+};
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(-25,-326,l),
+(275,924,l),
+(168,924,l),
+(-132,-326,l)
+);
+}
+);
+width = 107;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(11,-326,l),
+(311,924,l),
+(168,924,l),
+(-132,-326,l)
+);
+}
+);
+width = 143;
+}
+);
+},
+{
+glyphname = dotbelow;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+shapes = (
+{
+closed = 1;
+nodes = (
+(29,-233,o),
+(59,-204,o),
+(59,-166,cs),
+(59,-128,o),
+(29,-98,o),
+(-9,-98,cs),
+(-47,-98,o),
+(-76,-128,o),
+(-76,-166,cs),
+(-76,-166,ls),
+(-76,-204,o),
+(-47,-233,o),
+(-9,-233,cs)
+);
+}
+);
+width = 155;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+shapes = (
+{
+closed = 1;
+nodes = (
+(33,-260,o),
+(70,-223,o),
+(70,-180,cs),
+(70,-136,o),
+(33,-99,o),
+(-11,-99,cs),
+(-54,-99,o),
+(-91,-136,o),
+(-91,-180,cs),
+(-91,-180,ls),
+(-91,-223,o),
+(-54,-260,o),
+(-11,-260,cs)
+);
+}
+);
+width = 175;
+}
+);
+}
+);
+instances = (
+{
+axesValues = (
+400
+);
+instanceInterpolations = {
+"426C3F01-D24D-4224-A47E-56DA036E4742" = 1;
+};
+isItalic = 1;
+name = Italic;
+},
+{
+axesValues = (
+550
+);
+instanceInterpolations = {
+"426C3F01-D24D-4224-A47E-56DA036E4742" = 0.5;
+"DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC" = 0.5;
+};
+isItalic = 1;
+linkStyle = Medium;
+name = "Medium Italic";
+weightClass = 500;
+},
+{
+axesValues = (
+700
+);
+instanceInterpolations = {
+"DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC" = 1;
+};
+isBold = 1;
+isItalic = 1;
+name = "Bold Italic";
+weightClass = 700;
+}
+);
+kerningLTR = {
+"426C3F01-D24D-4224-A47E-56DA036E4742" = {
+"@MMK_L_A" = {
+"@MMK_R_A" = -18;
+"@MMK_R_C" = -24;
+"@MMK_R_G" = -28;
+"@MMK_R_O" = -24;
+"@MMK_R_S" = -4;
+"@MMK_R_T" = -60;
+"@MMK_R_U" = -44;
+"@MMK_R_W" = -36;
+"@MMK_R_Y" = -40;
+"@MMK_R_a" = -16;
+"@MMK_R_c" = -20;
+"@MMK_R_comma" = 36;
+"@MMK_R_d" = -12;
+"@MMK_R_e" = -12;
+"@MMK_R_f" = -28;
+"@MMK_R_o" = -12;
+"@MMK_R_t" = -16;
+"@MMK_R_u" = -20;
+"@MMK_R_w" = -20;
+"@MMK_R_y" = -32;
+Q = -24;
+V = -40;
+b = -12;
+guillemetleft = -32;
+guilsinglleft = -32;
+hyphen = 8;
+q = -16;
+quotedblleft = -24;
+quotedblright = -28;
+quoteleft = -20;
+quoteright = -24;
+v = -20;
+};
+"@MMK_L_C" = {
+"@MMK_R_A" = 32;
+"@MMK_R_H" = -16;
+"@MMK_R_K" = -24;
+"@MMK_R_O" = -12;
+"@MMK_R_comma" = 52;
+"@MMK_R_y" = -44;
+AE = 44;
+};
+"@MMK_L_D" = {
+"@MMK_R_A" = -48;
+"@MMK_R_J" = -32;
+"@MMK_R_N" = -32;
+"@MMK_R_T" = -28;
+"@MMK_R_W" = -24;
+"@MMK_R_Y" = -60;
+V = -28;
+X = -44;
+};
+"@MMK_L_E" = {
+"@MMK_R_C" = -16;
+"@MMK_R_T" = -28;
+"@MMK_R_W" = -24;
+V = -28;
+v = -16;
+};
+"@MMK_L_G" = {
+"@MMK_R_A" = -20;
+"@MMK_R_T" = -40;
+"@MMK_R_W" = -16;
+"@MMK_R_Y" = -48;
+"@MMK_R_comma" = 36;
+AE = -8;
+V = -16;
+guillemetleft = 4;
+};
+"@MMK_L_H" = {
+"@MMK_R_comma" = 24;
+};
+"@MMK_L_J" = {
+"@MMK_R_a" = -12;
+"@MMK_R_e" = -12;
+"@MMK_R_o" = -8;
+"@MMK_R_u" = -12;
+AE = 8;
+};
+"@MMK_L_K" = {
+"@MMK_R_A" = -4;
+"@MMK_R_C" = -40;
+"@MMK_R_G" = -48;
+"@MMK_R_O" = -40;
+"@MMK_R_S" = 40;
+"@MMK_R_T" = -16;
+"@MMK_R_U" = -40;
+"@MMK_R_W" = -16;
+"@MMK_R_e" = -4;
+"@MMK_R_o" = 4;
+"@MMK_R_u" = 16;
+"@MMK_R_y" = -72;
+guillemetleft = -64;
+hyphen = -24;
+oslash = 20;
+v = -4;
+};
+"@MMK_L_L" = {
+"@MMK_R_A" = 18;
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -16;
+"@MMK_R_O" = -8;
+"@MMK_R_S" = -4;
+"@MMK_R_T" = -64;
+"@MMK_R_U" = -36;
+"@MMK_R_W" = -40;
+"@MMK_R_Y" = -44;
+"@MMK_R_u" = 12;
+"@MMK_R_y" = -8;
+V = -44;
+hyphen = 56;
+quotedblleft = -84;
+quotedblright = -88;
+quoteleft = -84;
+quoteright = -88;
+};
+"@MMK_L_N" = {
+"@MMK_R_A" = -8;
+"@MMK_R_C" = -28;
+"@MMK_R_G" = -24;
+"@MMK_R_O" = -24;
+"@MMK_R_a" = -24;
+"@MMK_R_comma" = 12;
+"@MMK_R_e" = -20;
+"@MMK_R_o" = -20;
+"@MMK_R_u" = -28;
+};
+"@MMK_L_O" = {
+"@MMK_R_A" = -40;
+"@MMK_R_T" = -8;
+"@MMK_R_W" = -16;
+"@MMK_R_Y" = -48;
+"@MMK_R_Z" = -20;
+"@MMK_R_comma" = 12;
+AE = -28;
+V = -20;
+X = -36;
+};
+"@MMK_L_R" = {
+"@MMK_R_C" = -16;
+"@MMK_R_G" = -16;
+"@MMK_R_O" = -16;
+"@MMK_R_T" = -20;
+"@MMK_R_U" = -32;
+"@MMK_R_W" = -24;
+"@MMK_R_Y" = -4;
+"@MMK_R_colon" = 28;
+"@MMK_R_e" = -8;
+"@MMK_R_u" = 12;
+"@MMK_R_y" = -44;
+V = -28;
+guillemetleft = -40;
+hyphen = 8;
+};
+"@MMK_L_S" = {
+"@MMK_R_S" = -4;
+"@MMK_R_T" = -28;
+"@MMK_R_W" = -20;
+"@MMK_R_Y" = -36;
+AE = 12;
+V = -24;
+};
+"@MMK_L_T" = {
+"@MMK_R_A" = -28;
+"@MMK_R_C" = -16;
+"@MMK_R_G" = -12;
+"@MMK_R_J" = -28;
+"@MMK_R_O" = -12;
+"@MMK_R_S" = -16;
+"@MMK_R_Y" = -4;
+"@MMK_R_a" = -100;
+"@MMK_R_c" = -100;
+"@MMK_R_colon" = -60;
+"@MMK_R_comma" = -60;
+"@MMK_R_e" = -96;
+"@MMK_R_g" = -84;
+"@MMK_R_h" = -16;
+"@MMK_R_i" = -8;
+"@MMK_R_j" = -8;
+"@MMK_R_o" = -92;
+"@MMK_R_r" = -100;
+"@MMK_R_s" = -80;
+"@MMK_R_u" = -100;
+"@MMK_R_w" = -104;
+"@MMK_R_y" = -112;
+AE = -16;
+V = -24;
+guillemetleft = -120;
+guillemetright = -112;
+guilsinglleft = -120;
+hyphen = -76;
+m = -88;
+oslash = -96;
+v = -104;
+};
+"@MMK_L_U" = {
+"@MMK_R_A" = -28;
+"@MMK_R_comma" = 16;
+"@MMK_R_n" = -8;
+"@MMK_R_r" = -24;
+AE = -16;
+m = -8;
+p = -16;
+};
+"@MMK_L_W" = {
+"@MMK_R_A" = -96;
+"@MMK_R_C" = -60;
+"@MMK_R_G" = -60;
+"@MMK_R_O" = -60;
+"@MMK_R_S" = -32;
+"@MMK_R_a" = -96;
+"@MMK_R_c" = -96;
+"@MMK_R_colon" = -56;
+"@MMK_R_comma" = -88;
+"@MMK_R_d" = -92;
+"@MMK_R_e" = -92;
+"@MMK_R_g" = -92;
+"@MMK_R_h" = -20;
+"@MMK_R_i" = -16;
+"@MMK_R_o" = -88;
+"@MMK_R_r" = -52;
+"@MMK_R_u" = -56;
+"@MMK_R_y" = -68;
+AE = -84;
+Oslash = -60;
+guillemetleft = -112;
+guillemetright = -96;
+guilsinglleft = -112;
+hyphen = -68;
+oslash = -88;
+};
+"@MMK_L_Y" = {
+"@MMK_R_A" = 8;
+"@MMK_R_C" = -44;
+"@MMK_R_G" = -48;
+"@MMK_R_J" = 8;
+"@MMK_R_O" = -48;
+"@MMK_R_S" = -44;
+"@MMK_R_a" = -60;
+"@MMK_R_c" = -64;
+"@MMK_R_colon" = -28;
+"@MMK_R_comma" = -28;
+"@MMK_R_d" = -64;
+"@MMK_R_e" = -64;
+"@MMK_R_g" = -48;
+"@MMK_R_i" = -28;
+"@MMK_R_o" = -60;
+"@MMK_R_s" = -44;
+"@MMK_R_u" = -60;
+AE = 20;
+Oslash = -44;
+guillemetleft = -88;
+guillemetright = -80;
+guilsinglleft = -88;
+hyphen = -44;
+m = -52;
+oslash = -56;
+p = -48;
+q = -60;
+v = -64;
+};
+"@MMK_L_Z" = {
+"@MMK_R_O" = -16;
+"@MMK_R_comma" = 52;
+"@MMK_R_y" = -24;
+v = -12;
+};
+"@MMK_L_a" = {
+"@MMK_R_y" = -16;
+quoteright = -28;
+};
+"@MMK_L_c" = {
+"@MMK_R_h" = -12;
+"@MMK_R_k" = -8;
+};
+"@MMK_L_e" = {
+"@MMK_R_w" = 8;
+"@MMK_R_y" = 12;
+quoteright = -12;
+v = 8;
+x = -8;
+};
+"@MMK_L_f" = {
+"@MMK_R_a" = -16;
+"@MMK_R_c" = -24;
+"@MMK_R_comma" = 8;
+"@MMK_R_e" = -16;
+"@MMK_R_f" = 32;
+"@MMK_R_i" = 110;
+"@MMK_R_l" = 148;
+"@MMK_R_o" = -16;
+"@MMK_R_s" = -4;
+"@MMK_R_t" = 28;
+question = 128;
+quotedblleft = 110;
+quotedblright = 128;
+quoteleft = 110;
+quoteright = 128;
+};
+"@MMK_L_g" = {
+"@MMK_R_a" = -28;
+"@MMK_R_e" = -28;
+"@MMK_R_l" = -16;
+"@MMK_R_r" = 16;
+};
+"@MMK_L_h" = {
+"@MMK_R_y" = -20;
+quoteright = -36;
+};
+"@MMK_L_i" = {
+"@MMK_R_T" = -44;
+"@MMK_R_j" = -8;
+};
+"@MMK_L_k" = {
+"@MMK_R_a" = -4;
+"@MMK_R_c" = -8;
+"@MMK_R_comma" = 44;
+"@MMK_R_e" = -4;
+"@MMK_R_s" = 8;
+"@MMK_R_u" = -8;
+"@MMK_R_y" = -8;
+};
+"@MMK_L_l" = {
+"@MMK_R_y" = -40;
+v = -16;
+};
+"@MMK_L_n" = {
+"@MMK_R_y" = -20;
+quoteright = -36;
+};
+"@MMK_L_o" = {
+"@MMK_R_t" = -8;
+quoteright = -28;
+x = -20;
+};
+"@MMK_L_p" = {
+"@MMK_R_y" = -8;
+};
+"@MMK_L_period" = {
+one = 8;
+quotedblright = -32;
+quoteright = -32;
+};
+"@MMK_L_r" = {
+"@MMK_R_a" = -28;
+"@MMK_R_c" = -28;
+"@MMK_R_colon" = -16;
+"@MMK_R_comma" = -56;
+"@MMK_R_d" = -28;
+"@MMK_R_e" = -24;
+"@MMK_R_g" = -24;
+"@MMK_R_h" = -20;
+"@MMK_R_i" = 12;
+"@MMK_R_k" = -20;
+"@MMK_R_l" = -24;
+"@MMK_R_n" = 16;
+"@MMK_R_o" = -28;
+"@MMK_R_s" = -12;
+"@MMK_R_y" = 8;
+b = -20;
+hyphen = -64;
+m = 16;
+oslash = -28;
+q = -28;
+x = -24;
+};
+"@MMK_L_s" = {
+"@MMK_R_t" = -4;
+quoteright = -20;
+};
+"@MMK_L_t" = {
+"@MMK_R_a" = -4;
+"@MMK_R_colon" = 44;
+};
+"@MMK_L_u" = {
+quoteright = -36;
+};
+"@MMK_L_w" = {
+"@MMK_R_colon" = 28;
+"@MMK_R_comma" = 20;
+"@MMK_R_o" = 4;
+hyphen = 20;
+};
+"@MMK_L_y" = {
+"@MMK_R_a" = -32;
+"@MMK_R_c" = -36;
+"@MMK_R_colon" = 16;
+"@MMK_R_comma" = -24;
+"@MMK_R_d" = -32;
+"@MMK_R_e" = -32;
+"@MMK_R_o" = -28;
+"@MMK_R_s" = -16;
+hyphen = -28;
+};
+"@MMK_L_z" = {
+"@MMK_R_e" = -12;
+"@MMK_R_o" = -12;
+};
+B = {
+"@MMK_R_O" = -4;
+"@MMK_R_T" = -16;
+"@MMK_R_W" = -16;
+"@MMK_R_Y" = -44;
+AE = 16;
+V = -20;
+};
+F = {
+"@MMK_R_A" = -80;
+"@MMK_R_J" = -52;
+"@MMK_R_O" = -20;
+"@MMK_R_S" = -20;
+"@MMK_R_a" = -72;
+"@MMK_R_comma" = -64;
+"@MMK_R_e" = -68;
+"@MMK_R_i" = -20;
+"@MMK_R_j" = -20;
+"@MMK_R_o" = -64;
+"@MMK_R_r" = -24;
+"@MMK_R_u" = -28;
+"@MMK_R_y" = -44;
+hyphen = -40;
+oslash = -68;
+};
+Oslash = {
+"@MMK_R_A" = -40;
+};
+P = {
+"@MMK_R_A" = -88;
+"@MMK_R_J" = -64;
+"@MMK_R_Y" = -44;
+"@MMK_R_a" = -76;
+"@MMK_R_c" = -80;
+"@MMK_R_colon" = -44;
+"@MMK_R_comma" = -96;
+"@MMK_R_e" = -76;
+"@MMK_R_o" = -76;
+"@MMK_R_u" = -12;
+"@MMK_R_y" = -28;
+AE = -76;
+guillemetleft = -108;
+hyphen = -72;
+oslash = -76;
+};
+V = {
+"@MMK_R_A" = -88;
+"@MMK_R_C" = -56;
+"@MMK_R_G" = -56;
+"@MMK_R_J" = -56;
+"@MMK_R_O" = -52;
+"@MMK_R_S" = -32;
+"@MMK_R_a" = -88;
+"@MMK_R_c" = -88;
+"@MMK_R_colon" = -44;
+"@MMK_R_comma" = -72;
+"@MMK_R_e" = -80;
+"@MMK_R_g" = -80;
+"@MMK_R_i" = -16;
+"@MMK_R_o" = -80;
+"@MMK_R_r" = -48;
+"@MMK_R_u" = -52;
+"@MMK_R_y" = -64;
+AE = -80;
+Oslash = -52;
+guillemetleft = -100;
+guillemetright = -88;
+guilsinglleft = -100;
+hyphen = -60;
+oslash = -76;
+};
+X = {
+"@MMK_R_C" = -32;
+"@MMK_R_G" = -36;
+"@MMK_R_O" = -32;
+"@MMK_R_T" = -12;
+"@MMK_R_a" = 8;
+"@MMK_R_o" = 12;
+"@MMK_R_u" = 20;
+"@MMK_R_y" = -56;
+Q = -32;
+guillemetleft = -44;
+guillemetright = -20;
+};
+eight = {
+one = -20;
+seven = -20;
+};
+five = {
+one = -36;
+seven = -52;
+};
+four = {
+four = 20;
+one = -12;
+seven = -28;
+};
+guillemetleft = {
+"@MMK_R_T" = -108;
+"@MMK_R_W" = -36;
+"@MMK_R_Y" = -88;
+V = -40;
+};
+guillemetright = {
+"@MMK_R_A" = -36;
+"@MMK_R_J" = -44;
+"@MMK_R_T" = -120;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -100;
+AE = -24;
+V = -52;
+};
+guilsinglleft = {
+"@MMK_R_W" = -36;
+"@MMK_R_Y" = -92;
+V = -40;
+};
+guilsinglright = {
+"@MMK_R_A" = -36;
+"@MMK_R_T" = -120;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -104;
+V = -52;
+};
+hyphen = {
+"@MMK_R_C" = 20;
+"@MMK_R_G" = 16;
+"@MMK_R_J" = -16;
+"@MMK_R_O" = 24;
+"@MMK_R_T" = -80;
+"@MMK_R_W" = -12;
+"@MMK_R_Y" = -64;
+AE = 16;
+V = -12;
+};
+m = {
+"@MMK_R_y" = -20;
+};
+nine = {
+four = -16;
+one = -24;
+seven = -16;
+};
+one = {
+"@MMK_R_comma" = 32;
+eight = -16;
+five = -16;
+four = -32;
+nine = -32;
+one = 16;
+seven = -36;
+six = -24;
+three = -16;
+two = 12;
+zero = -16;
+};
+q = {
+"@MMK_R_u" = -4;
+};
+quotedblbase = {
+"@MMK_R_A" = 36;
+"@MMK_R_T" = -76;
+"@MMK_R_W" = -20;
+"@MMK_R_Y" = -56;
+"@MMK_R_y" = -80;
+AE = 48;
+V = -24;
+};
+quotedblleft = {
+"@MMK_R_A" = -64;
+"@MMK_R_J" = -8;
+"@MMK_R_T" = 16;
+"@MMK_R_W" = 16;
+AE = -52;
+V = 12;
+};
+quotedblright = {
+"@MMK_R_A" = -68;
+"@MMK_R_W" = 20;
+"@MMK_R_Y" = 8;
+AE = -56;
+V = 16;
+};
+quoteleft = {
+"@MMK_R_A" = -60;
+"@MMK_R_J" = -4;
+"@MMK_R_T" = 20;
+"@MMK_R_Y" = 8;
+AE = -48;
+};
+quoteright = {
+"@MMK_R_A" = -68;
+"@MMK_R_d" = -12;
+"@MMK_R_o" = -16;
+"@MMK_R_w" = 16;
+"@MMK_R_y" = 28;
+AE = -56;
+v = 16;
+};
+quotesinglbase = {
+"@MMK_R_T" = -72;
+"@MMK_R_Y" = -56;
+"@MMK_R_y" = -80;
+};
+seven = {
+"@MMK_R_colon" = -8;
+"@MMK_R_comma" = -8;
+eight = -24;
+five = -28;
+four = -52;
+nine = -24;
+one = 24;
+seven = -4;
+six = -32;
+three = -20;
+two = -16;
+};
+six = {
+four = 12;
+one = -32;
+seven = -52;
+};
+three = {
+four = 4;
+one = -20;
+seven = -24;
+};
+two = {
+one = -16;
+seven = -16;
+};
+v = {
+"@MMK_R_c" = -4;
+"@MMK_R_colon" = 24;
+"@MMK_R_comma" = 12;
+hyphen = 20;
+};
+x = {
+"@MMK_R_a" = -12;
+"@MMK_R_c" = -12;
+"@MMK_R_e" = -8;
+"@MMK_R_o" = -4;
+};
+zero = {
+one = -20;
+seven = -28;
+};
+};
+"DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC" = {
+"@MMK_L_A" = {
+"@MMK_R_A" = -24;
+"@MMK_R_C" = -28;
+"@MMK_R_G" = -32;
+"@MMK_R_O" = -28;
+"@MMK_R_S" = -8;
+"@MMK_R_T" = -64;
+"@MMK_R_U" = -48;
+"@MMK_R_W" = -36;
+"@MMK_R_Y" = -52;
+"@MMK_R_a" = -16;
+"@MMK_R_c" = -12;
+"@MMK_R_comma" = 20;
+"@MMK_R_d" = -20;
+"@MMK_R_e" = -16;
+"@MMK_R_f" = -16;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = -8;
+"@MMK_R_t" = -20;
+"@MMK_R_u" = -20;
+"@MMK_R_w" = -28;
+"@MMK_R_y" = -44;
+Q = -32;
+V = -44;
+b = -8;
+guillemetleft = -40;
+guilsinglleft = -44;
+hyphen = -4;
+q = -20;
+quotedblleft = -16;
+quotedblright = -24;
+quoteleft = -20;
+quoteright = -28;
+v = -24;
+};
+"@MMK_L_AE" = {
+"@MMK_R_C" = -8;
+"@MMK_R_T" = -20;
+"@MMK_R_W" = -8;
+V = -24;
+v = -16;
+};
+"@MMK_L_C" = {
+"@MMK_R_A" = 20;
+"@MMK_R_H" = -4;
+"@MMK_R_K" = -16;
+"@MMK_R_O" = -4;
+"@MMK_R_comma" = 40;
+"@MMK_R_y" = -44;
+AE = 40;
+};
+"@MMK_L_D" = {
+"@MMK_R_A" = -56;
+"@MMK_R_Eng" = -32;
+"@MMK_R_J" = -32;
+"@MMK_R_T" = -28;
+"@MMK_R_W" = -24;
+"@MMK_R_Y" = -72;
+V = -32;
+X = -48;
+};
+"@MMK_L_G" = {
+"@MMK_R_A" = -24;
+"@MMK_R_T" = -56;
+"@MMK_R_W" = -16;
+"@MMK_R_Y" = -64;
+"@MMK_R_comma" = 20;
+AE = -12;
+V = -32;
+};
+"@MMK_L_H" = {
+"@MMK_R_comma" = 8;
+};
+"@MMK_L_IJ" = {
+"@MMK_R_A" = -28;
+"@MMK_R_a" = -24;
+"@MMK_R_e" = -24;
+"@MMK_R_o" = -28;
+"@MMK_R_u" = -32;
+AE = -12;
+};
+"@MMK_L_K" = {
+"@MMK_R_A" = 18;
+"@MMK_R_C" = -44;
+"@MMK_R_G" = -48;
+"@MMK_R_O" = -52;
+"@MMK_R_S" = 28;
+"@MMK_R_T" = -32;
+"@MMK_R_U" = -52;
+"@MMK_R_W" = -24;
+"@MMK_R_Y" = -20;
+"@MMK_R_a" = -8;
+"@MMK_R_e" = -12;
+"@MMK_R_o" = -4;
+"@MMK_R_w" = -24;
+"@MMK_R_y" = -84;
+Oslash = -24;
+guillemetleft = -64;
+hyphen = -20;
+oslash = 16;
+v = -20;
+};
+"@MMK_L_L" = {
+"@MMK_R_A" = -18;
+"@MMK_R_C" = -8;
+"@MMK_R_G" = -12;
+"@MMK_R_O" = -12;
+"@MMK_R_S" = -4;
+"@MMK_R_T" = -68;
+"@MMK_R_U" = -36;
+"@MMK_R_W" = -36;
+"@MMK_R_Y" = -56;
+"@MMK_R_u" = 8;
+"@MMK_R_y" = -12;
+V = -48;
+hyphen = 44;
+quotedblleft = -76;
+quotedblright = -80;
+quoteleft = -80;
+quoteright = -88;
+};
+"@MMK_L_N" = {
+"@MMK_R_A" = -12;
+"@MMK_R_C" = -20;
+"@MMK_R_G" = -24;
+"@MMK_R_O" = -20;
+"@MMK_R_a" = -16;
+"@MMK_R_comma" = 8;
+"@MMK_R_e" = -12;
+"@MMK_R_o" = -16;
+"@MMK_R_u" = -20;
+};
+"@MMK_L_O" = {
+"@MMK_R_A" = -40;
+"@MMK_R_T" = -12;
+"@MMK_R_W" = -12;
+"@MMK_R_Y" = -60;
+"@MMK_R_Z" = -24;
+AE = -36;
+V = -20;
+X = -36;
+};
+"@MMK_L_R" = {
+"@MMK_R_C" = -16;
+"@MMK_R_G" = -20;
+"@MMK_R_O" = -16;
+"@MMK_R_T" = -24;
+"@MMK_R_U" = -32;
+"@MMK_R_W" = -20;
+"@MMK_R_Y" = -24;
+"@MMK_R_a" = -8;
+"@MMK_R_colon" = 56;
+"@MMK_R_e" = -12;
+"@MMK_R_y" = -56;
+V = -28;
+guillemetleft = -36;
+quotedblleft = 12;
+quotedblright = 8;
+quoteleft = 8;
+};
+"@MMK_L_S" = {
+"@MMK_R_A" = -4;
+"@MMK_R_T" = -32;
+"@MMK_R_W" = -12;
+"@MMK_R_Y" = -52;
+AE = 12;
+V = -24;
+};
+"@MMK_L_T" = {
+"@MMK_R_A" = -32;
+"@MMK_R_C" = -20;
+"@MMK_R_G" = -20;
+"@MMK_R_J" = -16;
+"@MMK_R_O" = -12;
+"@MMK_R_S" = -12;
+"@MMK_R_Y" = -16;
+"@MMK_R_a" = -96;
+"@MMK_R_c" = -92;
+"@MMK_R_colon" = -32;
+"@MMK_R_comma" = -68;
+"@MMK_R_dotlessi" = -12;
+"@MMK_R_dotlessj" = -8;
+"@MMK_R_e" = -96;
+"@MMK_R_g" = -72;
+"@MMK_R_h" = -24;
+"@MMK_R_o" = -92;
+"@MMK_R_r" = -92;
+"@MMK_R_s" = -80;
+"@MMK_R_u" = -96;
+"@MMK_R_w" = -104;
+"@MMK_R_y" = -116;
+AE = -16;
+V = -24;
+guillemetleft = -120;
+guillemetright = -104;
+guilsinglleft = -124;
+hyphen = -84;
+m = -88;
+oslash = -84;
+v = -100;
+};
+"@MMK_L_U" = {
+"@MMK_R_A" = -44;
+"@MMK_R_comma" = -8;
+"@MMK_R_eng" = -24;
+"@MMK_R_r" = -28;
+AE = -28;
+m = -20;
+p = -16;
+};
+"@MMK_L_W" = {
+"@MMK_R_A" = -108;
+"@MMK_R_C" = -64;
+"@MMK_R_G" = -64;
+"@MMK_R_O" = -52;
+"@MMK_R_S" = -28;
+"@MMK_R_a" = -96;
+"@MMK_R_c" = -92;
+"@MMK_R_colon" = -32;
+"@MMK_R_comma" = -104;
+"@MMK_R_d" = -100;
+"@MMK_R_dotlessi" = -16;
+"@MMK_R_e" = -96;
+"@MMK_R_g" = -88;
+"@MMK_R_h" = -20;
+"@MMK_R_o" = -100;
+"@MMK_R_r" = -52;
+"@MMK_R_u" = -48;
+"@MMK_R_y" = -84;
+AE = -104;
+Oslash = -56;
+guillemetleft = -124;
+guillemetright = -92;
+guilsinglleft = -128;
+hyphen = -88;
+oslash = -96;
+};
+"@MMK_L_Y" = {
+"@MMK_R_A" = -16;
+"@MMK_R_C" = -56;
+"@MMK_R_G" = -60;
+"@MMK_R_O" = -48;
+"@MMK_R_S" = -48;
+"@MMK_R_a" = -68;
+"@MMK_R_c" = -64;
+"@MMK_R_colon" = -4;
+"@MMK_R_comma" = -44;
+"@MMK_R_d" = -68;
+"@MMK_R_dotlessi" = -44;
+"@MMK_R_e" = -68;
+"@MMK_R_g" = -56;
+"@MMK_R_o" = -68;
+"@MMK_R_s" = -60;
+"@MMK_R_u" = -60;
+Oslash = -48;
+guillemetleft = -92;
+guillemetright = -76;
+guilsinglleft = -96;
+hyphen = -64;
+m = -56;
+oslash = -64;
+p = -52;
+q = -68;
+v = -76;
+};
+"@MMK_L_Z" = {
+"@MMK_R_O" = -20;
+"@MMK_R_comma" = 28;
+"@MMK_R_y" = -36;
+v = -24;
+};
+"@MMK_L_a" = {
+"@MMK_R_y" = -20;
+quoteright = -16;
+};
+"@MMK_L_ae" = {
+"@MMK_R_t" = -4;
+"@MMK_R_w" = -8;
+"@MMK_R_y" = -4;
+quoteright = -8;
+v = -4;
+x = -8;
+};
+"@MMK_L_c" = {
+"@MMK_R_h" = 4;
+"@MMK_R_k" = 4;
+};
+"@MMK_L_comma" = {
+one = 20;
+quotedblright = -12;
+quoteright = -20;
+};
+"@MMK_L_dotlessi" = {
+"@MMK_R_T" = -40;
+"@MMK_R_dotlessj" = 8;
+};
+"@MMK_L_f" = {
+"@MMK_R_a" = -8;
+"@MMK_R_c" = -4;
+"@MMK_R_comma" = 8;
+"@MMK_R_dotlessi" = 98;
+"@MMK_R_e" = -8;
+"@MMK_R_f" = 44;
+"@MMK_R_l" = 118;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = 8;
+"@MMK_R_t" = 32;
+question = 158;
+quotedblleft = 162;
+quotedblright = 162;
+quoteleft = 162;
+quoteright = 162;
+};
+"@MMK_L_f_f_l" = {
+"@MMK_R_y" = -36;
+v = -12;
+};
+"@MMK_L_g" = {
+"@MMK_R_a" = -16;
+"@MMK_R_comma" = -8;
+"@MMK_R_e" = -20;
+"@MMK_R_l" = -8;
+"@MMK_R_r" = 24;
+};
+"@MMK_L_h" = {
+"@MMK_R_y" = -24;
+quoteright = -24;
+};
+"@MMK_L_k" = {
+"@MMK_R_a" = 12;
+"@MMK_R_c" = 16;
+"@MMK_R_comma" = 44;
+"@MMK_R_e" = 12;
+"@MMK_R_g" = 20;
+"@MMK_R_o" = 12;
+"@MMK_R_s" = 14;
+"@MMK_R_u" = 8;
+"@MMK_R_y" = -4;
+hyphen = 12;
+};
+"@MMK_L_n" = {
+"@MMK_R_y" = -20;
+p = 12;
+quoteright = -24;
+};
+"@MMK_L_o" = {
+"@MMK_R_t" = -8;
+"@MMK_R_w" = -8;
+"@MMK_R_y" = -4;
+quoteright = -24;
+v = -4;
+x = -12;
+};
+"@MMK_L_p" = {
+"@MMK_R_y" = -8;
+};
+"@MMK_L_r" = {
+"@MMK_R_a" = -12;
+"@MMK_R_c" = -8;
+"@MMK_R_colon" = 24;
+"@MMK_R_comma" = -56;
+"@MMK_R_d" = -16;
+"@MMK_R_dotlessi" = 16;
+"@MMK_R_e" = -12;
+"@MMK_R_eng" = 16;
+"@MMK_R_f" = 20;
+"@MMK_R_g" = -4;
+"@MMK_R_h" = -12;
+"@MMK_R_k" = -12;
+"@MMK_R_l" = -16;
+"@MMK_R_o" = -16;
+"@MMK_R_r" = 12;
+"@MMK_R_t" = 8;
+"@MMK_R_u" = 20;
+"@MMK_R_w" = 12;
+"@MMK_R_y" = 12;
+hyphen = -64;
+m = 16;
+oslash = -16;
+q = -12;
+v = 12;
+};
+"@MMK_L_s" = {
+"@MMK_R_t" = -8;
+quoteright = -16;
+};
+"@MMK_L_t" = {
+"@MMK_R_colon" = 52;
+};
+"@MMK_L_u" = {
+quoteright = -20;
+};
+"@MMK_L_w" = {
+"@MMK_R_c" = 4;
+"@MMK_R_colon" = 56;
+"@MMK_R_comma" = 12;
+hyphen = 12;
+};
+"@MMK_L_y" = {
+"@MMK_R_a" = -12;
+"@MMK_R_c" = -8;
+"@MMK_R_colon" = 40;
+"@MMK_R_comma" = -28;
+"@MMK_R_d" = -12;
+"@MMK_R_e" = -8;
+"@MMK_R_o" = -16;
+hyphen = -28;
+};
+B = {
+"@MMK_R_A" = -16;
+"@MMK_R_O" = -8;
+"@MMK_R_T" = -28;
+"@MMK_R_W" = -16;
+"@MMK_R_Y" = -60;
+Oslash = -8;
+V = -28;
+};
+F = {
+"@MMK_R_A" = -88;
+"@MMK_R_J" = -64;
+"@MMK_R_O" = -32;
+"@MMK_R_S" = -24;
+"@MMK_R_a" = -76;
+"@MMK_R_comma" = -80;
+"@MMK_R_dotlessi" = -36;
+"@MMK_R_dotlessj" = -32;
+"@MMK_R_e" = -76;
+"@MMK_R_o" = -76;
+"@MMK_R_r" = -48;
+"@MMK_R_u" = -48;
+"@MMK_R_y" = -76;
+hyphen = -60;
+oslash = -72;
+};
+Oslash = {
+"@MMK_R_A" = -40;
+};
+P = {
+"@MMK_R_A" = -92;
+"@MMK_R_J" = -68;
+"@MMK_R_Y" = -52;
+"@MMK_R_a" = -80;
+"@MMK_R_c" = -76;
+"@MMK_R_colon" = -20;
+"@MMK_R_comma" = -108;
+"@MMK_R_e" = -76;
+"@MMK_R_o" = -84;
+"@MMK_R_u" = -4;
+"@MMK_R_y" = -44;
+AE = -96;
+guillemetleft = -116;
+hyphen = -88;
+oslash = -84;
+};
+V = {
+"@MMK_R_A" = -96;
+"@MMK_R_C" = -56;
+"@MMK_R_G" = -56;
+"@MMK_R_J" = -52;
+"@MMK_R_O" = -48;
+"@MMK_R_S" = -20;
+"@MMK_R_a" = -84;
+"@MMK_R_c" = -80;
+"@MMK_R_colon" = -28;
+"@MMK_R_comma" = -92;
+"@MMK_R_dotlessi" = -12;
+"@MMK_R_e" = -84;
+"@MMK_R_g" = -84;
+"@MMK_R_o" = -88;
+"@MMK_R_r" = -44;
+"@MMK_R_u" = -40;
+"@MMK_R_y" = -76;
+AE = -92;
+Oslash = -52;
+guillemetleft = -112;
+guillemetright = -84;
+guilsinglleft = -116;
+hyphen = -76;
+oslash = -88;
+};
+X = {
+"@MMK_R_C" = -40;
+"@MMK_R_G" = -44;
+"@MMK_R_O" = -40;
+"@MMK_R_T" = -32;
+"@MMK_R_a" = -4;
+"@MMK_R_e" = -12;
+"@MMK_R_u" = 4;
+"@MMK_R_y" = -72;
+Oslash = -20;
+Q = -48;
+guillemetleft = -48;
+hyphen = -12;
+};
+b = {
+"@MMK_R_w" = -16;
+"@MMK_R_y" = -12;
+v = -12;
+};
+eight = {
+four = -4;
+one = -32;
+seven = -16;
+};
+five = {
+four = -4;
+one = -32;
+seven = -40;
+};
+four = {
+four = 16;
+one = -16;
+seven = -24;
+};
+guillemetleft = {
+"@MMK_R_T" = -100;
+"@MMK_R_W" = -24;
+"@MMK_R_Y" = -92;
+V = -36;
+};
+guillemetright = {
+"@MMK_R_A" = -32;
+"@MMK_R_J" = -36;
+"@MMK_R_T" = -116;
+"@MMK_R_W" = -44;
+"@MMK_R_Y" = -108;
+AE = -24;
+V = -52;
+};
+guilsinglleft = {
+"@MMK_R_W" = -32;
+"@MMK_R_Y" = -100;
+V = -48;
+};
+guilsinglright = {
+"@MMK_R_A" = -36;
+"@MMK_R_T" = -120;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -116;
+V = -60;
+};
+hyphen = {
+"@MMK_R_C" = 16;
+"@MMK_R_G" = 12;
+"@MMK_R_J" = -24;
+"@MMK_R_O" = 12;
+"@MMK_R_T" = -84;
+"@MMK_R_W" = -12;
+"@MMK_R_Y" = -76;
+AE = 8;
+V = -24;
+};
+m = {
+"@MMK_R_y" = -12;
+v = 8;
+};
+nine = {
+four = -8;
+one = -24;
+};
+one = {
+"@MMK_R_comma" = 8;
+eight = -24;
+five = -24;
+four = -44;
+nine = -36;
+one = 16;
+seven = -36;
+six = -28;
+three = -12;
+two = 12;
+zero = -24;
+};
+quotedblbase = {
+"@MMK_R_A" = 40;
+"@MMK_R_T" = -60;
+"@MMK_R_W" = -4;
+"@MMK_R_Y" = -56;
+"@MMK_R_y" = -80;
+AE = 56;
+V = -16;
+};
+quotedblleft = {
+"@MMK_R_A" = -56;
+"@MMK_R_T" = 28;
+"@MMK_R_W" = 40;
+"@MMK_R_Y" = 8;
+AE = -64;
+V = 28;
+};
+quotedblright = {
+"@MMK_R_A" = -56;
+"@MMK_R_W" = 40;
+"@MMK_R_Y" = 12;
+AE = -68;
+V = 28;
+};
+quoteleft = {
+"@MMK_R_A" = -68;
+"@MMK_R_J" = -16;
+"@MMK_R_T" = 12;
+"@MMK_R_Y" = -4;
+AE = -80;
+};
+quoteright = {
+"@MMK_R_A" = -68;
+"@MMK_R_comma" = -8;
+"@MMK_R_d" = -12;
+"@MMK_R_o" = -16;
+"@MMK_R_s" = 4;
+"@MMK_R_w" = 16;
+"@MMK_R_y" = 16;
+AE = -76;
+v = 20;
+};
+quotesinglbase = {
+"@MMK_R_T" = -68;
+"@MMK_R_Y" = -60;
+"@MMK_R_y" = -88;
+};
+seven = {
+"@MMK_R_colon" = 16;
+"@MMK_R_comma" = -28;
+eight = -28;
+five = -24;
+four = -56;
+nine = -28;
+one = 20;
+seven = -4;
+six = -36;
+three = -20;
+two = -8;
+};
+six = {
+four = 12;
+one = -32;
+seven = -40;
+};
+three = {
+four = -4;
+one = -36;
+seven = -28;
+};
+two = {
+one = -16;
+seven = -12;
+};
+v = {
+"@MMK_R_a" = -4;
+"@MMK_R_colon" = 18;
+"@MMK_R_e" = -4;
+"@MMK_R_o" = -4;
+"@MMK_R_s" = -4;
+hyphen = 8;
+};
+zero = {
+one = -28;
+seven = -16;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = dflt;
+value = "Copyright 2012 The Libre Bodoni Project Authors (https://github.com/googlefonts/Libre-Bodoni/)";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = dflt;
+value = "Pablo Impallari, Rodrigo Fuenzalida";
+}
+);
+},
+{
+key = designerURL;
+value = www.impallari.com;
+},
+{
+key = manufacturers;
+values = (
+{
+language = dflt;
+value = "Impallari Type";
+}
+);
+},
+{
+key = manufacturerURL;
+value = www.impallari.com;
+},
+{
+key = licenseURL;
+value = "https://scripts.sil.org/OFL";
+},
+{
+key = descriptions;
+values = (
+{
+language = dflt;
+value = "Libre Bodoni is a webfont family optimized for body text. Based on 1923 ATF Specimens.";
+}
+);
+},
+{
+key = trademarks;
+values = (
+{
+language = dflt;
+value = "Libre Bodoni is a trademark of Impallari Type.";
+}
+);
+},
+{
+key = licenses;
+values = (
+{
+language = dflt;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://scripts.sil.org/OFL";
+}
+);
+}
+);
+stems = (
+{
+horizontal = 1;
+name = hStem0;
+},
+{
+name = vStem0;
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDimensionPlugin.Dimensions = {
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = {
+nV = "138";
+oH = "35";
+};
+"426C3F01-D24D-4224-A47E-56DA036E4742" = {
+nV = "103";
+oH = "25";
+};
+"DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC" = {
+nV = "138";
+oH = "35";
+};
+UUID0 = {
+nV = "110";
+oH = "30";
+};
+};
+};
+versionMajor = 2;
+versionMinor = 3;
+}

--- a/data/test/Libre-Bodoni/sources/LibreBodoni.glyphs
+++ b/data/test/Libre-Bodoni/sources/LibreBodoni.glyphs
@@ -1,0 +1,59114 @@
+{
+.appVersion = "3108";
+copyright = "Copyright 2012 The Libre Bodoni Project Authors (https://github.com/googlefonts/Libre-Bodoni/)";
+customParameters = (
+{
+name = panose;
+value = (
+2,
+7,
+5,
+3,
+7,
+6,
+0,
+0,
+0,
+3
+);
+},
+{
+name = "Axis Mappings";
+value = {
+wght = {
+400 = 400;
+500 = 550;
+700 = 700;
+};
+};
+},
+{
+name = fsType;
+value = (
+);
+},
+{
+name = "Use Line Breaks";
+value = 1;
+},
+{
+name = "Use Typo Metrics";
+value = 1;
+},
+{
+name = "Variable Font Origin";
+value = UUID0;
+},
+{
+name = licenseURL;
+value = "https://scripts.sil.org/OFL";
+},
+{
+name = description;
+value = "Libre Bodoni is a webfont family optimized for body text. Based on 1923 ATF Specimens.";
+},
+{
+name = trademark;
+value = "Libre Bodoni is a trademark of Impallari Type.";
+},
+{
+name = license;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://scripts.sil.org/OFL";
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+date = "2016-08-16 10:50:52 +0000";
+designer = "Pablo Impallari, Rodrigo Fuenzalida";
+designerURL = www.impallari.com;
+familyName = "Libre Bodoni";
+features = (
+{
+code = "sub f f i by f_f_i;
+	sub f f l by f_f_l;
+  sub f f by f_f;
+  sub f i by f_i;
+  sub f l by f_l;
+";
+name = liga;
+},
+{
+code = "sub [zero one two three four five six seven eight nine] [A a]' by [ordfeminine ordfeminine];
+	sub [zero one two three four five six seven eight nine] [O o]' by [ordmasculine ordmasculine];
+	sub [zero one two three four five six seven eight nine] period [A a]' by [ordfeminine ordfeminine];
+	sub [zero one two three four five six seven eight nine] period [O o]' by [ordmasculine ordmasculine];
+";
+name = ordn;
+},
+{
+code = "sub one [slash fraction] two by onehalf;
+	sub one [slash fraction] three by onethird;
+	sub one [slash fraction] four by onequarter;
+	sub one [slash fraction] eight by oneeighth;
+	sub two [slash fraction] three by twothirds;
+	sub three [slash fraction] four by threequarters;
+	sub three [slash fraction] eight by threeeighths;
+	sub five [slash fraction] eight by fiveeighths;
+	sub seven [slash fraction] eight by seveneighths;
+";
+name = frac;
+},
+{
+code = "sub zero by zerosuperior;
+	sub one by onesuperior;
+	sub two by twosuperior;
+	sub three by threesuperior;
+	sub four by foursuperior;
+	sub five by fivesuperior;
+	sub six by sixsuperior;
+	sub seven by sevensuperior;
+	sub eight by eightsuperior;
+	sub nine by ninesuperior;
+";
+name = sups;
+},
+{
+code = "sub zero by zeroinferior;
+	sub one by oneinferior;
+	sub two by twoinferior;
+	sub three by threeinferior;
+	sub four by fourinferior;
+	sub five by fiveinferior;
+	sub six by sixinferior;
+	sub seven by seveninferior;
+	sub eight by eightinferior;
+	sub nine by nineinferior;
+";
+name = sinf;
+},
+{
+code = "sub zero by zero.numerator;
+	sub one by one.numerator;
+	sub two by two.numerator;
+	sub three by three.numerator;
+	sub four by four.numerator;
+	sub five by five.numerator;
+	sub six by six.numerator;
+	sub seven by seven.numerator;
+	sub eight by eight.numerator;
+	sub nine by nine.numerator;
+";
+name = numr;
+},
+{
+code = "sub zero by zero.denominator;
+	sub one by one.denominator;
+	sub two by two.denominator;
+	sub three by three.denominator;
+	sub four by four.denominator;
+	sub five by five.denominator;
+	sub six by six.denominator;
+	sub seven by seven.denominator;
+	sub eight by eight.denominator;
+	sub nine by nine.denominator;
+";
+name = dnom;
+}
+);
+fontMaster = (
+{
+alignmentZones = (
+"{754, 12}",
+"{754, 12}",
+"{450, 12}",
+"{0, -12}",
+"{-314, -12}"
+);
+ascender = 754;
+capHeight = 754;
+customParameters = (
+{
+name = typoAscender;
+value = 924;
+},
+{
+name = typoDescender;
+value = -326;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = hheaAscender;
+value = 924;
+},
+{
+name = hheaDescender;
+value = -326;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1184;
+},
+{
+name = winDescent;
+value = 326;
+}
+);
+descender = -314;
+horizontalStems = (
+30
+);
+id = UUID0;
+verticalStems = (
+110
+);
+weightValue = 400;
+xHeight = 450;
+},
+{
+alignmentZones = (
+"{754, 12}",
+"{754, 12}",
+"{450, 12}",
+"{0, -12}",
+"{-314, -12}"
+);
+ascender = 754;
+capHeight = 754;
+customParameters = (
+{
+name = typoAscender;
+value = 924;
+},
+{
+name = typoDescender;
+value = -326;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = hheaAscender;
+value = 924;
+},
+{
+name = hheaDescender;
+value = -326;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1184;
+},
+{
+name = winDescent;
+value = 326;
+}
+);
+descender = -314;
+horizontalStems = (
+35
+);
+id = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+verticalStems = (
+138
+);
+weight = Bold;
+weightValue = 700;
+xHeight = 450;
+}
+);
+glyphs = (
+{
+glyphname = A;
+lastChange = "2016-08-22 11:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{343, 0}";
+},
+{
+name = ogonek;
+position = "{590, 44}";
+},
+{
+name = top;
+position = "{343, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"508 15 LINE",
+"642 15 LINE",
+"391 763 LINE",
+"361 763 LINE",
+"313 594 LINE",
+"320 565 LINE",
+"324 565 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"388 0 LINE",
+"735 0 LINE",
+"735 25 LINE",
+"388 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 236 LINE",
+"533 236 LINE",
+"533 261 LINE",
+"209 261 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"254 0 LINE",
+"254 25 LINE",
+"10 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"330 594 LINE",
+"391 763 LINE",
+"361 763 LINE",
+"100 15 LINE",
+"133 15 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"612 15 LINE",
+"361 766 LINE",
+"331 766 LINE",
+"283 594 LINE",
+"290 565 LINE",
+"294 565 LINE",
+"478 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 0 LINE",
+"224 25 LINE",
+"-16 25 LINE",
+"-16 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"503 236 LINE",
+"503 261 LINE",
+"179 261 LINE",
+"179 236 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"701 0 LINE",
+"701 25 LINE",
+"358 25 LINE",
+"358 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"103 15 LINE",
+"300 594 LINE",
+"361 766 LINE",
+"331 766 LINE",
+"70 15 LINE"
+);
+}
+);
+width = 686;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{358, 0}";
+},
+{
+name = ogonek;
+position = "{643, 10}";
+},
+{
+name = top;
+position = "{383, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"349 752 OFFCURVE",
+"346 744 OFFCURVE",
+"332 696 CURVE",
+"329 689 OFFCURVE",
+"326 682 OFFCURVE",
+"324 680 CURVE",
+"324 679 OFFCURVE",
+"323 675 OFFCURVE",
+"321 671 CURVE SMOOTH",
+"320 667 OFFCURVE",
+"316 655 OFFCURVE",
+"313 646 CURVE",
+"308 638 OFFCURVE",
+"301 616 OFFCURVE",
+"296 600 CURVE SMOOTH",
+"278 547 OFFCURVE",
+"271 529 OFFCURVE",
+"266 520 CURVE SMOOTH",
+"260 508 OFFCURVE",
+"254 490 OFFCURVE",
+"246 466 CURVE",
+"245 457 OFFCURVE",
+"241 446 OFFCURVE",
+"240 446 CURVE",
+"240 445 OFFCURVE",
+"238 441 OFFCURVE",
+"237 437 CURVE SMOOTH",
+"235 433 OFFCURVE",
+"231 426 OFFCURVE",
+"229 421 CURVE SMOOTH",
+"228 418 OFFCURVE",
+"224 412 OFFCURVE",
+"223 404 CURVE SMOOTH",
+"220 391 OFFCURVE",
+"212 368 OFFCURVE",
+"203 353 CURVE SMOOTH",
+"199 346 OFFCURVE",
+"195 331 OFFCURVE",
+"190 318 CURVE SMOOTH",
+"184 306 OFFCURVE",
+"178 291 OFFCURVE",
+"176 286 CURVE SMOOTH",
+"173 281 OFFCURVE",
+"171 276 OFFCURVE",
+"171 274 CURVE SMOOTH",
+"171 273 OFFCURVE",
+"162 248 OFFCURVE",
+"148 203 CURVE",
+"145 190 OFFCURVE",
+"137 178 OFFCURVE",
+"136 170 CURVE",
+"132 164 OFFCURVE",
+"128 153 OFFCURVE",
+"126 145 CURVE SMOOTH",
+"121 132 OFFCURVE",
+"109 98 OFFCURVE",
+"99 77 CURVE",
+"96 65 OFFCURVE",
+"76 47 OFFCURVE",
+"65 42 CURVE SMOOTH",
+"62 40 OFFCURVE",
+"49 39 OFFCURVE",
+"32 39 CURVE",
+"3 37 OFFCURVE",
+"-3 36 OFFCURVE",
+"-6 27 CURVE SMOOTH",
+"-10 19 OFFCURVE",
+"-8 11 OFFCURVE",
+"-3 5 CURVE",
+"0 0 LINE",
+"62 0 LINE SMOOTH",
+"94 0 OFFCURVE",
+"128 0 OFFCURVE",
+"132 2 CURVE",
+"135 2 OFFCURVE",
+"161 2 OFFCURVE",
+"186 0 CURVE",
+"231 -2 LINE",
+"238 5 LINE",
+"243 8 OFFCURVE",
+"243 12 OFFCURVE",
+"243 19 CURVE SMOOTH",
+"243 36 OFFCURVE",
+"232 42 OFFCURVE",
+"207 44 CURVE",
+"198 44 OFFCURVE",
+"186 44 OFFCURVE",
+"179 42 CURVE",
+"157 39 OFFCURVE",
+"145 45 OFFCURVE",
+"140 64 CURVE",
+"140 69 OFFCURVE",
+"162 111 OFFCURVE",
+"162 132 CURVE",
+"165 139 OFFCURVE",
+"170 148 OFFCURVE",
+"171 156 CURVE",
+"177 173 OFFCURVE",
+"191 194 OFFCURVE",
+"191 198 CURVE",
+"207 206 OFFCURVE",
+"223 207 OFFCURVE",
+"316 207 CURVE SMOOTH",
+"342 207 OFFCURVE",
+"373 209 OFFCURVE",
+"385 209 CURVE",
+"398 211 OFFCURVE",
+"410 211 OFFCURVE",
+"410 209 CURVE",
+"414 206 OFFCURVE",
+"428 181 OFFCURVE",
+"440 140 CURVE SMOOTH",
+"444 132 OFFCURVE",
+"450 114 OFFCURVE",
+"454 100 CURVE SMOOTH",
+"463 72 OFFCURVE",
+"465 59 OFFCURVE",
+"458 50 CURVE SMOOTH",
+"455 45 OFFCURVE",
+"454 45 OFFCURVE",
+"432 45 CURVE SMOOTH",
+"408 44 OFFCURVE",
+"407 44 OFFCURVE",
+"396 37 CURVE SMOOTH",
+"391 34 OFFCURVE",
+"385 28 OFFCURVE",
+"385 25 CURVE",
+"382 19 OFFCURVE",
+"385 8 OFFCURVE",
+"391 3 CURVE SMOOTH",
+"396 0 OFFCURVE",
+"400 0 OFFCURVE",
+"429 0 CURVE",
+"487 2 OFFCURVE",
+"567 0 OFFCURVE",
+"649 0 CURVE",
+"695 -2 OFFCURVE",
+"733 -2 OFFCURVE",
+"736 -2 CURVE SMOOTH",
+"746 -2 OFFCURVE",
+"750 2 OFFCURVE",
+"755 11 CURVE",
+"758 19 OFFCURVE",
+"756 27 OFFCURVE",
+"748 36 CURVE SMOOTH",
+"742 40 LINE",
+"709 40 LINE SMOOTH",
+"689 40 OFFCURVE",
+"675 40 OFFCURVE",
+"674 42 CURVE SMOOTH",
+"674 44 OFFCURVE",
+"671 50 OFFCURVE",
+"667 59 CURVE",
+"666 67 OFFCURVE",
+"661 78 OFFCURVE",
+"659 84 CURVE SMOOTH",
+"658 89 OFFCURVE",
+"653 100 OFFCURVE",
+"649 109 CURVE SMOOTH",
+"647 117 OFFCURVE",
+"641 132 OFFCURVE",
+"636 144 CURVE",
+"633 156 OFFCURVE",
+"624 174 OFFCURVE",
+"619 187 CURVE",
+"616 201 OFFCURVE",
+"609 214 OFFCURVE",
+"608 217 CURVE SMOOTH",
+"605 223 OFFCURVE",
+"602 231 OFFCURVE",
+"600 237 CURVE SMOOTH",
+"597 246 OFFCURVE",
+"594 256 OFFCURVE",
+"591 262 CURVE",
+"589 270 OFFCURVE",
+"582 282 OFFCURVE",
+"579 295 CURVE",
+"575 306 OFFCURVE",
+"571 318 OFFCURVE",
+"567 323 CURVE",
+"558 345 OFFCURVE",
+"550 365 OFFCURVE",
+"546 379 CURVE",
+"535 407 OFFCURVE",
+"521 448 OFFCURVE",
+"516 463 CURVE SMOOTH",
+"512 470 OFFCURVE",
+"505 488 OFFCURVE",
+"500 502 CURVE",
+"474 582 OFFCURVE",
+"463 607 OFFCURVE",
+"457 622 CURVE",
+"450 635 OFFCURVE",
+"447 646 OFFCURVE",
+"432 683 CURVE SMOOTH",
+"429 691 OFFCURVE",
+"425 702 OFFCURVE",
+"424 711 CURVE",
+"416 731 OFFCURVE",
+"405 755 OFFCURVE",
+"399 759 CURVE",
+"395 763 OFFCURVE",
+"391 764 OFFCURVE",
+"377 764 CURVE SMOOTH",
+"362 764 OFFCURVE",
+"360 763 OFFCURVE",
+"357 759 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 487 OFFCURVE",
+"333 435 OFFCURVE",
+"345 398 CURVE SMOOTH",
+"349 387 OFFCURVE",
+"356 368 OFFCURVE",
+"358 356 CURVE",
+"363 343 OFFCURVE",
+"368 329 OFFCURVE",
+"370 324 CURVE",
+"373 320 OFFCURVE",
+"377 311 OFFCURVE",
+"379 304 CURVE SMOOTH",
+"380 299 OFFCURVE",
+"382 291 OFFCURVE",
+"383 290 CURVE SMOOTH",
+"387 284 OFFCURVE",
+"393 262 OFFCURVE",
+"393 257 CURVE SMOOTH",
+"393 254 OFFCURVE",
+"393 253 OFFCURVE",
+"391 251 CURVE SMOOTH",
+"388 249 OFFCURVE",
+"355 248 OFFCURVE",
+"337 249 CURVE SMOOTH",
+"313 251 OFFCURVE",
+"265 251 OFFCURVE",
+"254 249 CURVE SMOOTH",
+"251 249 OFFCURVE",
+"241 249 OFFCURVE",
+"232 251 CURVE",
+"209 253 OFFCURVE",
+"206 259 OFFCURVE",
+"216 281 CURVE",
+"220 286 OFFCURVE",
+"226 299 OFFCURVE",
+"229 309 CURVE SMOOTH",
+"232 320 OFFCURVE",
+"238 332 OFFCURVE",
+"240 340 CURVE SMOOTH",
+"243 348 OFFCURVE",
+"248 366 OFFCURVE",
+"256 383 CURVE",
+"279 448 OFFCURVE",
+"297 495 OFFCURVE",
+"299 499 CURVE SMOOTH",
+"301 502 OFFCURVE",
+"305 502 OFFCURVE",
+"307 496 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"666 15 LINE",
+"394 763 LINE",
+"368 763 LINE",
+"300 553 LINE",
+"306 516 LINE",
+"310 516 LINE",
+"493 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 0 LINE",
+"229 30 LINE",
+"-15 30 LINE",
+"-15 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 204 LINE",
+"508 233 LINE",
+"164 233 LINE",
+"164 204 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"730 0 LINE",
+"730 30 LINE",
+"383 30 LINE",
+"383 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"106 15 LINE",
+"342 604 LINE",
+"394 763 LINE",
+"368 763 LINE",
+"73 15 LINE"
+);
+}
+);
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0041;
+},
+{
+glyphname = Aacute;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 18, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -7, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C1;
+},
+{
+glyphname = Abreve;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0102;
+},
+{
+glyphname = Abreveacute;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAE;
+},
+{
+glyphname = Abrevedotbelow;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 59, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 65, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB6;
+},
+{
+glyphname = Abrevegrave;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB0;
+},
+{
+glyphname = Abrevehookabove;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB2;
+},
+{
+glyphname = Abrevetilde;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB4;
+},
+{
+glyphname = Acircumflex;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C2;
+},
+{
+glyphname = Acircumflexacute;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA4;
+},
+{
+glyphname = Acircumflexdotbelow;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 59, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 65, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAC;
+},
+{
+glyphname = Acircumflexgrave;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA6;
+},
+{
+glyphname = Acircumflexhookabove;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA8;
+},
+{
+glyphname = Acircumflextilde;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAA;
+},
+{
+glyphname = Adblgrave;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 130, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 115, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0200;
+},
+{
+glyphname = Adieresis;
+lastChange = "2016-08-22 11:57:59 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 179, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 213, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C4;
+},
+{
+glyphname = Adotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 59, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 65, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA0;
+},
+{
+glyphname = Agrave;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 134, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C0;
+},
+{
+glyphname = Ahookabove;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 58, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA2;
+},
+{
+glyphname = Ainvertedbreve;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 176, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 206, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0202;
+},
+{
+glyphname = Amacron;
+lastChange = "2016-08-22 11:58:49 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 175, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 211, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0100;
+},
+{
+glyphname = Aogonek;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = A;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 373, -6}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+alignment = -1;
+name = A;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 397, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0104;
+},
+{
+glyphname = Aring;
+lastChange = "2016-08-22 11:57:38 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 242, 40}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 275, 80}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C5;
+},
+{
+glyphname = Aringacute;
+lastChange = "2022-02-25 09:09:23 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 242, 40}";
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 18, 514}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 275, 80}";
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -9, 554}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 01FA;
+},
+{
+glyphname = Atilde;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 70, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C3;
+},
+{
+glyphname = AE;
+lastChange = "2016-08-22 11:59:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{524, 0}";
+},
+{
+name = top;
+position = "{524, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"379 0 LINE",
+"1010 0 LINE",
+"1010 235 LINE",
+"975 235 LINE",
+"973 123 OFFCURVE",
+"916 25 OFFCURVE",
+"817 25 CURVE SMOOTH",
+"631 25 LINE",
+"631 363 LINE",
+"752 362 OFFCURVE",
+"783 327 OFFCURVE",
+"786 216 CURVE",
+"821 216 LINE",
+"821 526 LINE",
+"786 526 LINE",
+"786 419 OFFCURVE",
+"752 388 OFFCURVE",
+"631 388 CURVE",
+"631 729 LINE",
+"787 729 LINE SMOOTH",
+"886 729 OFFCURVE",
+"943 646 OFFCURVE",
+"945 549 CURVE",
+"980 549 LINE",
+"980 754 LINE",
+"339 754 LINE",
+"339 729 LINE",
+"442 729 LINE",
+"108 25 LINE",
+"10 25 LINE",
+"10 0 LINE",
+"254 0 LINE",
+"254 25 LINE",
+"138 25 LINE",
+"238 236 LINE",
+"497 236 LINE",
+"497 25 LINE",
+"379 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"473 729 LINE",
+"497 729 LINE",
+"497 261 LINE",
+"250 261 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"254 0 LINE",
+"254 25 LINE",
+"138 25 LINE",
+"238 236 LINE",
+"497 236 LINE",
+"497 25 LINE",
+"379 25 LINE",
+"379 0 LINE",
+"1010 0 LINE",
+"1010 235 LINE",
+"975 235 LINE",
+"973 123 OFFCURVE",
+"916 25 OFFCURVE",
+"817 25 CURVE SMOOTH",
+"631 25 LINE",
+"631 363 LINE",
+"752 362 OFFCURVE",
+"783 327 OFFCURVE",
+"786 216 CURVE",
+"821 216 LINE",
+"821 526 LINE",
+"786 526 LINE",
+"786 419 OFFCURVE",
+"752 388 OFFCURVE",
+"631 388 CURVE",
+"631 729 LINE",
+"787 729 LINE SMOOTH",
+"886 729 OFFCURVE",
+"943 646 OFFCURVE",
+"945 549 CURVE",
+"980 549 LINE",
+"980 754 LINE",
+"339 754 LINE",
+"339 729 LINE",
+"442 729 LINE",
+"108 25 LINE",
+"10 25 LINE",
+"10 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"473 729 LINE",
+"497 729 LINE",
+"497 261 LINE",
+"250 261 LINE"
+);
+}
+);
+width = 1047;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{566, 0}";
+},
+{
+name = top;
+position = "{566, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"455 0 LINE",
+"1096 0 LINE",
+"1096 245 LINE",
+"1056 245 LINE",
+"1054 131 OFFCURVE",
+"989 30 OFFCURVE",
+"878 30 CURVE SMOOTH",
+"708 30 LINE",
+"708 356 LINE",
+"837 355 OFFCURVE",
+"885 311 OFFCURVE",
+"887 216 CURVE",
+"927 216 LINE",
+"927 516 LINE",
+"887 516 LINE",
+"885 428 OFFCURVE",
+"837 387 OFFCURVE",
+"708 386 CURVE",
+"708 724 LINE",
+"878 724 LINE SMOOTH",
+"980 724 OFFCURVE",
+"1039 646 OFFCURVE",
+"1041 554 CURVE",
+"1081 554 LINE",
+"1081 754 LINE",
+"385 754 LINE",
+"385 724 LINE",
+"470 724 LINE",
+"102 30 LINE",
+"10 30 LINE",
+"10 0 LINE",
+"254 0 LINE",
+"254 30 LINE",
+"150 30 LINE",
+"257 231 LINE",
+"550 231 LINE",
+"550 30 LINE",
+"455 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"520 724 LINE",
+"550 724 LINE",
+"550 263 LINE",
+"274 263 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"254 0 LINE",
+"254 30 LINE",
+"150 30 LINE",
+"257 231 LINE",
+"550 231 LINE",
+"550 30 LINE",
+"455 30 LINE",
+"455 0 LINE",
+"1096 0 LINE",
+"1096 245 LINE",
+"1056 245 LINE",
+"1054 131 OFFCURVE",
+"989 30 OFFCURVE",
+"878 30 CURVE SMOOTH",
+"708 30 LINE",
+"708 356 LINE",
+"837 355 OFFCURVE",
+"885 311 OFFCURVE",
+"887 216 CURVE",
+"927 216 LINE",
+"927 516 LINE",
+"887 516 LINE",
+"885 428 OFFCURVE",
+"837 387 OFFCURVE",
+"708 386 CURVE",
+"708 724 LINE",
+"878 724 LINE SMOOTH",
+"980 724 OFFCURVE",
+"1039 646 OFFCURVE",
+"1041 554 CURVE",
+"1081 554 LINE",
+"1081 754 LINE",
+"385 754 LINE",
+"385 724 LINE",
+"470 724 LINE",
+"102 30 LINE",
+"10 30 LINE",
+"10 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"520 724 LINE",
+"550 724 LINE",
+"550 263 LINE",
+"274 263 LINE"
+);
+}
+);
+width = 1131;
+}
+);
+leftKerningGroup = AE;
+rightKerningGroup = E;
+unicode = 00C6;
+},
+{
+glyphname = AEacute;
+lastChange = "2016-08-22 11:59:17 +0000";
+layers = (
+{
+components = (
+{
+name = AE;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 199, 304}";
+}
+);
+layerId = UUID0;
+width = 1047;
+},
+{
+components = (
+{
+name = AE;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 176, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1131;
+}
+);
+leftKerningGroup = AE;
+rightKerningGroup = E;
+unicode = 01FC;
+},
+{
+glyphname = B;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{352, 0}";
+},
+{
+name = top;
+position = "{352, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 15 LINE",
+"261 15 LINE",
+"261 754 LINE",
+"127 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"363 382 LINE SMOOTH",
+"516 382 OFFCURVE",
+"638 459 OFFCURVE",
+"638 572 CURVE SMOOTH",
+"638 677 OFFCURVE",
+"534 754 OFFCURVE",
+"403 754 CURVE SMOOTH",
+"17 754 LINE",
+"17 729 LINE",
+"363 729 LINE SMOOTH",
+"451 729 OFFCURVE",
+"493 703 OFFCURVE",
+"493 568 CURVE SMOOTH",
+"493 440 OFFCURVE",
+"455 412 OFFCURVE",
+"363 412 CURVE SMOOTH",
+"230 412 LINE",
+"230 382 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"333 382 LINE",
+"468 382 OFFCURVE",
+"513 344 OFFCURVE",
+"513 209 CURVE SMOOTH",
+"513 59 OFFCURVE",
+"457 25 OFFCURVE",
+"363 25 CURVE SMOOTH",
+"17 25 LINE",
+"17 0 LINE",
+"403 0 LINE SMOOTH",
+"552 0 OFFCURVE",
+"666 83 OFFCURVE",
+"666 204 CURVE SMOOTH",
+"666 345 OFFCURVE",
+"510 412 OFFCURVE",
+"303 412 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"380 0 LINE SMOOTH",
+"529 0 OFFCURVE",
+"643 83 OFFCURVE",
+"643 204 CURVE SMOOTH",
+"643 345 OFFCURVE",
+"487 412 OFFCURVE",
+"280 412 CURVE",
+"310 382 LINE",
+"445 382 OFFCURVE",
+"490 344 OFFCURVE",
+"490 209 CURVE SMOOTH",
+"490 59 OFFCURVE",
+"434 25 OFFCURVE",
+"340 25 CURVE SMOOTH",
+"-6 25 LINE",
+"-6 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 15 LINE",
+"238 754 LINE",
+"104 754 LINE",
+"104 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"340 382 LINE SMOOTH",
+"493 382 OFFCURVE",
+"615 459 OFFCURVE",
+"615 572 CURVE SMOOTH",
+"615 677 OFFCURVE",
+"511 754 OFFCURVE",
+"380 754 CURVE SMOOTH",
+"-6 754 LINE",
+"-6 729 LINE",
+"340 729 LINE SMOOTH",
+"428 729 OFFCURVE",
+"470 703 OFFCURVE",
+"470 568 CURVE SMOOTH",
+"470 440 OFFCURVE",
+"432 412 OFFCURVE",
+"340 412 CURVE SMOOTH",
+"207 412 LINE",
+"207 382 LINE"
+);
+}
+);
+width = 703;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{376, 0}";
+},
+{
+name = top;
+position = "{376, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"30 751 OFFCURVE",
+"25 747 OFFCURVE",
+"24 735 CURVE",
+"22 731 OFFCURVE",
+"24 727 OFFCURVE",
+"29 723 CURVE",
+"33 715 LINE",
+"75 715 LINE SMOOTH",
+"95 715 OFFCURVE",
+"116 715 OFFCURVE",
+"116 715 CURVE",
+"123 714 OFFCURVE",
+"124 702 OFFCURVE",
+"124 658 CURVE SMOOTH",
+"124 635 OFFCURVE",
+"126 609 OFFCURVE",
+"126 604 CURVE SMOOTH",
+"124 499 OFFCURVE",
+"123 394 OFFCURVE",
+"123 362 CURVE SMOOTH",
+"123 341 OFFCURVE",
+"123 307 OFFCURVE",
+"123 285 CURVE SMOOTH",
+"123 264 OFFCURVE",
+"123 225 OFFCURVE",
+"123 197 CURVE SMOOTH",
+"123 170 OFFCURVE",
+"123 127 OFFCURVE",
+"123 105 CURVE SMOOTH",
+"123 62 OFFCURVE",
+"121 41 OFFCURVE",
+"118 37 CURVE SMOOTH",
+"116 34 OFFCURVE",
+"95 34 OFFCURVE",
+"63 36 CURVE SMOOTH",
+"38 37 OFFCURVE",
+"38 37 OFFCURVE",
+"30 33 CURVE",
+"14 21 OFFCURVE",
+"21 -2 OFFCURVE",
+"44 -4 CURVE SMOOTH",
+"47 -4 OFFCURVE",
+"83 -2 OFFCURVE",
+"123 -2 CURVE",
+"162 0 OFFCURVE",
+"252 0 OFFCURVE",
+"321 0 CURVE SMOOTH",
+"418 0 OFFCURVE",
+"456 0 OFFCURVE",
+"481 3 CURVE",
+"515 4 OFFCURVE",
+"539 9 OFFCURVE",
+"558 17 CURVE SMOOTH",
+"561 18 OFFCURVE",
+"572 21 OFFCURVE",
+"575 23 CURVE",
+"594 29 OFFCURVE",
+"627 47 OFFCURVE",
+"641 59 CURVE SMOOTH",
+"685 91 OFFCURVE",
+"717 156 OFFCURVE",
+"714 206 CURVE SMOOTH",
+"712 233 OFFCURVE",
+"707 249 OFFCURVE",
+"699 271 CURVE",
+"687 292 OFFCURVE",
+"674 312 OFFCURVE",
+"660 321 CURVE SMOOTH",
+"653 326 OFFCURVE",
+"643 333 OFFCURVE",
+"640 337 CURVE",
+"629 346 OFFCURVE",
+"600 361 OFFCURVE",
+"577 370 CURVE SMOOTH",
+"559 376 OFFCURVE",
+"523 386 OFFCURVE",
+"504 389 CURVE SMOOTH",
+"497 390 OFFCURVE",
+"490 390 OFFCURVE",
+"490 392 CURVE",
+"485 394 OFFCURVE",
+"494 398 OFFCURVE",
+"509 400 CURVE",
+"530 405 OFFCURVE",
+"575 422 OFFCURVE",
+"592 430 CURVE SMOOTH",
+"615 443 OFFCURVE",
+"653 479 OFFCURVE",
+"663 499 CURVE",
+"671 512 OFFCURVE",
+"679 535 OFFCURVE",
+"679 546 CURVE",
+"682 561 OFFCURVE",
+"681 594 OFFCURVE",
+"678 608 CURVE SMOOTH",
+"671 635 OFFCURVE",
+"656 661 OFFCURVE",
+"633 683 CURVE",
+"621 696 OFFCURVE",
+"592 715 OFFCURVE",
+"588 715 CURVE SMOOTH",
+"588 715 OFFCURVE",
+"583 717 OFFCURVE",
+"575 721 CURVE SMOOTH",
+"542 735 OFFCURVE",
+"504 745 OFFCURVE",
+"471 748 CURVE",
+"462 748 OFFCURVE",
+"395 748 OFFCURVE",
+"321 750 CURVE",
+"249 750 OFFCURVE",
+"177 750 OFFCURVE",
+"161 751 CURVE SMOOTH",
+"107 753 OFFCURVE",
+"58 753 OFFCURVE",
+"46 751 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"445 707 OFFCURVE",
+"450 704 OFFCURVE",
+"462 694 CURVE SMOOTH",
+"488 674 OFFCURVE",
+"496 632 OFFCURVE",
+"492 540 CURVE SMOOTH",
+"489 486 OFFCURVE",
+"484 461 OFFCURVE",
+"469 441 CURVE",
+"465 433 OFFCURVE",
+"448 420 OFFCURVE",
+"440 415 CURVE",
+"428 411 OFFCURVE",
+"411 409 OFFCURVE",
+"356 409 CURVE SMOOTH",
+"304 409 OFFCURVE",
+"298 409 OFFCURVE",
+"295 412 CURVE SMOOTH",
+"293 415 OFFCURVE",
+"292 425 OFFCURVE",
+"292 527 CURVE SMOOTH",
+"292 587 OFFCURVE",
+"292 653 OFFCURVE",
+"293 673 CURVE",
+"293 707 OFFCURVE",
+"293 709 OFFCURVE",
+"298 712 CURVE SMOOTH",
+"301 715 OFFCURVE",
+"306 715 OFFCURVE",
+"362 715 CURVE SMOOTH",
+"414 715 OFFCURVE",
+"423 714 OFFCURVE",
+"433 710 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"427 370 OFFCURVE",
+"433 370 OFFCURVE",
+"440 365 CURVE SMOOTH",
+"443 364 OFFCURVE",
+"450 362 OFFCURVE",
+"454 359 CURVE SMOOTH",
+"457 357 OFFCURVE",
+"462 354 OFFCURVE",
+"466 353 CURVE SMOOTH",
+"472 349 OFFCURVE",
+"485 337 OFFCURVE",
+"492 329 CURVE",
+"514 308 OFFCURVE",
+"514 280 OFFCURVE",
+"514 217 CURVE",
+"515 198 OFFCURVE",
+"512 148 OFFCURVE",
+"507 116 CURVE",
+"504 90 OFFCURVE",
+"497 75 OFFCURVE",
+"481 59 CURVE SMOOTH",
+"469 45 OFFCURVE",
+"462 42 OFFCURVE",
+"440 37 CURVE",
+"430 36 OFFCURVE",
+"411 36 OFFCURVE",
+"362 36 CURVE SMOOTH",
+"300 36 OFFCURVE",
+"300 36 OFFCURVE",
+"295 39 CURVE SMOOTH",
+"292 42 OFFCURVE",
+"292 47 OFFCURVE",
+"292 116 CURVE SMOOTH",
+"292 157 OFFCURVE",
+"292 228 OFFCURVE",
+"292 275 CURVE",
+"290 333 OFFCURVE",
+"292 361 OFFCURVE",
+"293 364 CURVE SMOOTH",
+"296 376 OFFCURVE",
+"301 376 OFFCURVE",
+"354 376 CURVE",
+"380 374 OFFCURVE",
+"407 373 OFFCURVE",
+"413 373 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"428 0 LINE SMOOTH",
+"586 0 OFFCURVE",
+"706 60 OFFCURVE",
+"706 194 CURVE SMOOTH",
+"706 345 OFFCURVE",
+"558 402 OFFCURVE",
+"341 402 CURVE",
+"371 367 LINE",
+"489 367 OFFCURVE",
+"528 332 OFFCURVE",
+"528 206 CURVE SMOOTH",
+"528 63 OFFCURVE",
+"475 30 OFFCURVE",
+"388 30 CURVE SMOOTH",
+"25 30 LINE",
+"25 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 15 LINE",
+"283 754 LINE",
+"125 754 LINE",
+"125 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"388 367 LINE SMOOTH",
+"559 367 OFFCURVE",
+"678 434 OFFCURVE",
+"678 565 CURVE SMOOTH",
+"678 691 OFFCURVE",
+"568 754 OFFCURVE",
+"428 754 CURVE SMOOTH",
+"25 754 LINE",
+"25 724 LINE",
+"388 724 LINE SMOOTH",
+"471 724 OFFCURVE",
+"508 698 OFFCURVE",
+"508 564 CURVE SMOOTH",
+"508 432 OFFCURVE",
+"472 402 OFFCURVE",
+"388 402 CURVE SMOOTH",
+"228 402 LINE",
+"228 367 LINE"
+);
+}
+);
+width = 751;
+}
+);
+unicode = 0042;
+},
+{
+glyphname = C;
+lastChange = "2016-08-22 12:01:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{393, 0}";
+},
+{
+name = top;
+position = "{397, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"458 -12 OFFCURVE",
+"525 6 OFFCURVE",
+"578 46 CURVE",
+"612 0 LINE",
+"637 0 LINE",
+"637 212 LINE",
+"612 212 LINE",
+"588 103 OFFCURVE",
+"531 18 OFFCURVE",
+"393 18 CURVE SMOOTH",
+"279 18 OFFCURVE",
+"206 87 OFFCURVE",
+"206 377 CURVE SMOOTH",
+"206 667 OFFCURVE",
+"281 736 OFFCURVE",
+"395 736 CURVE SMOOTH",
+"526 736 OFFCURVE",
+"581 640 OFFCURVE",
+"603 528 CURVE",
+"628 528 LINE",
+"628 754 LINE",
+"603 754 LINE",
+"564 704 LINE",
+"513 747 OFFCURVE",
+"459 766 OFFCURVE",
+"396 766 CURVE SMOOTH",
+"200 766 OFFCURVE",
+"46 583 OFFCURVE",
+"46 377 CURVE SMOOTH",
+"46 171 OFFCURVE",
+"197 -12 OFFCURVE",
+"393 -12 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"458 -12 OFFCURVE",
+"525 6 OFFCURVE",
+"578 46 CURVE",
+"612 0 LINE",
+"637 0 LINE",
+"637 212 LINE",
+"612 212 LINE",
+"588 103 OFFCURVE",
+"531 18 OFFCURVE",
+"393 18 CURVE SMOOTH",
+"279 18 OFFCURVE",
+"206 87 OFFCURVE",
+"206 377 CURVE SMOOTH",
+"206 667 OFFCURVE",
+"281 736 OFFCURVE",
+"395 736 CURVE SMOOTH",
+"526 736 OFFCURVE",
+"581 640 OFFCURVE",
+"603 528 CURVE",
+"628 528 LINE",
+"628 754 LINE",
+"603 754 LINE",
+"564 704 LINE",
+"513 747 OFFCURVE",
+"459 766 OFFCURVE",
+"396 766 CURVE SMOOTH",
+"200 766 OFFCURVE",
+"46 583 OFFCURVE",
+"46 377 CURVE SMOOTH",
+"46 171 OFFCURVE",
+"197 -12 OFFCURVE",
+"393 -12 CURVE SMOOTH"
+);
+}
+);
+width = 687;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{412, -3}";
+},
+{
+name = top;
+position = "{410, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"476 -13 OFFCURVE",
+"534 4 OFFCURVE",
+"592 46 CURVE",
+"636 0 LINE",
+"666 0 LINE",
+"666 217 LINE",
+"636 217 LINE",
+"613 112 OFFCURVE",
+"549 22 OFFCURVE",
+"413 22 CURVE SMOOTH",
+"297 22 OFFCURVE",
+"240 86 OFFCURVE",
+"240 361 CURVE SMOOTH",
+"240 672 OFFCURVE",
+"313 728 OFFCURVE",
+"412 728 CURVE SMOOTH",
+"537 728 OFFCURVE",
+"600 639 OFFCURVE",
+"622 523 CURVE",
+"652 523 LINE",
+"652 754 LINE",
+"627 754 LINE",
+"583 704 LINE",
+"530 744 OFFCURVE",
+"485 763 OFFCURVE",
+"416 763 CURVE SMOOTH",
+"201 763 OFFCURVE",
+"50 577 OFFCURVE",
+"50 372 CURVE SMOOTH",
+"50 167 OFFCURVE",
+"202 -13 OFFCURVE",
+"412 -13 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"476 -13 OFFCURVE",
+"534 4 OFFCURVE",
+"592 46 CURVE",
+"636 0 LINE",
+"666 0 LINE",
+"666 217 LINE",
+"636 217 LINE",
+"613 112 OFFCURVE",
+"549 22 OFFCURVE",
+"413 22 CURVE SMOOTH",
+"297 22 OFFCURVE",
+"240 86 OFFCURVE",
+"240 361 CURVE SMOOTH",
+"240 672 OFFCURVE",
+"313 728 OFFCURVE",
+"412 728 CURVE SMOOTH",
+"537 728 OFFCURVE",
+"600 639 OFFCURVE",
+"622 523 CURVE",
+"652 523 LINE",
+"652 754 LINE",
+"627 754 LINE",
+"583 704 LINE",
+"530 744 OFFCURVE",
+"485 763 OFFCURVE",
+"416 763 CURVE SMOOTH",
+"201 763 OFFCURVE",
+"50 577 OFFCURVE",
+"50 372 CURVE SMOOTH",
+"50 167 OFFCURVE",
+"202 -13 OFFCURVE",
+"412 -13 CURVE SMOOTH"
+);
+}
+);
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 0043;
+},
+{
+glyphname = Cacute;
+lastChange = "2016-08-22 12:00:34 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 72, 304}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 20, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 0106;
+},
+{
+glyphname = Ccaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 227, 1}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 196, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 010C;
+},
+{
+glyphname = Ccedilla;
+lastChange = "2016-08-22 12:01:59 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 288, 6}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 295, 10}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 00C7;
+},
+{
+glyphname = Ccircumflex;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 107, 304}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 114, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 0108;
+},
+{
+glyphname = Cdotaccent;
+lastChange = "2016-08-22 12:08:11 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 322, 5}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 331, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 010A;
+},
+{
+glyphname = D;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{389, 0}";
+},
+{
+name = center;
+position = "{389, 377}";
+},
+{
+name = top;
+position = "{389, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 15 LINE",
+"261 15 LINE",
+"261 754 LINE",
+"127 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 729 LINE SMOOTH",
+"519 729 OFFCURVE",
+"579 662 OFFCURVE",
+"579 379 CURVE SMOOTH",
+"579 91 OFFCURVE",
+"517 25 OFFCURVE",
+"352 25 CURVE SMOOTH",
+"17 25 LINE",
+"17 0 LINE",
+"382 0 LINE SMOOTH",
+"582 0 OFFCURVE",
+"739 180 OFFCURVE",
+"739 380 CURVE SMOOTH",
+"739 578 OFFCURVE",
+"586 754 OFFCURVE",
+"392 754 CURVE SMOOTH",
+"17 754 LINE",
+"17 729 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"376 0 LINE SMOOTH",
+"576 0 OFFCURVE",
+"733 179 OFFCURVE",
+"733 377 CURVE SMOOTH",
+"733 575 OFFCURVE",
+"577 754 OFFCURVE",
+"377 754 CURVE SMOOTH",
+"11 754 LINE",
+"11 729 LINE",
+"345 729 LINE SMOOTH",
+"509 729 OFFCURVE",
+"573 663 OFFCURVE",
+"573 377 CURVE SMOOTH",
+"573 91 OFFCURVE",
+"510 25 OFFCURVE",
+"346 25 CURVE SMOOTH",
+"11 25 LINE",
+"11 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 15 LINE",
+"255 754 LINE",
+"121 754 LINE",
+"121 15 LINE"
+);
+}
+);
+width = 777;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{399, 0}";
+},
+{
+name = center;
+position = "{399, 377}";
+},
+{
+name = top;
+position = "{399, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"9 752 OFFCURVE",
+"4 740 OFFCURVE",
+"7 731 CURVE SMOOTH",
+"12 719 OFFCURVE",
+"16 719 OFFCURVE",
+"60 721 CURVE",
+"90 721 OFFCURVE",
+"101 721 OFFCURVE",
+"103 719 CURVE SMOOTH",
+"104 717 OFFCURVE",
+"106 710 OFFCURVE",
+"108 693 CURVE",
+"108 677 OFFCURVE",
+"108 666 OFFCURVE",
+"108 663 CURVE SMOOTH",
+"108 661 OFFCURVE",
+"106 651 OFFCURVE",
+"106 641 CURVE SMOOTH",
+"106 619 OFFCURVE",
+"106 603 OFFCURVE",
+"106 590 CURVE SMOOTH",
+"106 572 OFFCURVE",
+"106 241 OFFCURVE",
+"108 205 CURVE SMOOTH",
+"108 202 OFFCURVE",
+"108 188 OFFCURVE",
+"106 175 CURVE",
+"106 163 OFFCURVE",
+"106 127 OFFCURVE",
+"106 95 CURVE SMOOTH",
+"106 65 OFFCURVE",
+"104 37 OFFCURVE",
+"103 36 CURVE",
+"103 34 OFFCURVE",
+"100 32 OFFCURVE",
+"88 32 CURVE SMOOTH",
+"82 32 OFFCURVE",
+"70 34 OFFCURVE",
+"65 34 CURVE",
+"59 36 OFFCURVE",
+"45 37 OFFCURVE",
+"35 37 CURVE",
+"15 39 LINE",
+"9 32 LINE",
+"2 26 OFFCURVE",
+"2 24 OFFCURVE",
+"2 16 CURVE SMOOTH",
+"2 3 OFFCURVE",
+"14 -4 OFFCURVE",
+"32 -5 CURVE SMOOTH",
+"39 -5 OFFCURVE",
+"92 -2 OFFCURVE",
+"100 -1 CURVE",
+"106 1 OFFCURVE",
+"132 1 OFFCURVE",
+"225 -1 CURVE",
+"373 -2 OFFCURVE",
+"432 -2 OFFCURVE",
+"454 1 CURVE SMOOTH",
+"485 4 OFFCURVE",
+"542 20 OFFCURVE",
+"556 26 CURVE",
+"556 29 OFFCURVE",
+"568 34 OFFCURVE",
+"581 39 CURVE",
+"609 54 OFFCURVE",
+"635 73 OFFCURVE",
+"658 97 CURVE",
+"673 109 OFFCURVE",
+"682 122 OFFCURVE",
+"687 125 CURVE",
+"699 139 OFFCURVE",
+"720 177 OFFCURVE",
+"730 194 CURVE",
+"741 219 OFFCURVE",
+"758 258 OFFCURVE",
+"758 276 CURVE",
+"760 282 OFFCURVE",
+"762 291 OFFCURVE",
+"763 294 CURVE SMOOTH",
+"768 312 OFFCURVE",
+"771 401 OFFCURVE",
+"766 428 CURVE SMOOTH",
+"765 434 OFFCURVE",
+"763 448 OFFCURVE",
+"763 456 CURVE",
+"758 479 OFFCURVE",
+"748 519 OFFCURVE",
+"743 524 CURVE SMOOTH",
+"741 525 OFFCURVE",
+"741 527 OFFCURVE",
+"741 528 CURVE SMOOTH",
+"741 534 OFFCURVE",
+"710 594 OFFCURVE",
+"700 608 CURVE SMOOTH",
+"690 623 OFFCURVE",
+"662 654 OFFCURVE",
+"654 661 CURVE",
+"650 663 OFFCURVE",
+"642 671 OFFCURVE",
+"636 677 CURVE SMOOTH",
+"627 684 OFFCURVE",
+"617 693 OFFCURVE",
+"613 694 CURVE",
+"609 698 OFFCURVE",
+"600 701 OFFCURVE",
+"596 704 CURVE SMOOTH",
+"566 723 OFFCURVE",
+"523 739 OFFCURVE",
+"493 742 CURVE",
+"443 751 OFFCURVE",
+"424 752 OFFCURVE",
+"245 752 CURVE SMOOTH",
+"150 752 OFFCURVE",
+"60 754 OFFCURVE",
+"46 754 CURVE SMOOTH",
+"34 754 OFFCURVE",
+"21 754 OFFCURVE",
+"19 754 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 717 LINE",
+"464 710 LINE SMOOTH",
+"481 706 OFFCURVE",
+"492 701 OFFCURVE",
+"492 698 CURVE",
+"495 696 OFFCURVE",
+"498 693 OFFCURVE",
+"501 693 CURVE",
+"501 691 OFFCURVE",
+"511 684 OFFCURVE",
+"520 676 CURVE",
+"542 663 OFFCURVE",
+"542 661 OFFCURVE",
+"542 643 CURVE",
+"545 633 OFFCURVE",
+"548 621 OFFCURVE",
+"550 618 CURVE",
+"550 615 OFFCURVE",
+"551 611 OFFCURVE",
+"553 610 CURVE",
+"553 607 OFFCURVE",
+"556 597 OFFCURVE",
+"556 585 CURVE",
+"558 575 OFFCURVE",
+"559 558 OFFCURVE",
+"561 550 CURVE",
+"564 520 OFFCURVE",
+"566 499 OFFCURVE",
+"566 429 CURVE SMOOTH",
+"567 312 OFFCURVE",
+"566 251 OFFCURVE",
+"561 208 CURVE",
+"559 200 OFFCURVE",
+"558 186 OFFCURVE",
+"556 180 CURVE",
+"553 147 OFFCURVE",
+"545 120 OFFCURVE",
+"536 106 CURVE SMOOTH",
+"518 76 OFFCURVE",
+"500 57 OFFCURVE",
+"482 49 CURVE",
+"460 37 OFFCURVE",
+"432 34 OFFCURVE",
+"357 34 CURVE SMOOTH",
+"336 34 OFFCURVE",
+"319 34 OFFCURVE",
+"318 34 CURVE SMOOTH",
+"288 34 OFFCURVE",
+"286 36 OFFCURVE",
+"286 56 CURVE SMOOTH",
+"286 67 OFFCURVE",
+"286 266 OFFCURVE",
+"286 284 CURVE SMOOTH",
+"286 337 OFFCURVE",
+"286 643 OFFCURVE",
+"286 685 CURVE SMOOTH",
+"286 710 LINE",
+"293 715 LINE",
+"297 721 OFFCURVE",
+"300 721 OFFCURVE",
+"303 721 CURVE SMOOTH",
+"307 721 OFFCURVE",
+"338 719 OFFCURVE",
+"374 719 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"411 0 LINE SMOOTH",
+"611 0 OFFCURVE",
+"768 180 OFFCURVE",
+"768 380 CURVE SMOOTH",
+"768 578 OFFCURVE",
+"615 754 OFFCURVE",
+"421 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"390 724 LINE SMOOTH",
+"527 724 OFFCURVE",
+"578 657 OFFCURVE",
+"578 379 CURVE SMOOTH",
+"578 95 OFFCURVE",
+"525 30 OFFCURVE",
+"381 30 CURVE SMOOTH",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+}
+);
+width = 798;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = D;
+unicode = 0044;
+},
+{
+glyphname = DZ;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 777, 0}";
+}
+);
+layerId = UUID0;
+width = 1428;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 798, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1419;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = Z;
+unicode = 01F1;
+},
+{
+glyphname = DZcaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = DZ;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 933, 1}";
+}
+);
+layerId = UUID0;
+width = 1428;
+},
+{
+components = (
+{
+name = DZ;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 895, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1419;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = Z;
+unicode = 01C4;
+},
+{
+glyphname = Eth;
+lastChange = "2016-08-22 12:09:32 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 15 LINE",
+"261 15 LINE",
+"261 754 LINE",
+"127 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 729 LINE SMOOTH",
+"519 729 OFFCURVE",
+"579 662 OFFCURVE",
+"579 379 CURVE SMOOTH",
+"579 91 OFFCURVE",
+"517 25 OFFCURVE",
+"352 25 CURVE SMOOTH",
+"17 25 LINE",
+"17 0 LINE",
+"382 0 LINE SMOOTH",
+"582 0 OFFCURVE",
+"739 180 OFFCURVE",
+"739 380 CURVE SMOOTH",
+"739 578 OFFCURVE",
+"586 754 OFFCURVE",
+"392 754 CURVE SMOOTH",
+"17 754 LINE",
+"17 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"16 367 LINE",
+"381 367 LINE",
+"381 402 LINE",
+"16 402 LINE"
+);
+}
+);
+};
+components = (
+{
+name = D;
+},
+{
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 389, 377}";
+}
+);
+layerId = UUID0;
+width = 777;
+},
+{
+components = (
+{
+name = D;
+},
+{
+alignment = 1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, -65, 377}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 798;
+}
+);
+rightKerningGroup = D;
+unicode = 00D0;
+},
+{
+glyphname = Dcaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 219, 1}";
+}
+);
+layerId = UUID0;
+width = 777;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 185, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 798;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = D;
+unicode = 010E;
+},
+{
+glyphname = Dcroat;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"381 367 LINE",
+"381 402 LINE",
+"16 402 LINE",
+"16 367 LINE"
+);
+}
+);
+width = 777;
+},
+{
+components = (
+{
+name = D;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"411 361 LINE",
+"411 408 LINE",
+"16 408 LINE",
+"16 361 LINE"
+);
+}
+);
+width = 798;
+}
+);
+rightKerningGroup = D;
+unicode = 0110;
+},
+{
+glyphname = Ddotbelow;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 105, 0}";
+}
+);
+layerId = UUID0;
+width = 777;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 106, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 798;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = D;
+unicode = 1E0C;
+},
+{
+glyphname = Dz;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 777, 0}";
+}
+);
+layerId = UUID0;
+width = 1257;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 798, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1274;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = z;
+unicode = 01F2;
+},
+{
+glyphname = Dzcaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = Dz;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 847, -303}";
+}
+);
+layerId = UUID0;
+width = 1257;
+},
+{
+components = (
+{
+name = Dz;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 822, -302}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1274;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = z;
+unicode = 01C5;
+},
+{
+glyphname = E;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{346, 0}";
+},
+{
+name = ogonek;
+position = "{622, 10}";
+},
+{
+name = top;
+position = "{346, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"126 15 LINE",
+"260 15 LINE",
+"260 744 LINE",
+"126 744 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 526 LINE",
+"415 526 LINE",
+"415 418 OFFCURVE",
+"381 388 OFFCURVE",
+"257 388 CURVE",
+"257 363 LINE",
+"381 363 OFFCURVE",
+"412 328 OFFCURVE",
+"415 216 CURVE",
+"450 216 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"8 729 LINE",
+"416 729 LINE SMOOTH",
+"515 729 OFFCURVE",
+"572 646 OFFCURVE",
+"574 549 CURVE",
+"609 549 LINE",
+"609 754 LINE",
+"8 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"8 0 LINE",
+"639 0 LINE",
+"639 235 LINE",
+"604 235 LINE",
+"602 123 OFFCURVE",
+"545 25 OFFCURVE",
+"446 25 CURVE SMOOTH",
+"8 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"639 0 LINE",
+"639 235 LINE",
+"604 235 LINE",
+"602 123 OFFCURVE",
+"545 25 OFFCURVE",
+"446 25 CURVE SMOOTH",
+"8 25 LINE",
+"8 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 15 LINE",
+"260 744 LINE",
+"126 744 LINE",
+"126 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 216 LINE",
+"450 526 LINE",
+"415 526 LINE",
+"415 418 OFFCURVE",
+"381 388 OFFCURVE",
+"257 388 CURVE",
+"257 363 LINE",
+"381 363 OFFCURVE",
+"412 328 OFFCURVE",
+"415 216 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 549 LINE",
+"609 754 LINE",
+"8 754 LINE",
+"8 729 LINE",
+"416 729 LINE SMOOTH",
+"515 729 OFFCURVE",
+"572 646 OFFCURVE",
+"574 549 CURVE"
+);
+}
+);
+width = 691;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{348, 0}";
+},
+{
+name = ogonek;
+position = "{626, 10}";
+},
+{
+name = top;
+position = "{348, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 15 LINE",
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"661 0 LINE",
+"661 245 LINE",
+"621 245 LINE",
+"619 131 OFFCURVE",
+"554 30 OFFCURVE",
+"443 30 CURVE SMOOTH",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 646 OFFCURVE",
+"606 554 CURVE",
+"646 554 LINE",
+"646 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"269 356 LINE",
+"401 356 OFFCURVE",
+"450 312 OFFCURVE",
+"452 216 CURVE",
+"492 216 LINE",
+"492 516 LINE",
+"452 516 LINE",
+"450 427 OFFCURVE",
+"401 386 OFFCURVE",
+"269 386 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"661 0 LINE",
+"661 245 LINE",
+"621 245 LINE",
+"619 131 OFFCURVE",
+"554 30 OFFCURVE",
+"443 30 CURVE SMOOTH",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 216 LINE",
+"492 516 LINE",
+"452 516 LINE",
+"450 427 OFFCURVE",
+"401 386 OFFCURVE",
+"269 386 CURVE",
+"269 356 LINE",
+"401 356 OFFCURVE",
+"450 312 OFFCURVE",
+"452 216 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"646 554 LINE",
+"646 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 646 OFFCURVE",
+"606 554 CURVE"
+);
+}
+);
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0045;
+},
+{
+glyphname = Eacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 21, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -42, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 00C9;
+},
+{
+glyphname = Ebreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 51, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 50, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0114;
+},
+{
+glyphname = Ecaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 176, 1}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 134, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 011A;
+},
+{
+glyphname = Ecircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 00CA;
+},
+{
+glyphname = Ecircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBE;
+},
+{
+glyphname = Ecircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 62, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 55, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC6;
+},
+{
+glyphname = Ecircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC0;
+},
+{
+glyphname = Ecircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC2;
+},
+{
+glyphname = Ecircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC4;
+},
+{
+glyphname = Edblgrave;
+lastChange = "2016-08-22 12:07:48 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 133, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 80, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0204;
+},
+{
+glyphname = Edieresis;
+lastChange = "2016-08-22 12:07:48 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 182, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 178, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 00CB;
+},
+{
+glyphname = Edotaccent;
+lastChange = "2016-08-22 12:08:14 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 271, 5}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 269, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0116;
+},
+{
+glyphname = Edotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 62, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 55, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EB8;
+},
+{
+glyphname = Egrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 59, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 00C8;
+},
+{
+glyphname = Ehookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 61, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 64, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBA;
+},
+{
+glyphname = Einvertedbreve;
+lastChange = "2016-08-22 12:07:48 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 179, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 171, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0206;
+},
+{
+glyphname = Emacron;
+lastChange = "2016-08-22 12:07:48 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 178, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 176, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0112;
+},
+{
+glyphname = Eogonek;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = E;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 323, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+alignment = -1;
+name = E;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 356, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0118;
+},
+{
+glyphname = Etilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 55, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 35, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBC;
+},
+{
+glyphname = Schwa;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"587 -13 OFFCURVE",
+"723 187 OFFCURVE",
+"723 378 CURVE SMOOTH",
+"723 581 OFFCURVE",
+"570 764 OFFCURVE",
+"377 764 CURVE SMOOTH",
+"235 764 OFFCURVE",
+"101 664 OFFCURVE",
+"57 513 CURVE",
+"91 513 LINE",
+"136 645 OFFCURVE",
+"251 733 OFFCURVE",
+"382 733 CURVE SMOOTH",
+"516 733 OFFCURVE",
+"563 642 OFFCURVE",
+"563 374 CURVE SMOOTH",
+"563 85 OFFCURVE",
+"508 17 OFFCURVE",
+"380 17 CURVE SMOOTH",
+"269 17 OFFCURVE",
+"215 69 OFFCURVE",
+"215 183 CURVE SMOOTH",
+"215 309 LINE",
+"596 309 LINE",
+"596 343 LINE",
+"52 343 LINE",
+"52 333 LINE SMOOTH",
+"52 120 OFFCURVE",
+"206 -13 OFFCURVE",
+"377 -13 CURVE SMOOTH"
+);
+}
+);
+width = 753;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"611 -13 OFFCURVE",
+"755 187 OFFCURVE",
+"755 378 CURVE SMOOTH",
+"755 581 OFFCURVE",
+"594 764 OFFCURVE",
+"385 764 CURVE SMOOTH",
+"243 764 OFFCURVE",
+"109 664 OFFCURVE",
+"65 513 CURVE",
+"104 513 LINE",
+"147 642 OFFCURVE",
+"258 728 OFFCURVE",
+"385 728 CURVE SMOOTH",
+"518 728 OFFCURVE",
+"566 638 OFFCURVE",
+"566 374 CURVE SMOOTH",
+"566 89 OFFCURVE",
+"511 21 OFFCURVE",
+"388 21 CURVE SMOOTH",
+"277 21 OFFCURVE",
+"223 73 OFFCURVE",
+"223 183 CURVE SMOOTH",
+"223 309 LINE",
+"604 309 LINE",
+"604 348 LINE",
+"40 348 LINE",
+"40 333 LINE SMOOTH",
+"40 120 OFFCURVE",
+"204 -13 OFFCURVE",
+"385 -13 CURVE SMOOTH"
+);
+}
+);
+width = 795;
+}
+);
+unicode = 018F;
+},
+{
+glyphname = F;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{329, 0}";
+},
+{
+name = top;
+position = "{329, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"129 15 LINE",
+"263 15 LINE",
+"263 754 LINE",
+"129 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"11 0 LINE",
+"373 0 LINE",
+"373 25 LINE",
+"11 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 526 LINE",
+"418 526 LINE",
+"418 418 OFFCURVE",
+"384 388 OFFCURVE",
+"260 388 CURVE",
+"260 363 LINE",
+"384 363 OFFCURVE",
+"415 328 OFFCURVE",
+"418 216 CURVE",
+"453 216 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"11 729 LINE",
+"429 729 LINE SMOOTH",
+"528 729 OFFCURVE",
+"585 626 OFFCURVE",
+"587 509 CURVE",
+"622 509 LINE",
+"622 754 LINE",
+"11 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"622 509 LINE",
+"622 754 LINE",
+"11 754 LINE",
+"11 729 LINE",
+"429 729 LINE SMOOTH",
+"528 729 OFFCURVE",
+"585 626 OFFCURVE",
+"587 509 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"373 0 LINE",
+"373 25 LINE",
+"11 25 LINE",
+"11 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 15 LINE",
+"263 754 LINE",
+"129 754 LINE",
+"129 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 216 LINE",
+"453 526 LINE",
+"418 526 LINE",
+"418 418 OFFCURVE",
+"384 388 OFFCURVE",
+"260 388 CURVE",
+"260 363 LINE",
+"384 363 OFFCURVE",
+"415 328 OFFCURVE",
+"418 216 CURVE"
+);
+}
+);
+width = 658;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{351, 0}";
+},
+{
+name = top;
+position = "{351, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 14 LINE",
+"273 14 LINE",
+"273 754 LINE",
+"115 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 639 OFFCURVE",
+"606 539 CURVE",
+"646 539 LINE",
+"646 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 355 LINE",
+"269 355 LINE SMOOTH",
+"401 355 OFFCURVE",
+"450 311 OFFCURVE",
+"452 215 CURVE",
+"492 215 LINE",
+"492 515 LINE",
+"452 515 LINE",
+"450 426 OFFCURVE",
+"401 385 OFFCURVE",
+"269 385 CURVE SMOOTH",
+"156 385 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"401 0 LINE",
+"401 30 LINE",
+"20 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"646 539 LINE",
+"646 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 639 OFFCURVE",
+"606 539 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"401 0 LINE",
+"401 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 14 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 14 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 215 LINE",
+"492 515 LINE",
+"452 515 LINE",
+"450 426 OFFCURVE",
+"401 385 OFFCURVE",
+"269 385 CURVE SMOOTH",
+"269 355 LINE",
+"401 355 OFFCURVE",
+"450 311 OFFCURVE",
+"452 215 CURVE"
+);
+}
+);
+width = 702;
+}
+);
+unicode = 0046;
+},
+{
+glyphname = G;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{369, 0}";
+},
+{
+name = top;
+position = "{369, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"532 -12 OFFCURVE",
+"665 89 OFFCURVE",
+"665 259 CURVE SMOOTH",
+"665 283 LINE",
+"516 283 LINE",
+"516 140 LINE SMOOTH",
+"516 64 OFFCURVE",
+"465 20 OFFCURVE",
+"378 20 CURVE SMOOTH",
+"270 20 OFFCURVE",
+"205 87 OFFCURVE",
+"205 365 CURVE SMOOTH",
+"205 667 OFFCURVE",
+"282 736 OFFCURVE",
+"394 736 CURVE SMOOTH",
+"525 736 OFFCURVE",
+"580 640 OFFCURVE",
+"602 528 CURVE",
+"627 528 LINE",
+"627 754 LINE",
+"602 754 LINE",
+"558 704 LINE",
+"508 747 OFFCURVE",
+"457 766 OFFCURVE",
+"394 766 CURVE SMOOTH",
+"195 766 OFFCURVE",
+"45 579 OFFCURVE",
+"45 370 CURVE SMOOTH",
+"45 177 OFFCURVE",
+"174 -12 OFFCURVE",
+"381 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"393 268 LINE",
+"723 268 LINE",
+"723 293 LINE",
+"393 293 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"532 -12 OFFCURVE",
+"665 89 OFFCURVE",
+"665 259 CURVE SMOOTH",
+"665 283 LINE",
+"516 283 LINE",
+"516 140 LINE SMOOTH",
+"516 64 OFFCURVE",
+"465 20 OFFCURVE",
+"378 20 CURVE SMOOTH",
+"270 20 OFFCURVE",
+"205 87 OFFCURVE",
+"205 365 CURVE SMOOTH",
+"205 667 OFFCURVE",
+"282 736 OFFCURVE",
+"394 736 CURVE SMOOTH",
+"525 736 OFFCURVE",
+"580 640 OFFCURVE",
+"602 528 CURVE",
+"627 528 LINE",
+"627 754 LINE",
+"602 754 LINE",
+"558 704 LINE",
+"508 747 OFFCURVE",
+"457 766 OFFCURVE",
+"394 766 CURVE SMOOTH",
+"195 766 OFFCURVE",
+"45 579 OFFCURVE",
+"45 370 CURVE SMOOTH",
+"45 177 OFFCURVE",
+"174 -12 OFFCURVE",
+"381 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"723 268 LINE",
+"723 293 LINE",
+"393 293 LINE",
+"393 268 LINE"
+);
+}
+);
+width = 737;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{395, 0}";
+},
+{
+name = top;
+position = "{395, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"551 -13 OFFCURVE",
+"657 42 OFFCURVE",
+"701 130 CURVE",
+"701 262 LINE",
+"519 262 LINE",
+"519 145 LINE SMOOTH",
+"519 69 OFFCURVE",
+"477 24 OFFCURVE",
+"395 24 CURVE SMOOTH",
+"296 24 OFFCURVE",
+"240 91 OFFCURVE",
+"240 358 CURVE SMOOTH",
+"240 672 OFFCURVE",
+"317 728 OFFCURVE",
+"420 728 CURVE SMOOTH",
+"557 728 OFFCURVE",
+"612 628 OFFCURVE",
+"632 523 CURVE",
+"662 523 LINE",
+"662 754 LINE",
+"632 754 LINE",
+"593 704 LINE",
+"536 747 OFFCURVE",
+"492 763 OFFCURVE",
+"427 763 CURVE SMOOTH",
+"206 763 OFFCURVE",
+"50 578 OFFCURVE",
+"50 369 CURVE SMOOTH",
+"50 192 OFFCURVE",
+"163 -13 OFFCURVE",
+"419 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"423 250 LINE",
+"778 250 LINE",
+"778 280 LINE",
+"423 280 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"532 -13 OFFCURVE",
+"669 68 OFFCURVE",
+"701 170 CURVE",
+"701 282 LINE",
+"519 282 LINE",
+"519 145 LINE SMOOTH",
+"519 69 OFFCURVE",
+"477 24 OFFCURVE",
+"395 24 CURVE SMOOTH",
+"296 24 OFFCURVE",
+"240 91 OFFCURVE",
+"240 358 CURVE SMOOTH",
+"240 672 OFFCURVE",
+"317 728 OFFCURVE",
+"420 728 CURVE SMOOTH",
+"557 728 OFFCURVE",
+"616 622 OFFCURVE",
+"632 518 CURVE",
+"662 518 LINE",
+"662 754 LINE",
+"632 754 LINE",
+"593 704 LINE",
+"536 747 OFFCURVE",
+"492 763 OFFCURVE",
+"427 763 CURVE SMOOTH",
+"215 763 OFFCURVE",
+"50 589 OFFCURVE",
+"50 367 CURVE SMOOTH",
+"50 155 OFFCURVE",
+"202 -13 OFFCURVE",
+"397 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"778 270 LINE",
+"778 300 LINE",
+"423 300 LINE",
+"423 270 LINE"
+);
+}
+);
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 0047;
+},
+{
+glyphname = Gacute;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 44, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 5, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 01F4;
+},
+{
+glyphname = Gbreve;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 74, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 97, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 011E;
+},
+{
+glyphname = Gcircumflex;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 79, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 011C;
+},
+{
+glyphname = Gcommaaccent;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 283, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 302, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 0122;
+},
+{
+glyphname = Gdotaccent;
+lastChange = "2016-08-22 12:08:14 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 294, 5}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 316, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 0120;
+},
+{
+glyphname = H;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{401, 0}";
+},
+{
+name = center;
+position = "{401, 377}";
+},
+{
+name = top;
+position = "{401, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"123 15 LINE",
+"257 15 LINE",
+"257 754 LINE",
+"123 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"13 0 LINE",
+"367 0 LINE",
+"367 25 LINE",
+"13 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"13 729 LINE",
+"367 729 LINE",
+"367 754 LINE",
+"13 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"545 15 LINE",
+"679 15 LINE",
+"679 754 LINE",
+"545 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 0 LINE",
+"789 0 LINE",
+"789 25 LINE",
+"435 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 729 LINE",
+"789 729 LINE",
+"789 754 LINE",
+"435 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"225 375 LINE",
+"580 375 LINE",
+"580 400 LINE",
+"225 400 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"367 0 LINE",
+"367 25 LINE",
+"257 25 LINE",
+"257 375 LINE",
+"545 375 LINE",
+"545 25 LINE",
+"435 25 LINE",
+"435 0 LINE",
+"789 0 LINE",
+"789 25 LINE",
+"679 25 LINE",
+"679 729 LINE",
+"789 729 LINE",
+"789 754 LINE",
+"435 754 LINE",
+"435 729 LINE",
+"545 729 LINE",
+"545 400 LINE",
+"257 400 LINE",
+"257 729 LINE",
+"367 729 LINE",
+"367 754 LINE",
+"13 754 LINE",
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+}
+);
+width = 801;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{413, 0}";
+},
+{
+name = center;
+position = "{413, 377}";
+},
+{
+name = top;
+position = "{413, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 15 LINE",
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"371 0 LINE",
+"371 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"556 15 LINE",
+"714 15 LINE",
+"714 754 LINE",
+"556 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"458 0 LINE",
+"811 0 LINE",
+"811 30 LINE",
+"458 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"458 724 LINE",
+"811 724 LINE",
+"811 754 LINE",
+"458 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"219 374 LINE",
+"613 374 LINE",
+"613 404 LINE",
+"219 404 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"371 0 LINE",
+"371 30 LINE",
+"273 30 LINE",
+"273 374 LINE",
+"556 374 LINE",
+"556 30 LINE",
+"458 30 LINE",
+"458 0 LINE",
+"811 0 LINE",
+"811 30 LINE",
+"714 30 LINE",
+"714 724 LINE",
+"811 724 LINE",
+"811 754 LINE",
+"458 754 LINE",
+"458 724 LINE",
+"556 724 LINE",
+"556 404 LINE",
+"273 404 LINE",
+"273 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+}
+);
+width = 826;
+}
+);
+leftKerningGroup = H;
+rightKerningGroup = H;
+unicode = 0048;
+},
+{
+glyphname = Hbar;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = H;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"789 548 LINE",
+"789 578 LINE",
+"20 578 LINE",
+"20 548 LINE"
+);
+}
+);
+width = 801;
+},
+{
+components = (
+{
+name = H;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"789 541 LINE",
+"789 578 LINE",
+"20 578 LINE",
+"20 541 LINE"
+);
+}
+);
+width = 826;
+}
+);
+unicode = 0126;
+},
+{
+glyphname = Hcircumflex;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = H;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 111, 304}";
+}
+);
+layerId = UUID0;
+width = 801;
+},
+{
+components = (
+{
+name = H;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 117, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 826;
+}
+);
+leftKerningGroup = H;
+rightKerningGroup = H;
+unicode = 0124;
+},
+{
+glyphname = Hdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = H;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 117, 0}";
+}
+);
+layerId = UUID0;
+width = 801;
+},
+{
+components = (
+{
+name = H;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 120, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 826;
+}
+);
+leftKerningGroup = H;
+rightKerningGroup = H;
+unicode = 1E24;
+},
+{
+glyphname = I;
+lastChange = "2016-08-22 09:51:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{190, 0}";
+},
+{
+name = ogonek;
+position = "{341, 10}";
+},
+{
+name = top;
+position = "{190, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 15 LINE",
+"261 15 LINE",
+"261 754 LINE",
+"127 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"17 0 LINE",
+"371 0 LINE",
+"371 25 LINE",
+"17 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"17 729 LINE",
+"371 729 LINE",
+"371 754 LINE",
+"17 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"257 15 LINE",
+"257 754 LINE",
+"123 754 LINE",
+"123 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"367 0 LINE",
+"367 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"367 729 LINE",
+"367 754 LINE",
+"13 754 LINE",
+"13 729 LINE"
+);
+}
+);
+width = 379;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{193, 0}";
+},
+{
+name = ogonek;
+position = "{347, 10}";
+},
+{
+name = top;
+position = "{193, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"13 729 OFFCURVE",
+"9 713 OFFCURVE",
+"18 702 CURVE",
+"25 697 LINE",
+"58 697 LINE",
+"95 699 OFFCURVE",
+"102 699 OFFCURVE",
+"106 692 CURVE",
+"109 689 OFFCURVE",
+"109 611 OFFCURVE",
+"108 537 CURVE",
+"105 456 OFFCURVE",
+"105 436 OFFCURVE",
+"106 419 CURVE",
+"108 412 OFFCURVE",
+"108 404 OFFCURVE",
+"108 404 CURVE",
+"108 403 OFFCURVE",
+"108 392 OFFCURVE",
+"106 379 CURVE",
+"106 366 OFFCURVE",
+"106 355 OFFCURVE",
+"106 352 CURVE SMOOTH",
+"106 345 OFFCURVE",
+"106 289 OFFCURVE",
+"106 244 CURVE SMOOTH",
+"106 224 OFFCURVE",
+"106 171 OFFCURVE",
+"106 126 CURVE",
+"108 49 OFFCURVE",
+"106 46 OFFCURVE",
+"103 40 CURVE SMOOTH",
+"100 35 LINE",
+"66 35 LINE",
+"23 38 OFFCURVE",
+"18 38 OFFCURVE",
+"13 33 CURVE SMOOTH",
+"2 24 OFFCURVE",
+"5 8 OFFCURVE",
+"18 3 CURVE",
+"23 0 OFFCURVE",
+"29 0 OFFCURVE",
+"45 1 CURVE SMOOTH",
+"77 3 OFFCURVE",
+"265 3 OFFCURVE",
+"290 1 CURVE SMOOTH",
+"338 -2 OFFCURVE",
+"364 -2 OFFCURVE",
+"367 0 CURVE SMOOTH",
+"377 4 OFFCURVE",
+"380 19 OFFCURVE",
+"377 28 CURVE",
+"372 35 OFFCURVE",
+"367 36 OFFCURVE",
+"324 36 CURVE SMOOTH",
+"295 36 OFFCURVE",
+"284 38 OFFCURVE",
+"282 40 CURVE SMOOTH",
+"279 43 OFFCURVE",
+"277 78 OFFCURVE",
+"279 121 CURVE",
+"281 142 OFFCURVE",
+"282 262 OFFCURVE",
+"282 387 CURVE SMOOTH",
+"282 513 OFFCURVE",
+"282 632 OFFCURVE",
+"282 651 CURVE",
+"284 683 OFFCURVE",
+"284 688 OFFCURVE",
+"287 691 CURVE SMOOTH",
+"291 696 OFFCURVE",
+"291 696 OFFCURVE",
+"330 694 CURVE SMOOTH",
+"367 692 OFFCURVE",
+"369 692 OFFCURVE",
+"373 697 CURVE",
+"385 705 OFFCURVE",
+"383 723 OFFCURVE",
+"370 729 CURVE SMOOTH",
+"365 731 OFFCURVE",
+"362 732 OFFCURVE",
+"343 731 CURVE SMOOTH",
+"314 729 OFFCURVE",
+"140 728 OFFCURVE",
+"117 729 CURVE",
+"92 732 OFFCURVE",
+"36 732 OFFCURVE",
+"28 731 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"371 0 LINE",
+"371 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 0049;
+},
+{
+glyphname = IJ;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 379, 0}";
+}
+);
+layerId = UUID0;
+width = 839;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 386, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 772;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = J;
+unicode = 0132;
+},
+{
+glyphname = Iacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -135, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -197, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 00CD;
+},
+{
+glyphname = Ibreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -105, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -105, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 012C;
+},
+{
+glyphname = Icircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -100, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -103, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 00CE;
+},
+{
+glyphname = Idblgrave;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, -23, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, -75, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 0208;
+},
+{
+glyphname = Idieresis;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 26, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 00CF;
+},
+{
+glyphname = Idotaccent;
+lastChange = "2016-08-22 12:08:14 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 115, 5}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 114, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 0130;
+},
+{
+glyphname = Idotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -94, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -100, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 1ECA;
+},
+{
+glyphname = Igrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -97, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -56, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 00CC;
+},
+{
+glyphname = Ihookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -95, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -91, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+unicode = 1EC8;
+},
+{
+glyphname = Iinvertedbreve;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 16, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 020A;
+},
+{
+glyphname = Imacron;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 22, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 21, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 012A;
+},
+{
+glyphname = Iogonek;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = I;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 34, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+alignment = -1;
+name = I;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 39, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 012E;
+},
+{
+glyphname = Itilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -101, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -120, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 0128;
+},
+{
+glyphname = J;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{230, 0}";
+},
+{
+name = top;
+position = "{230, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"46 729 LINE",
+"400 729 LINE",
+"400 754 LINE",
+"46 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"176 125 LINE SMOOTH",
+"176 -33 OFFCURVE",
+"144 -75 OFFCURVE",
+"108 -75 CURVE SMOOTH",
+"95 -75 OFFCURVE",
+"84 -69 OFFCURVE",
+"84 -55 CURVE SMOOTH",
+"84 -37 OFFCURVE",
+"102 -21 OFFCURVE",
+"102 7 CURVE SMOOTH",
+"102 42 OFFCURVE",
+"75 70 OFFCURVE",
+"39 70 CURVE SMOOTH",
+"4 70 OFFCURVE",
+"-29 44 OFFCURVE",
+"-29 -5 CURVE SMOOTH",
+"-29 -63 OFFCURVE",
+"17 -108 OFFCURVE",
+"91 -108 CURVE SMOOTH",
+"204 -108 OFFCURVE",
+"310 -1 OFFCURVE",
+"310 125 CURVE SMOOTH",
+"310 754 LINE",
+"176 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"204 -108 OFFCURVE",
+"310 -1 OFFCURVE",
+"310 125 CURVE SMOOTH",
+"310 754 LINE",
+"176 754 LINE",
+"176 125 LINE SMOOTH",
+"176 -33 OFFCURVE",
+"144 -75 OFFCURVE",
+"108 -75 CURVE SMOOTH",
+"95 -75 OFFCURVE",
+"84 -69 OFFCURVE",
+"84 -55 CURVE SMOOTH",
+"84 -37 OFFCURVE",
+"102 -21 OFFCURVE",
+"102 7 CURVE SMOOTH",
+"102 42 OFFCURVE",
+"75 70 OFFCURVE",
+"39 70 CURVE SMOOTH",
+"4 70 OFFCURVE",
+"-29 44 OFFCURVE",
+"-29 -5 CURVE SMOOTH",
+"-29 -63 OFFCURVE",
+"17 -108 OFFCURVE",
+"91 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 729 LINE",
+"400 754 LINE",
+"46 754 LINE",
+"46 729 LINE"
+);
+}
+);
+width = 460;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{193, 0}";
+},
+{
+name = top;
+position = "{193, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"273 754 LINE",
+"115 754 LINE",
+"115 27 LINE SMOOTH",
+"115 -45 OFFCURVE",
+"75 -64 OFFCURVE",
+"51 -64 CURVE SMOOTH",
+"38 -64 OFFCURVE",
+"23 -59 OFFCURVE",
+"23 -45 CURVE SMOOTH",
+"23 -31 OFFCURVE",
+"41 -11 OFFCURVE",
+"41 20 CURVE SMOOTH",
+"41 65 OFFCURVE",
+"2 91 OFFCURVE",
+"-35 91 CURVE SMOOTH",
+"-81 91 OFFCURVE",
+"-115 51 OFFCURVE",
+"-115 1 CURVE SMOOTH",
+"-115 -60 OFFCURVE",
+"-63 -102 OFFCURVE",
+"35 -102 CURVE SMOOTH",
+"168 -102 OFFCURVE",
+"273 -24 OFFCURVE",
+"273 137 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"168 -102 OFFCURVE",
+"273 -24 OFFCURVE",
+"273 137 CURVE SMOOTH",
+"273 754 LINE",
+"115 754 LINE",
+"115 27 LINE SMOOTH",
+"115 -45 OFFCURVE",
+"75 -64 OFFCURVE",
+"51 -64 CURVE SMOOTH",
+"38 -64 OFFCURVE",
+"23 -59 OFFCURVE",
+"23 -45 CURVE SMOOTH",
+"23 -31 OFFCURVE",
+"41 -11 OFFCURVE",
+"41 20 CURVE SMOOTH",
+"41 65 OFFCURVE",
+"2 91 OFFCURVE",
+"-35 91 CURVE SMOOTH",
+"-81 91 OFFCURVE",
+"-115 51 OFFCURVE",
+"-115 1 CURVE SMOOTH",
+"-115 -60 OFFCURVE",
+"-63 -102 OFFCURVE",
+"35 -102 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 386;
+}
+);
+leftKerningGroup = J;
+rightKerningGroup = J;
+unicode = 004A;
+},
+{
+glyphname = Jcircumflex;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = J;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -60, 304}";
+}
+);
+layerId = UUID0;
+width = 460;
+},
+{
+components = (
+{
+name = J;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -103, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = J;
+rightKerningGroup = J;
+unicode = 0134;
+},
+{
+glyphname = K;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{365, 0}";
+},
+{
+name = top;
+position = "{365, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE",
+"357 0 LINE",
+"357 25 LINE",
+"257 25 LINE",
+"257 729 LINE",
+"357 729 LINE",
+"357 754 LINE",
+"13 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"436 0 LINE",
+"784 0 LINE",
+"784 25 LINE",
+"436 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"555 15 LINE",
+"723 15 LINE",
+"362 469 LINE",
+"267 384 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"438 729 LINE",
+"721 729 LINE",
+"721 754 LINE",
+"438 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"235 361 LINE",
+"235 310 LINE",
+"612 736 LINE",
+"569 736 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"357 0 LINE",
+"357 25 LINE",
+"257 25 LINE",
+"257 729 LINE",
+"357 729 LINE",
+"357 754 LINE",
+"13 754 LINE",
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"784 0 LINE",
+"784 25 LINE",
+"436 25 LINE",
+"436 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"723 15 LINE",
+"362 469 LINE",
+"267 384 LINE",
+"555 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"612 736 LINE",
+"569 736 LINE",
+"235 361 LINE",
+"235 310 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"721 729 LINE",
+"721 754 LINE",
+"438 754 LINE",
+"438 729 LINE"
+);
+}
+);
+width = 729;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{406, 0}";
+},
+{
+name = top;
+position = "{406, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"371 0 LINE",
+"371 30 LINE",
+"273 30 LINE",
+"273 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 0 LINE",
+"826 0 LINE",
+"826 31 LINE",
+"440 31 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 15 LINE",
+"757 15 LINE",
+"423 500 LINE",
+"298 385 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"482 724 LINE",
+"765 724 LINE",
+"765 754 LINE",
+"482 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"249 364 LINE",
+"249 314 LINE",
+"659 736 LINE",
+"613 736 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"371 0 LINE",
+"371 30 LINE",
+"273 30 LINE",
+"273 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"826 0 LINE",
+"826 31 LINE",
+"440 31 LINE",
+"440 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"757 15 LINE",
+"423 500 LINE",
+"298 385 LINE",
+"559 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"659 736 LINE",
+"613 736 LINE",
+"249 364 LINE",
+"249 314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"765 724 LINE",
+"765 754 LINE",
+"482 754 LINE",
+"482 724 LINE"
+);
+}
+);
+width = 811;
+}
+);
+leftKerningGroup = K;
+rightKerningGroup = K;
+unicode = 004B;
+},
+{
+glyphname = Kcommaaccent;
+lastChange = "2016-08-22 12:07:46 +0000";
+layers = (
+{
+components = (
+{
+name = K;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 279, 0}";
+}
+);
+layerId = UUID0;
+width = 729;
+},
+{
+components = (
+{
+name = K;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 313, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 811;
+}
+);
+leftKerningGroup = K;
+rightKerningGroup = K;
+unicode = 0136;
+},
+{
+glyphname = L;
+lastChange = "2016-08-22 12:04:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{331, 0}";
+},
+{
+name = center;
+position = "{331, 377}";
+},
+{
+name = top;
+position = "{192, 754}";
+},
+{
+name = topright;
+position = "{642, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"128 15 LINE",
+"262 15 LINE",
+"262 754 LINE",
+"128 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"10 729 LINE",
+"383 729 LINE",
+"383 754 LINE",
+"10 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"626 0 LINE",
+"626 235 LINE",
+"591 235 LINE",
+"589 123 OFFCURVE",
+"532 25 OFFCURVE",
+"433 25 CURVE SMOOTH",
+"10 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"629 0 LINE",
+"629 235 LINE",
+"594 235 LINE",
+"592 123 OFFCURVE",
+"535 25 OFFCURVE",
+"436 25 CURVE SMOOTH",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 15 LINE",
+"265 754 LINE",
+"131 754 LINE",
+"131 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 729 LINE",
+"386 754 LINE",
+"13 754 LINE",
+"13 729 LINE"
+);
+}
+);
+width = 662;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{341, 0}";
+},
+{
+name = center;
+position = "{341, 377}";
+},
+{
+name = top;
+position = "{186, 754}";
+},
+{
+name = topright;
+position = "{661, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"22 749 OFFCURVE",
+"19 744 OFFCURVE",
+"21 732 CURVE",
+"21 724 OFFCURVE",
+"21 723 OFFCURVE",
+"26 719 CURVE SMOOTH",
+"30 716 OFFCURVE",
+"35 716 OFFCURVE",
+"72 714 CURVE SMOOTH",
+"96 714 OFFCURVE",
+"113 714 OFFCURVE",
+"116 714 CURVE SMOOTH",
+"121 714 OFFCURVE",
+"122 704 OFFCURVE",
+"121 644 CURVE",
+"119 613 OFFCURVE",
+"119 586 OFFCURVE",
+"119 585 CURVE SMOOTH",
+"121 583 OFFCURVE",
+"119 422 OFFCURVE",
+"118 397 CURVE SMOOTH",
+"118 395 OFFCURVE",
+"119 374 OFFCURVE",
+"119 350 CURVE SMOOTH",
+"119 327 OFFCURVE",
+"121 292 OFFCURVE",
+"121 274 CURVE",
+"119 256 OFFCURVE",
+"119 196 OFFCURVE",
+"119 139 CURVE SMOOTH",
+"119 50 OFFCURVE",
+"119 38 OFFCURVE",
+"116 34 CURVE SMOOTH",
+"112 29 LINE",
+"71 29 LINE",
+"27 29 LINE",
+"22 25 LINE",
+"22 17 OFFCURVE",
+"22 3 OFFCURVE",
+"22 -2 CURVE",
+"28 -8 OFFCURVE",
+"34 -10 OFFCURVE",
+"57 -8 CURVE",
+"99 -7 OFFCURVE",
+"260 -5 OFFCURVE",
+"411 -7 CURVE",
+"628 -8 OFFCURVE",
+"649 -8 OFFCURVE",
+"655 -5 CURVE SMOOTH",
+"658 -4 OFFCURVE",
+"661 0 OFFCURVE",
+"664 3 CURVE SMOOTH",
+"666 7 OFFCURVE",
+"666 23 OFFCURVE",
+"666 43 CURVE SMOOTH",
+"666 84 OFFCURVE",
+"669 154 OFFCURVE",
+"672 189 CURVE",
+"677 228 OFFCURVE",
+"677 234 OFFCURVE",
+"670 239 CURVE",
+"666 244 OFFCURVE",
+"664 244 OFFCURVE",
+"653 244 CURVE SMOOTH",
+"639 244 OFFCURVE",
+"632 241 OFFCURVE",
+"628 229 CURVE",
+"622 200 OFFCURVE",
+"616 183 OFFCURVE",
+"605 159 CURVE",
+"597 145 OFFCURVE",
+"592 133 OFFCURVE",
+"592 131 CURVE SMOOTH",
+"592 126 OFFCURVE",
+"562 88 OFFCURVE",
+"544 70 CURVE SMOOTH",
+"534 60 OFFCURVE",
+"512 46 OFFCURVE",
+"503 43 CURVE",
+"495 42 OFFCURVE",
+"489 38 OFFCURVE",
+"484 37 CURVE",
+"473 32 OFFCURVE",
+"464 29 OFFCURVE",
+"392 29 CURVE SMOOTH",
+"358 29 OFFCURVE",
+"325 28 OFFCURVE",
+"320 28 CURVE",
+"310 26 OFFCURVE",
+"310 26 OFFCURVE",
+"304 32 CURVE SMOOTH",
+"301 35 OFFCURVE",
+"300 37 OFFCURVE",
+"300 63 CURVE SMOOTH",
+"300 79 OFFCURVE",
+"300 109 OFFCURVE",
+"300 131 CURVE SMOOTH",
+"300 153 OFFCURVE",
+"301 286 OFFCURVE",
+"301 428 CURVE SMOOTH",
+"301 571 OFFCURVE",
+"301 694 OFFCURVE",
+"301 701 CURVE",
+"303 712 OFFCURVE",
+"303 712 OFFCURVE",
+"309 716 CURVE",
+"309 718 OFFCURVE",
+"317 718 OFFCURVE",
+"335 716 CURVE",
+"344 716 OFFCURVE",
+"365 714 OFFCURVE",
+"376 714 CURVE SMOOTH",
+"399 714 OFFCURVE",
+"399 714 OFFCURVE",
+"404 718 CURVE",
+"404 724 OFFCURVE",
+"404 742 OFFCURVE",
+"404 749 CURVE",
+"401 751 OFFCURVE",
+"386 752 OFFCURVE",
+"317 751 CURVE SMOOTH",
+"196 749 OFFCURVE",
+"122 749 OFFCURVE",
+"55 752 CURVE",
+"47 754 OFFCURVE",
+"38 752 OFFCURVE",
+"32 752 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"661 0 LINE",
+"661 245 LINE",
+"621 245 LINE",
+"619 131 OFFCURVE",
+"554 30 OFFCURVE",
+"443 30 CURVE SMOOTH",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 724 LINE",
+"391 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 681;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = L;
+unicode = 004C;
+},
+{
+glyphname = LJ;
+lastChange = "2016-08-22 12:11:18 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+alignment = -1;
+name = J;
+transform = "{1, 0, 0, 1, 690, 0}";
+}
+);
+layerId = UUID0;
+width = 1122;
+},
+{
+components = (
+{
+name = L;
+},
+{
+alignment = -1;
+name = J;
+transform = "{1, 0, 0, 1, 815, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1236;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = J;
+unicode = 01C7;
+},
+{
+glyphname = Lacute;
+lastChange = "2016-08-22 12:07:46 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -133, 304}";
+}
+);
+layerId = UUID0;
+width = 662;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -204, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 681;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = L;
+unicode = 0139;
+},
+{
+glyphname = Lcaron;
+lastChange = "2016-08-22 12:04:07 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 22, 1}";
+}
+);
+layerId = UUID0;
+width = 662;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, -28, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 681;
+}
+);
+leftKerningGroup = L;
+unicode = 013D;
+},
+{
+glyphname = Lcommaaccent;
+lastChange = "2016-08-22 12:07:46 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 245, 0}";
+}
+);
+layerId = UUID0;
+width = 662;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 248, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 681;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = L;
+unicode = 013B;
+},
+{
+glyphname = Ldot;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = L;
+},
+{
+alignment = -1;
+name = periodcentered;
+transform = "{1, 0, 0, 1, 344, 108}";
+}
+);
+layerId = UUID0;
+width = 828;
+},
+{
+components = (
+{
+alignment = -1;
+name = L;
+},
+{
+alignment = -1;
+name = periodcentered;
+transform = "{1, 0, 0, 1, 310, 116}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 955;
+}
+);
+leftKerningGroup = L;
+unicode = 013F;
+},
+{
+glyphname = Lj;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 662, 0}";
+}
+);
+layerId = UUID0;
+width = 992;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 681, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 999;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = j;
+unicode = 01C8;
+},
+{
+glyphname = Lslash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"415 463 LINE",
+"415 503 LINE",
+"28 277 LINE",
+"28 237 LINE"
+);
+}
+);
+width = 662;
+},
+{
+components = (
+{
+name = L;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"415 463 LINE",
+"415 503 LINE",
+"28 277 LINE",
+"28 237 LINE"
+);
+}
+);
+width = 681;
+}
+);
+unicode = 0141;
+},
+{
+glyphname = M;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{442, 0}";
+},
+{
+name = top;
+position = "{442, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"635 15 LINE",
+"769 15 LINE",
+"769 754 LINE",
+"635 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 0 LINE",
+"879 0 LINE",
+"879 25 LINE",
+"525 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"649 729 LINE",
+"879 729 LINE",
+"879 754 LINE",
+"649 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"129 15 LINE",
+"168 15 LINE",
+"168 754 LINE",
+"129 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"278 0 LINE",
+"278 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 729 LINE",
+"278 729 LINE",
+"278 754 LINE",
+"19 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"290 754 LINE",
+"156 754 LINE",
+"168 665 LINE",
+"172 665 LINE",
+"386 -9 LINE",
+"416 -9 LINE",
+"464 160 LINE",
+"453 226 LINE",
+"449 226 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"432 160 LINE",
+"386 -9 LINE",
+"422 -9 LINE",
+"631 665 LINE",
+"635 665 LINE",
+"655 744 LINE",
+"640 754 LINE",
+"616 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"415 -9 LINE",
+"624 665 LINE",
+"628 665 LINE",
+"628 25 LINE",
+"518 25 LINE",
+"518 0 LINE",
+"872 0 LINE",
+"872 25 LINE",
+"762 25 LINE",
+"762 729 LINE",
+"872 729 LINE",
+"872 754 LINE",
+"609 754 LINE",
+"446 226 LINE",
+"442 226 LINE",
+"283 754 LINE",
+"12 754 LINE",
+"12 729 LINE",
+"122 729 LINE",
+"122 25 LINE",
+"12 25 LINE",
+"12 0 LINE",
+"271 0 LINE",
+"271 25 LINE",
+"161 25 LINE",
+"161 665 LINE",
+"165 665 LINE",
+"379 -9 LINE"
+);
+}
+);
+width = 884;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{464, 0}";
+},
+{
+name = top;
+position = "{464, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"35 749 LINE SMOOTH",
+"28 743 OFFCURVE",
+"27 731 OFFCURVE",
+"31 724 CURVE SMOOTH",
+"34 719 OFFCURVE",
+"53 716 OFFCURVE",
+"64 718 CURVE",
+"69 718 OFFCURVE",
+"86 718 OFFCURVE",
+"102 718 CURVE SMOOTH",
+"126 719 OFFCURVE",
+"126 718 OFFCURVE",
+"131 716 CURVE",
+"135 713 OFFCURVE",
+"135 704 OFFCURVE",
+"135 633 CURVE",
+"133 590 OFFCURVE",
+"133 525 OFFCURVE",
+"133 490 CURVE",
+"131 432 OFFCURVE",
+"131 161 OFFCURVE",
+"131 98 CURVE",
+"133 38 OFFCURVE",
+"123 29 OFFCURVE",
+"65 29 CURVE SMOOTH",
+"35 29 OFFCURVE",
+"27 28 OFFCURVE",
+"23 18 CURVE",
+"22 12 OFFCURVE",
+"23 3 OFFCURVE",
+"28 -2 CURVE SMOOTH",
+"30 -5 OFFCURVE",
+"40 -5 OFFCURVE",
+"150 -5 CURVE SMOOTH",
+"213 -5 OFFCURVE",
+"266 -4 OFFCURVE",
+"268 -4 CURVE",
+"276 0 OFFCURVE",
+"277 17 OFFCURVE",
+"271 25 CURVE",
+"266 28 OFFCURVE",
+"239 34 OFFCURVE",
+"230 29 CURVE",
+"214 26 OFFCURVE",
+"181 37 OFFCURVE",
+"175 48 CURVE",
+"168 56 OFFCURVE",
+"166 78 OFFCURVE",
+"166 106 CURVE",
+"168 133 OFFCURVE",
+"168 289 OFFCURVE",
+"168 557 CURVE SMOOTH",
+"168 623 OFFCURVE",
+"168 679 OFFCURVE",
+"168 681 CURVE",
+"169 682 OFFCURVE",
+"171 684 OFFCURVE",
+"175 682 CURVE",
+"177 682 OFFCURVE",
+"180 677 OFFCURVE",
+"185 661 CURVE SMOOTH",
+"189 649 OFFCURVE",
+"193 636 OFFCURVE",
+"194 633 CURVE",
+"194 624 OFFCURVE",
+"208 591 OFFCURVE",
+"214 568 CURVE",
+"218 557 OFFCURVE",
+"222 536 OFFCURVE",
+"227 525 CURVE",
+"230 513 OFFCURVE",
+"233 500 OFFCURVE",
+"235 497 CURVE",
+"236 493 OFFCURVE",
+"239 482 OFFCURVE",
+"243 470 CURVE SMOOTH",
+"246 460 OFFCURVE",
+"251 442 OFFCURVE",
+"255 428 CURVE",
+"260 417 OFFCURVE",
+"263 402 OFFCURVE",
+"264 399 CURVE SMOOTH",
+"268 382 OFFCURVE",
+"290 319 OFFCURVE",
+"294 302 CURVE",
+"296 297 OFFCURVE",
+"299 286 OFFCURVE",
+"302 278 CURVE SMOOTH",
+"320 220 OFFCURVE",
+"331 179 OFFCURVE",
+"334 171 CURVE SMOOTH",
+"339 161 OFFCURVE",
+"346 136 OFFCURVE",
+"347 129 CURVE SMOOTH",
+"347 125 OFFCURVE",
+"351 117 OFFCURVE",
+"352 108 CURVE",
+"355 100 OFFCURVE",
+"359 84 OFFCURVE",
+"363 73 CURVE SMOOTH",
+"366 62 OFFCURVE",
+"369 48 OFFCURVE",
+"371 43 CURVE SMOOTH",
+"372 38 OFFCURVE",
+"376 26 OFFCURVE",
+"377 20 CURVE",
+"380 12 OFFCURVE",
+"384 3 OFFCURVE",
+"385 1 CURVE",
+"385 -4 OFFCURVE",
+"409 -5 OFFCURVE",
+"409 -4 CURVE",
+"417 -2 OFFCURVE",
+"421 1 OFFCURVE",
+"440 76 CURVE",
+"446 104 OFFCURVE",
+"446 109 OFFCURVE",
+"468 171 CURVE SMOOTH",
+"475 189 OFFCURVE",
+"482 219 OFFCURVE",
+"488 234 CURVE",
+"493 251 OFFCURVE",
+"499 267 OFFCURVE",
+"501 272 CURVE SMOOTH",
+"502 275 OFFCURVE",
+"505 287 OFFCURVE",
+"507 295 CURVE SMOOTH",
+"510 303 OFFCURVE",
+"515 320 OFFCURVE",
+"518 333 CURVE",
+"528 355 OFFCURVE",
+"528 362 OFFCURVE",
+"537 389 CURVE",
+"538 399 OFFCURVE",
+"545 417 OFFCURVE",
+"548 428 CURVE",
+"554 440 OFFCURVE",
+"557 455 OFFCURVE",
+"559 458 CURVE",
+"559 463 OFFCURVE",
+"562 472 OFFCURVE",
+"563 477 CURVE SMOOTH",
+"567 488 OFFCURVE",
+"576 519 OFFCURVE",
+"582 535 CURVE",
+"586 558 OFFCURVE",
+"595 583 OFFCURVE",
+"600 590 CURVE",
+"601 594 OFFCURVE",
+"603 599 OFFCURVE",
+"603 602 CURVE SMOOTH",
+"603 607 OFFCURVE",
+"604 615 OFFCURVE",
+"609 621 CURVE",
+"610 627 OFFCURVE",
+"613 635 OFFCURVE",
+"613 636 CURVE SMOOTH",
+"613 638 OFFCURVE",
+"615 644 OFFCURVE",
+"618 651 CURVE SMOOTH",
+"620 657 OFFCURVE",
+"623 668 OFFCURVE",
+"625 673 CURVE",
+"626 681 OFFCURVE",
+"631 682 OFFCURVE",
+"635 676 CURVE SMOOTH",
+"638 673 OFFCURVE",
+"638 636 OFFCURVE",
+"638 585 CURVE SMOOTH",
+"638 543 OFFCURVE",
+"638 447 OFFCURVE",
+"638 395 CURVE SMOOTH",
+"638 374 OFFCURVE",
+"638 347 OFFCURVE",
+"638 336 CURVE SMOOTH",
+"638 325 OFFCURVE",
+"637 283 OFFCURVE",
+"637 241 CURVE SMOOTH",
+"637 118 OFFCURVE",
+"637 46 OFFCURVE",
+"635 40 CURVE SMOOTH",
+"631 31 OFFCURVE",
+"629 31 OFFCURVE",
+"604 29 CURVE",
+"573 29 OFFCURVE",
+"548 26 OFFCURVE",
+"545 23 CURVE SMOOTH",
+"540 20 OFFCURVE",
+"538 12 OFFCURVE",
+"540 4 CURVE",
+"542 0 OFFCURVE",
+"545 -2 OFFCURVE",
+"550 -4 CURVE SMOOTH",
+"554 -5 OFFCURVE",
+"587 -5 OFFCURVE",
+"623 -5 CURVE SMOOTH",
+"776 -4 OFFCURVE",
+"814 -4 OFFCURVE",
+"874 -7 CURVE SMOOTH",
+"906 -8 LINE",
+"912 -2 LINE SMOOTH",
+"919 4 OFFCURVE",
+"919 12 OFFCURVE",
+"916 21 CURVE",
+"911 29 OFFCURVE",
+"903 29 OFFCURVE",
+"861 29 CURVE",
+"826 28 OFFCURVE",
+"820 28 OFFCURVE",
+"819 31 CURVE SMOOTH",
+"816 35 OFFCURVE",
+"814 43 OFFCURVE",
+"816 56 CURVE",
+"816 90 OFFCURVE",
+"817 287 OFFCURVE",
+"817 380 CURVE SMOOTH",
+"817 447 OFFCURVE",
+"817 503 OFFCURVE",
+"817 507 CURVE SMOOTH",
+"817 508 OFFCURVE",
+"817 525 OFFCURVE",
+"817 541 CURVE SMOOTH",
+"816 610 OFFCURVE",
+"817 699 OFFCURVE",
+"819 706 CURVE SMOOTH",
+"820 710 OFFCURVE",
+"822 715 OFFCURVE",
+"825 716 CURVE",
+"828 719 OFFCURVE",
+"846 719 OFFCURVE",
+"879 716 CURVE",
+"902 715 OFFCURVE",
+"911 716 OFFCURVE",
+"916 724 CURVE SMOOTH",
+"919 731 OFFCURVE",
+"919 741 OFFCURVE",
+"912 746 CURVE",
+"908 751 LINE",
+"858 751 LINE",
+"794 749 OFFCURVE",
+"736 749 OFFCURVE",
+"671 751 CURVE",
+"620 751 LINE",
+"615 746 LINE SMOOTH",
+"613 743 OFFCURVE",
+"609 729 OFFCURVE",
+"603 713 CURVE SMOOTH",
+"598 698 OFFCURVE",
+"590 674 OFFCURVE",
+"587 661 CURVE",
+"582 648 OFFCURVE",
+"576 632 OFFCURVE",
+"575 623 CURVE",
+"567 593 OFFCURVE",
+"559 569 OFFCURVE",
+"554 557 CURVE SMOOTH",
+"551 548 OFFCURVE",
+"548 538 OFFCURVE",
+"546 535 CURVE",
+"546 528 OFFCURVE",
+"538 505 OFFCURVE",
+"529 475 CURVE",
+"526 461 OFFCURVE",
+"521 449 OFFCURVE",
+"520 444 CURVE",
+"520 438 OFFCURVE",
+"518 432 OFFCURVE",
+"517 428 CURVE SMOOTH",
+"513 420 OFFCURVE",
+"510 411 OFFCURVE",
+"509 402 CURVE",
+"507 399 OFFCURVE",
+"502 382 OFFCURVE",
+"496 367 CURVE",
+"492 350 OFFCURVE",
+"487 336 OFFCURVE",
+"487 333 CURVE SMOOTH",
+"485 324 OFFCURVE",
+"480 316 OFFCURVE",
+"477 316 CURVE SMOOTH",
+"476 316 OFFCURVE",
+"474 320 OFFCURVE",
+"472 325 CURVE SMOOTH",
+"470 330 OFFCURVE",
+"467 337 OFFCURVE",
+"465 342 CURVE SMOOTH",
+"463 349 OFFCURVE",
+"455 374 OFFCURVE",
+"446 410 CURVE",
+"442 420 OFFCURVE",
+"437 435 OFFCURVE",
+"434 447 CURVE SMOOTH",
+"432 457 OFFCURVE",
+"426 475 OFFCURVE",
+"422 486 CURVE",
+"419 499 OFFCURVE",
+"413 513 OFFCURVE",
+"412 521 CURVE",
+"410 528 OFFCURVE",
+"405 540 OFFCURVE",
+"404 546 CURVE SMOOTH",
+"402 553 OFFCURVE",
+"401 561 OFFCURVE",
+"399 566 CURVE SMOOTH",
+"397 571 OFFCURVE",
+"394 582 OFFCURVE",
+"391 590 CURVE SMOOTH",
+"388 598 OFFCURVE",
+"385 607 OFFCURVE",
+"385 608 CURVE SMOOTH",
+"382 621 OFFCURVE",
+"374 649 OFFCURVE",
+"371 656 CURVE SMOOTH",
+"369 660 OFFCURVE",
+"366 669 OFFCURVE",
+"364 677 CURVE SMOOTH",
+"357 709 OFFCURVE",
+"355 718 OFFCURVE",
+"352 731 CURVE SMOOTH",
+"346 752 OFFCURVE",
+"352 751 OFFCURVE",
+"255 751 CURVE SMOOTH",
+"208 751 OFFCURVE",
+"139 752 OFFCURVE",
+"105 752 CURVE",
+"40 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"388 291 OFFCURVE",
+"387 291 OFFCURVE",
+"385 291 CURVE SMOOTH",
+"385 291 OFFCURVE",
+"385 291 OFFCURVE",
+"385 292 CURVE SMOOTH",
+"387 295 OFFCURVE",
+"393 294 OFFCURVE",
+"391 292 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 237 OFFCURVE",
+"415 237 OFFCURVE",
+"415 236 CURVE SMOOTH",
+"412 233 OFFCURVE",
+"407 236 OFFCURVE",
+"409 239 CURVE SMOOTH",
+"410 242 OFFCURVE",
+"412 244 OFFCURVE",
+"415 241 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"433 -9 LINE",
+"646 684 LINE",
+"650 684 LINE",
+"650 30 LINE",
+"543 30 LINE",
+"543 0 LINE",
+"912 0 LINE",
+"912 30 LINE",
+"808 30 LINE",
+"808 724 LINE",
+"912 724 LINE",
+"912 754 LINE",
+"622 754 LINE",
+"481 299 LINE",
+"477 299 LINE",
+"336 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"130 724 LINE",
+"130 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"174 30 LINE",
+"174 684 LINE",
+"178 684 LINE",
+"392 -9 LINE"
+);
+}
+);
+width = 927;
+}
+);
+unicode = 004D;
+},
+{
+glyphname = N;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{372, 0}";
+},
+{
+name = top;
+position = "{372, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"125 15 LINE",
+"164 15 LINE",
+"164 754 LINE",
+"125 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 0 LINE",
+"274 0 LINE",
+"274 25 LINE",
+"15 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 729 LINE",
+"274 729 LINE",
+"274 754 LINE",
+"15 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"596 223 LINE",
+"604 -13 LINE",
+"635 -13 LINE",
+"635 754 LINE",
+"596 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"496 729 LINE",
+"735 729 LINE",
+"735 754 LINE",
+"496 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"286 754 LINE",
+"152 754 LINE",
+"164 683 LINE",
+"168 683 LINE",
+"604 -13 LINE",
+"626 -13 LINE",
+"596 268 LINE",
+"592 268 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"633 -12 LINE",
+"633 729 LINE",
+"733 729 LINE",
+"733 754 LINE",
+"494 754 LINE",
+"494 729 LINE",
+"594 729 LINE",
+"594 268 LINE",
+"590 268 LINE",
+"284 754 LINE",
+"13 754 LINE",
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE",
+"272 0 LINE",
+"272 25 LINE",
+"162 25 LINE",
+"162 683 LINE",
+"166 683 LINE",
+"602 -12 LINE"
+);
+}
+);
+width = 744;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{396, 0}";
+},
+{
+name = top;
+position = "{396, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"748 751 OFFCURVE",
+"701 751 OFFCURVE",
+"647 751 CURVE SMOOTH",
+"543 751 LINE",
+"538 746 LINE SMOOTH",
+"534 743 OFFCURVE",
+"533 742 OFFCURVE",
+"534 734 CURVE SMOOTH",
+"536 718 OFFCURVE",
+"544 713 OFFCURVE",
+"584 712 CURVE",
+"616 709 OFFCURVE",
+"625 706 OFFCURVE",
+"631 690 CURVE",
+"634 679 OFFCURVE",
+"634 662 OFFCURVE",
+"634 545 CURVE SMOOTH",
+"634 538 OFFCURVE",
+"634 505 OFFCURVE",
+"634 473 CURVE",
+"636 442 OFFCURVE",
+"636 402 OFFCURVE",
+"636 384 CURVE SMOOTH",
+"636 320 OFFCURVE",
+"636 318 OFFCURVE",
+"630 320 CURVE SMOOTH",
+"625 321 OFFCURVE",
+"608 343 OFFCURVE",
+"589 371 CURVE",
+"570 402 OFFCURVE",
+"555 423 OFFCURVE",
+"545 435 CURVE",
+"539 440 OFFCURVE",
+"533 451 OFFCURVE",
+"528 459 CURVE SMOOTH",
+"523 467 OFFCURVE",
+"513 480 OFFCURVE",
+"506 488 CURVE SMOOTH",
+"500 496 OFFCURVE",
+"492 509 OFFCURVE",
+"486 515 CURVE",
+"483 520 OFFCURVE",
+"478 529 OFFCURVE",
+"476 530 CURVE",
+"473 534 OFFCURVE",
+"465 545 OFFCURVE",
+"456 557 CURVE SMOOTH",
+"448 568 OFFCURVE",
+"440 582 OFFCURVE",
+"438 584 CURVE SMOOTH",
+"428 596 OFFCURVE",
+"415 617 OFFCURVE",
+"408 625 CURVE SMOOTH",
+"405 629 OFFCURVE",
+"397 642 OFFCURVE",
+"389 651 CURVE SMOOTH",
+"380 662 OFFCURVE",
+"375 671 OFFCURVE",
+"375 673 CURVE SMOOTH",
+"375 673 OFFCURVE",
+"370 682 OFFCURVE",
+"364 690 CURVE SMOOTH",
+"351 704 OFFCURVE",
+"343 717 OFFCURVE",
+"336 729 CURVE SMOOTH",
+"325 750 OFFCURVE",
+"320 753 OFFCURVE",
+"280 750 CURVE",
+"256 750 OFFCURVE",
+"183 750 OFFCURVE",
+"80 751 CURVE",
+"26 753 LINE",
+"23 748 LINE SMOOTH",
+"18 742 OFFCURVE",
+"18 728 OFFCURVE",
+"22 721 CURVE",
+"25 718 OFFCURVE",
+"25 718 OFFCURVE",
+"57 717 CURVE",
+"104 717 OFFCURVE",
+"111 715 OFFCURVE",
+"125 695 CURVE SMOOTH",
+"130 687 LINE",
+"130 617 LINE",
+"131 578 OFFCURVE",
+"131 540 OFFCURVE",
+"131 530 CURVE SMOOTH",
+"131 521 OFFCURVE",
+"130 413 OFFCURVE",
+"130 290 CURVE SMOOTH",
+"130 165 OFFCURVE",
+"128 62 OFFCURVE",
+"128 57 CURVE",
+"126 47 OFFCURVE",
+"120 38 OFFCURVE",
+"112 34 CURVE SMOOTH",
+"103 29 LINE",
+"65 29 LINE",
+"26 29 LINE",
+"22 22 LINE",
+"22 15 OFFCURVE",
+"22 4 OFFCURVE",
+"22 -3 CURVE",
+"28 -8 LINE",
+"148 -8 LINE SMOOTH",
+"220 -8 OFFCURVE",
+"270 -8 OFFCURVE",
+"272 -6 CURVE SMOOTH",
+"278 -1 OFFCURVE",
+"281 10 OFFCURVE",
+"276 21 CURVE SMOOTH",
+"273 27 OFFCURVE",
+"267 29 OFFCURVE",
+"228 29 CURVE SMOOTH",
+"193 29 OFFCURVE",
+"187 30 OFFCURVE",
+"176 40 CURVE",
+"167 54 OFFCURVE",
+"165 63 OFFCURVE",
+"165 159 CURVE SMOOTH",
+"165 205 OFFCURVE",
+"165 326 OFFCURVE",
+"165 427 CURVE SMOOTH",
+"165 529 OFFCURVE",
+"165 617 OFFCURVE",
+"167 623 CURVE",
+"169 642 OFFCURVE",
+"172 645 OFFCURVE",
+"181 635 CURVE",
+"185 634 OFFCURVE",
+"190 626 OFFCURVE",
+"192 623 CURVE",
+"192 618 OFFCURVE",
+"214 604 OFFCURVE",
+"214 592 CURVE",
+"221 580 OFFCURVE",
+"231 567 OFFCURVE",
+"231 565 CURVE",
+"233 562 OFFCURVE",
+"237 557 OFFCURVE",
+"240 553 CURVE SMOOTH",
+"243 550 OFFCURVE",
+"249 542 OFFCURVE",
+"253 535 CURVE SMOOTH",
+"267 515 OFFCURVE",
+"300 467 OFFCURVE",
+"317 445 CURVE",
+"323 432 OFFCURVE",
+"330 425 OFFCURVE",
+"336 415 CURVE",
+"343 409 OFFCURVE",
+"350 396 OFFCURVE",
+"370 370 CURVE",
+"376 360 OFFCURVE",
+"381 352 OFFCURVE",
+"381 352 CURVE",
+"381 351 OFFCURVE",
+"384 345 OFFCURVE",
+"390 340 CURVE",
+"394 335 OFFCURVE",
+"403 323 OFFCURVE",
+"408 313 CURVE",
+"416 305 OFFCURVE",
+"423 293 OFFCURVE",
+"426 288 CURVE",
+"438 274 OFFCURVE",
+"448 263 OFFCURVE",
+"456 249 CURVE",
+"462 242 OFFCURVE",
+"470 229 OFFCURVE",
+"476 220 CURVE",
+"484 212 OFFCURVE",
+"489 201 OFFCURVE",
+"493 196 CURVE SMOOTH",
+"497 192 OFFCURVE",
+"500 185 OFFCURVE",
+"503 184 CURVE",
+"505 180 OFFCURVE",
+"509 176 OFFCURVE",
+"511 170 CURVE",
+"514 167 OFFCURVE",
+"520 159 OFFCURVE",
+"523 155 CURVE SMOOTH",
+"526 151 OFFCURVE",
+"534 140 OFFCURVE",
+"539 132 CURVE SMOOTH",
+"544 124 OFFCURVE",
+"553 113 OFFCURVE",
+"558 109 CURVE",
+"563 102 OFFCURVE",
+"569 93 OFFCURVE",
+"573 88 CURVE",
+"577 79 OFFCURVE",
+"585 67 OFFCURVE",
+"603 37 CURVE SMOOTH",
+"615 17 OFFCURVE",
+"639 -13 OFFCURVE",
+"641 -15 CURVE",
+"641 -18 OFFCURVE",
+"641 -20 OFFCURVE",
+"664 -18 CURVE",
+"675 -15 OFFCURVE",
+"676 -10 OFFCURVE",
+"676 22 CURVE SMOOTH",
+"676 37 OFFCURVE",
+"675 55 OFFCURVE",
+"675 65 CURVE",
+"673 80 OFFCURVE",
+"672 402 OFFCURVE",
+"673 588 CURVE SMOOTH",
+"673 675 OFFCURVE",
+"675 688 OFFCURVE",
+"683 701 CURVE SMOOTH",
+"692 715 OFFCURVE",
+"696 715 OFFCURVE",
+"736 715 CURVE SMOOTH",
+"769 715 LINE",
+"773 720 LINE SMOOTH",
+"783 731 OFFCURVE",
+"778 748 OFFCURVE",
+"766 753 CURVE",
+"758 754 OFFCURVE",
+"751 754 OFFCURVE",
+"750 753 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"676 -13 LINE",
+"676 724 LINE",
+"776 724 LINE",
+"776 754 LINE",
+"532 754 LINE",
+"532 724 LINE",
+"632 724 LINE",
+"632 309 LINE",
+"628 309 LINE",
+"312 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"130 724 LINE",
+"130 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"174 30 LINE",
+"174 641 LINE",
+"178 641 LINE",
+"632 -13 LINE"
+);
+}
+);
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 004E;
+},
+{
+glyphname = NJ;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 744, 0}";
+}
+);
+layerId = UUID0;
+width = 1204;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 791, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1177;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = J;
+unicode = 01CA;
+},
+{
+glyphname = Nacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 47, 304}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 6, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 0143;
+},
+{
+glyphname = Ncaron;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 202, 1}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 182, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 0147;
+},
+{
+glyphname = Ncommaaccent;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 286, 0}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 303, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 0145;
+},
+{
+glyphname = Ndotaccent;
+lastChange = "2016-08-22 12:08:14 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 297, 5}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 317, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 1E44;
+},
+{
+glyphname = Nj;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 744, 0}";
+}
+);
+layerId = UUID0;
+width = 1074;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 791, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1109;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = j;
+unicode = 01CB;
+},
+{
+glyphname = Ntilde;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 81, 304}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 83, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 00D1;
+},
+{
+glyphname = Eng;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"597 76 LINE SMOOTH",
+"597 -82 OFFCURVE",
+"565 -124 OFFCURVE",
+"529 -124 CURVE SMOOTH",
+"516 -124 OFFCURVE",
+"505 -118 OFFCURVE",
+"505 -104 CURVE SMOOTH",
+"505 -86 OFFCURVE",
+"523 -70 OFFCURVE",
+"523 -42 CURVE SMOOTH",
+"523 -7 OFFCURVE",
+"496 21 OFFCURVE",
+"460 21 CURVE SMOOTH",
+"425 21 OFFCURVE",
+"392 -5 OFFCURVE",
+"392 -54 CURVE SMOOTH",
+"392 -112 OFFCURVE",
+"438 -157 OFFCURVE",
+"513 -157 CURVE SMOOTH",
+"574 -157 OFFCURVE",
+"635 -127 OFFCURVE",
+"635 76 CURVE SMOOTH",
+"635 735 LINE",
+"597 735 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"125 15 LINE",
+"164 15 LINE",
+"164 754 LINE",
+"125 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 0 LINE",
+"274 0 LINE",
+"274 25 LINE",
+"15 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 729 LINE",
+"274 729 LINE",
+"274 754 LINE",
+"15 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"496 729 LINE",
+"735 729 LINE",
+"735 754 LINE",
+"496 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"286 754 LINE",
+"152 754 LINE",
+"164 683 LINE",
+"168 683 LINE",
+"604 47 LINE",
+"626 47 LINE",
+"597 328 LINE",
+"593 328 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"574 -157 OFFCURVE",
+"635 -127 OFFCURVE",
+"635 76 CURVE SMOOTH",
+"635 729 LINE",
+"735 729 LINE",
+"735 754 LINE",
+"496 754 LINE",
+"496 729 LINE",
+"597 729 LINE",
+"597 328 LINE",
+"593 328 LINE",
+"286 754 LINE",
+"15 754 LINE",
+"15 729 LINE",
+"125 729 LINE",
+"125 25 LINE",
+"15 25 LINE",
+"15 0 LINE",
+"274 0 LINE",
+"274 25 LINE",
+"164 25 LINE",
+"164 683 LINE",
+"168 683 LINE",
+"597 57 LINE",
+"597 25 LINE SMOOTH",
+"597 -82 OFFCURVE",
+"560 -124 OFFCURVE",
+"529 -124 CURVE SMOOTH",
+"516 -124 OFFCURVE",
+"505 -118 OFFCURVE",
+"505 -104 CURVE SMOOTH",
+"505 -86 OFFCURVE",
+"523 -70 OFFCURVE",
+"523 -42 CURVE SMOOTH",
+"523 -7 OFFCURVE",
+"496 21 OFFCURVE",
+"460 21 CURVE SMOOTH",
+"425 21 OFFCURVE",
+"392 -5 OFFCURVE",
+"392 -54 CURVE SMOOTH",
+"392 -112 OFFCURVE",
+"438 -157 OFFCURVE",
+"513 -157 CURVE SMOOTH",
+"513 -157 LINE SMOOTH"
+);
+}
+);
+width = 743;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"676 686 LINE",
+"632 686 LINE",
+"632 21 LINE SMOOTH",
+"632 -104 OFFCURVE",
+"592 -122 OFFCURVE",
+"567 -122 CURVE SMOOTH",
+"554 -122 OFFCURVE",
+"540 -117 OFFCURVE",
+"540 -104 CURVE SMOOTH",
+"540 -89 OFFCURVE",
+"558 -76 OFFCURVE",
+"558 -47 CURVE SMOOTH",
+"558 -4 OFFCURVE",
+"519 23 OFFCURVE",
+"482 23 CURVE SMOOTH",
+"436 23 OFFCURVE",
+"402 -17 OFFCURVE",
+"402 -67 CURVE SMOOTH",
+"402 -128 OFFCURVE",
+"452 -170 OFFCURVE",
+"536 -170 CURVE SMOOTH",
+"642 -170 OFFCURVE",
+"676 -102 OFFCURVE",
+"676 20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 15 LINE",
+"174 15 LINE",
+"174 754 LINE",
+"130 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"284 724 LINE",
+"284 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"632 57 LINE",
+"676 57 LINE",
+"676 754 LINE",
+"632 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 724 LINE",
+"776 724 LINE",
+"776 754 LINE",
+"532 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 754 LINE",
+"162 754 LINE",
+"174 641 LINE",
+"178 641 LINE",
+"632 57 LINE",
+"662 57 LINE",
+"632 379 LINE",
+"628 379 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"642 -170 OFFCURVE",
+"676 -102 OFFCURVE",
+"676 20 CURVE SMOOTH",
+"676 724 LINE",
+"776 724 LINE",
+"776 754 LINE",
+"532 754 LINE",
+"532 724 LINE",
+"632 724 LINE",
+"632 379 LINE",
+"628 379 LINE",
+"312 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"130 724 LINE",
+"130 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"174 30 LINE",
+"174 641 LINE",
+"178 641 LINE",
+"632 57 LINE",
+"632 21 LINE SMOOTH",
+"632 -104 OFFCURVE",
+"592 -122 OFFCURVE",
+"567 -122 CURVE SMOOTH",
+"554 -122 OFFCURVE",
+"540 -117 OFFCURVE",
+"540 -104 CURVE SMOOTH",
+"540 -89 OFFCURVE",
+"558 -76 OFFCURVE",
+"558 -47 CURVE SMOOTH",
+"558 -4 OFFCURVE",
+"519 23 OFFCURVE",
+"482 23 CURVE SMOOTH",
+"436 23 OFFCURVE",
+"402 -17 OFFCURVE",
+"402 -67 CURVE SMOOTH",
+"402 -128 OFFCURVE",
+"452 -170 OFFCURVE",
+"536 -170 CURVE SMOOTH",
+"536 -170 LINE"
+);
+}
+);
+width = 791;
+}
+);
+leftKerningGroup = N;
+unicode = 014A;
+},
+{
+glyphname = O;
+lastChange = "2016-08-22 09:33:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{391, 0}";
+},
+{
+name = center;
+position = "{391, 377}";
+},
+{
+name = ogonek;
+position = "{704, 10}";
+},
+{
+name = top;
+position = "{391, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+},
+{
+name = topright;
+position = "{550, 701}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 172 OFFCURVE",
+"152 -13 OFFCURVE",
+"346 -13 CURVE SMOOTH",
+"540 -13 OFFCURVE",
+"693 172 OFFCURVE",
+"693 380 CURVE SMOOTH",
+"693 582 OFFCURVE",
+"540 763 OFFCURVE",
+"346 763 CURVE SMOOTH",
+"152 763 OFFCURVE",
+"0 582 OFFCURVE",
+"0 380 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 666 OFFCURVE",
+"209 733 OFFCURVE",
+"345 733 CURVE SMOOTH",
+"482 733 OFFCURVE",
+"533 665 OFFCURVE",
+"533 378 CURVE SMOOTH",
+"533 86 OFFCURVE",
+"483 17 OFFCURVE",
+"346 17 CURVE SMOOTH",
+"209 17 OFFCURVE",
+"160 85 OFFCURVE",
+"160 380 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"585 -12 OFFCURVE",
+"738 169 OFFCURVE",
+"738 377 CURVE SMOOTH",
+"738 585 OFFCURVE",
+"585 766 OFFCURVE",
+"391 766 CURVE SMOOTH",
+"197 766 OFFCURVE",
+"44 585 OFFCURVE",
+"44 377 CURVE SMOOTH",
+"44 169 OFFCURVE",
+"197 -12 OFFCURVE",
+"391 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 18 OFFCURVE",
+"204 91 OFFCURVE",
+"204 377 CURVE SMOOTH",
+"204 663 OFFCURVE",
+"255 736 OFFCURVE",
+"391 736 CURVE SMOOTH",
+"527 736 OFFCURVE",
+"578 664 OFFCURVE",
+"578 378 CURVE SMOOTH",
+"578 92 OFFCURVE",
+"527 18 OFFCURVE",
+"391 18 CURVE SMOOTH"
+);
+}
+);
+width = 782;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{412, 0}";
+},
+{
+name = center;
+position = "{412, 377}";
+},
+{
+name = ogonek;
+position = "{741, 10}";
+},
+{
+name = top;
+position = "{412, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+},
+{
+name = topright;
+position = "{451, 702}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"351 753 OFFCURVE",
+"340 751 OFFCURVE",
+"330 748 CURVE SMOOTH",
+"321 746 OFFCURVE",
+"310 743 OFFCURVE",
+"305 741 CURVE SMOOTH",
+"294 738 OFFCURVE",
+"236 713 OFFCURVE",
+"220 703 CURVE SMOOTH",
+"204 692 OFFCURVE",
+"175 669 OFFCURVE",
+"167 661 CURVE SMOOTH",
+"159 652 OFFCURVE",
+"153 647 OFFCURVE",
+"138 631 CURVE",
+"130 625 OFFCURVE",
+"119 613 OFFCURVE",
+"113 605 CURVE SMOOTH",
+"100 589 OFFCURVE",
+"68 537 OFFCURVE",
+"68 532 CURVE SMOOTH",
+"68 530 OFFCURVE",
+"68 529 OFFCURVE",
+"66 527 CURVE SMOOTH",
+"65 525 OFFCURVE",
+"54 501 OFFCURVE",
+"49 489 CURVE SMOOTH",
+"41 465 OFFCURVE",
+"39 457 OFFCURVE",
+"38 442 CURVE",
+"33 405 OFFCURVE",
+"31 394 OFFCURVE",
+"31 393 CURVE SMOOTH",
+"31 391 OFFCURVE",
+"31 380 OFFCURVE",
+"33 367 CURVE SMOOTH",
+"34 354 OFFCURVE",
+"34 343 OFFCURVE",
+"34 341 CURVE SMOOTH",
+"33 335 OFFCURVE",
+"38 292 OFFCURVE",
+"47 273 CURVE",
+"58 241 OFFCURVE",
+"70 207 OFFCURVE",
+"81 194 CURVE",
+"105 156 OFFCURVE",
+"110 149 OFFCURVE",
+"140 117 CURVE SMOOTH",
+"175 81 OFFCURVE",
+"218 49 OFFCURVE",
+"255 33 CURVE SMOOTH",
+"259 31 OFFCURVE",
+"264 28 OFFCURVE",
+"273 25 CURVE",
+"277 21 OFFCURVE",
+"285 20 OFFCURVE",
+"286 20 CURVE SMOOTH",
+"286 20 OFFCURVE",
+"290 18 OFFCURVE",
+"295 15 CURVE",
+"311 9 OFFCURVE",
+"354 -1 OFFCURVE",
+"382 -3 CURVE SMOOTH",
+"447 -6 OFFCURVE",
+"500 7 OFFCURVE",
+"570 47 CURVE SMOOTH",
+"610 69 OFFCURVE",
+"654 109 OFFCURVE",
+"694 159 CURVE",
+"705 175 OFFCURVE",
+"738 239 OFFCURVE",
+"743 257 CURVE SMOOTH",
+"752 285 OFFCURVE",
+"761 314 OFFCURVE",
+"761 335 CURVE SMOOTH",
+"761 362 OFFCURVE",
+"761 401 OFFCURVE",
+"761 417 CURVE",
+"759 433 OFFCURVE",
+"751 469 OFFCURVE",
+"746 479 CURVE",
+"745 485 OFFCURVE",
+"743 490 OFFCURVE",
+"743 492 CURVE SMOOTH",
+"743 497 OFFCURVE",
+"732 525 OFFCURVE",
+"726 538 CURVE SMOOTH",
+"710 569 OFFCURVE",
+"676 615 OFFCURVE",
+"650 641 CURVE",
+"630 663 OFFCURVE",
+"586 697 OFFCURVE",
+"567 708 CURVE SMOOTH",
+"564 709 OFFCURVE",
+"514 733 OFFCURVE",
+"510 735 CURVE SMOOTH",
+"500 740 OFFCURVE",
+"476 745 OFFCURVE",
+"466 745 CURVE SMOOTH",
+"463 745 OFFCURVE",
+"457 746 OFFCURVE",
+"454 748 CURVE SMOOTH",
+"442 753 OFFCURVE",
+"377 756 OFFCURVE",
+"354 753 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 705 OFFCURVE",
+"510 693 OFFCURVE",
+"516 687 CURVE SMOOTH",
+"528 674 OFFCURVE",
+"540 652 OFFCURVE",
+"540 636 CURVE",
+"542 628 OFFCURVE",
+"543 618 OFFCURVE",
+"545 615 CURVE",
+"545 612 OFFCURVE",
+"545 607 OFFCURVE",
+"545 605 CURVE SMOOTH",
+"545 604 OFFCURVE",
+"545 594 OFFCURVE",
+"546 583 CURVE",
+"548 573 OFFCURVE",
+"550 554 OFFCURVE",
+"550 541 CURVE SMOOTH",
+"550 530 OFFCURVE",
+"551 513 OFFCURVE",
+"551 503 CURVE",
+"553 493 OFFCURVE",
+"554 473 OFFCURVE",
+"554 457 CURVE",
+"556 433 OFFCURVE",
+"556 426 OFFCURVE",
+"553 412 CURVE SMOOTH",
+"550 397 OFFCURVE",
+"550 393 OFFCURVE",
+"551 386 CURVE",
+"553 380 OFFCURVE",
+"554 361 OFFCURVE",
+"553 314 CURVE SMOOTH",
+"553 279 OFFCURVE",
+"551 247 OFFCURVE",
+"551 244 CURVE SMOOTH",
+"551 242 OFFCURVE",
+"550 229 OFFCURVE",
+"548 217 CURVE",
+"543 153 OFFCURVE",
+"538 125 OFFCURVE",
+"532 105 CURVE SMOOTH",
+"524 82 OFFCURVE",
+"521 74 OFFCURVE",
+"510 65 CURVE",
+"497 52 OFFCURVE",
+"478 44 OFFCURVE",
+"446 36 CURVE SMOOTH",
+"431 33 OFFCURVE",
+"430 33 OFFCURVE",
+"425 34 CURVE",
+"418 37 OFFCURVE",
+"418 37 OFFCURVE",
+"409 34 CURVE SMOOTH",
+"404 33 OFFCURVE",
+"398 31 OFFCURVE",
+"393 31 CURVE",
+"390 33 OFFCURVE",
+"385 33 OFFCURVE",
+"382 33 CURVE SMOOTH",
+"356 33 OFFCURVE",
+"335 36 OFFCURVE",
+"327 41 CURVE",
+"322 42 OFFCURVE",
+"316 45 OFFCURVE",
+"313 45 CURVE",
+"302 49 OFFCURVE",
+"284 61 OFFCURVE",
+"284 66 CURVE SMOOTH",
+"284 68 OFFCURVE",
+"281 69 OFFCURVE",
+"279 71 CURVE SMOOTH",
+"276 73 OFFCURVE",
+"271 76 OFFCURVE",
+"270 77 CURVE SMOOTH",
+"265 84 OFFCURVE",
+"255 108 OFFCURVE",
+"250 127 CURVE",
+"247 143 OFFCURVE",
+"239 215 OFFCURVE",
+"239 241 CURVE SMOOTH",
+"239 287 OFFCURVE",
+"239 474 OFFCURVE",
+"239 495 CURVE",
+"241 508 OFFCURVE",
+"241 519 OFFCURVE",
+"241 521 CURVE SMOOTH",
+"241 522 OFFCURVE",
+"241 530 OFFCURVE",
+"241 538 CURVE SMOOTH",
+"242 548 OFFCURVE",
+"244 569 OFFCURVE",
+"246 586 CURVE SMOOTH",
+"249 613 OFFCURVE",
+"250 620 OFFCURVE",
+"257 641 CURVE SMOOTH",
+"261 655 OFFCURVE",
+"266 668 OFFCURVE",
+"270 671 CURVE",
+"271 673 OFFCURVE",
+"273 677 OFFCURVE",
+"273 679 CURVE",
+"276 684 OFFCURVE",
+"280 689 OFFCURVE",
+"290 697 CURVE",
+"303 705 OFFCURVE",
+"312 708 OFFCURVE",
+"330 711 CURVE",
+"340 711 OFFCURVE",
+"352 714 OFFCURVE",
+"362 716 CURVE SMOOTH",
+"372 717 OFFCURVE",
+"386 717 OFFCURVE",
+"414 717 CURVE SMOOTH",
+"448 716 OFFCURVE",
+"453 716 OFFCURVE",
+"468 711 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"620 -13 OFFCURVE",
+"783 173 OFFCURVE",
+"783 378 CURVE SMOOTH",
+"783 583 OFFCURVE",
+"620 763 OFFCURVE",
+"411 763 CURVE SMOOTH",
+"202 763 OFFCURVE",
+"40 583 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 173 OFFCURVE",
+"202 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 22 OFFCURVE",
+"230 88 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 661 OFFCURVE",
+"276 728 OFFCURVE",
+"410 728 CURVE SMOOTH",
+"545 728 OFFCURVE",
+"593 660 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 91 OFFCURVE",
+"545 22 OFFCURVE",
+"410 22 CURVE SMOOTH"
+);
+}
+);
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 004F;
+},
+{
+glyphname = Oacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 66, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 22, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D3;
+},
+{
+glyphname = Obreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 96, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 114, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 014E;
+},
+{
+glyphname = Ocircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D4;
+},
+{
+glyphname = Ocircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED0;
+},
+{
+glyphname = Ocircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 107, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 119, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED8;
+},
+{
+glyphname = Ocircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED2;
+},
+{
+glyphname = Ocircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED4;
+},
+{
+glyphname = Ocircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED6;
+},
+{
+glyphname = Odblgrave;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 178, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 144, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 020C;
+},
+{
+glyphname = Odieresis;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 227, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 242, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D6;
+},
+{
+glyphname = Odotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 107, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ECC;
+},
+{
+glyphname = Ograve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 104, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 163, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D2;
+},
+{
+glyphname = Ohookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 106, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 128, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ECE;
+},
+{
+glyphname = Ohorn;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 238, 251}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 252, 252}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 01A0;
+},
+{
+glyphname = Ohornacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 66, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 22, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDA;
+},
+{
+glyphname = Ohorndotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 107, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EE2;
+},
+{
+glyphname = Ohorngrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 104, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 163, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDC;
+},
+{
+glyphname = Ohornhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 106, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 128, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDE;
+},
+{
+glyphname = Ohorntilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 100, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EE0;
+},
+{
+glyphname = Ohungarumlaut;
+lastChange = "2022-02-25 09:09:57 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = O;
+},
+{
+name = hungarumlaut.case;
+transform = "{1, 0, 0, 1, 259, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+alignment = -1;
+name = O;
+},
+{
+alignment = -1;
+name = hungarumlaut.case;
+transform = "{1, 0, 0, 1, 214, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 0150;
+},
+{
+glyphname = Oinvertedbreve;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 224, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 235, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 020E;
+},
+{
+glyphname = Omacron;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 223, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 240, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 014C;
+},
+{
+glyphname = Oogonek;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = O;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 234, -14}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+alignment = -1;
+name = O;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 250, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 01EA;
+},
+{
+glyphname = Oslash;
+lastChange = "2022-02-25 09:10:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{377, 0}";
+},
+{
+name = top;
+position = "{377, 754}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"570 -13 OFFCURVE",
+"723 172 OFFCURVE",
+"723 380 CURVE SMOOTH",
+"723 582 OFFCURVE",
+"570 763 OFFCURVE",
+"376 763 CURVE SMOOTH",
+"182 763 OFFCURVE",
+"30 582 OFFCURVE",
+"30 380 CURVE SMOOTH",
+"30 172 OFFCURVE",
+"182 -13 OFFCURVE",
+"376 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"118 -53 LINE",
+"673 804 LINE",
+"635 804 LINE",
+"80 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 17 OFFCURVE",
+"190 85 OFFCURVE",
+"190 380 CURVE SMOOTH",
+"190 666 OFFCURVE",
+"239 733 OFFCURVE",
+"375 733 CURVE SMOOTH",
+"512 733 OFFCURVE",
+"563 665 OFFCURVE",
+"563 378 CURVE SMOOTH",
+"563 86 OFFCURVE",
+"513 17 OFFCURVE",
+"376 17 CURVE SMOOTH"
+);
+}
+);
+width = 753;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{412, 0}";
+},
+{
+name = top;
+position = "{412, 754}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"620 -13 OFFCURVE",
+"783 173 OFFCURVE",
+"783 378 CURVE SMOOTH",
+"783 583 OFFCURVE",
+"620 763 OFFCURVE",
+"411 763 CURVE SMOOTH",
+"202 763 OFFCURVE",
+"40 583 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 173 OFFCURVE",
+"202 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"165 -53 LINE",
+"720 804 LINE",
+"662 804 LINE",
+"107 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 22 OFFCURVE",
+"230 88 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 661 OFFCURVE",
+"276 728 OFFCURVE",
+"410 728 CURVE SMOOTH",
+"545 728 OFFCURVE",
+"593 660 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 91 OFFCURVE",
+"545 22 OFFCURVE",
+"410 22 CURVE SMOOTH"
+);
+}
+);
+width = 823;
+}
+);
+unicode = 00D8;
+},
+{
+glyphname = Oslashacute;
+lastChange = "2022-02-25 09:10:17 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = Oslash;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 87, 279}";
+}
+);
+layerId = UUID0;
+width = 779;
+},
+{
+components = (
+{
+name = Oslash;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 22, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+unicode = 01FE;
+},
+{
+glyphname = Otilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 100, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D5;
+},
+{
+glyphname = OE;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1056 0 LINE",
+"1056 235 LINE",
+"1021 235 LINE",
+"1019 123 OFFCURVE",
+"962 25 OFFCURVE",
+"863 25 CURVE SMOOTH",
+"677 25 LINE",
+"677 363 LINE",
+"798 362 OFFCURVE",
+"829 327 OFFCURVE",
+"832 216 CURVE",
+"867 216 LINE",
+"867 526 LINE",
+"832 526 LINE",
+"832 419 OFFCURVE",
+"798 388 OFFCURVE",
+"677 388 CURVE",
+"677 729 LINE",
+"833 729 LINE SMOOTH",
+"932 729 OFFCURVE",
+"989 646 OFFCURVE",
+"991 549 CURVE",
+"1026 549 LINE",
+"1026 754 LINE",
+"376 754 LINE SMOOTH",
+"182 754 OFFCURVE",
+"30 578 OFFCURVE",
+"30 380 CURVE SMOOTH",
+"30 180 OFFCURVE",
+"182 0 OFFCURVE",
+"376 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"190 659 OFFCURVE",
+"239 724 OFFCURVE",
+"375 724 CURVE SMOOTH",
+"492 724 OFFCURVE",
+"543 658 OFFCURVE",
+"543 367 CURVE SMOOTH",
+"543 94 OFFCURVE",
+"490 30 OFFCURVE",
+"376 30 CURVE SMOOTH",
+"239 30 OFFCURVE",
+"190 96 OFFCURVE",
+"190 380 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"1056 0 LINE",
+"1056 235 LINE",
+"1021 235 LINE",
+"1019 123 OFFCURVE",
+"962 25 OFFCURVE",
+"863 25 CURVE SMOOTH",
+"677 25 LINE",
+"677 363 LINE",
+"798 362 OFFCURVE",
+"829 327 OFFCURVE",
+"832 216 CURVE",
+"867 216 LINE",
+"867 526 LINE",
+"832 526 LINE",
+"832 419 OFFCURVE",
+"798 388 OFFCURVE",
+"677 388 CURVE",
+"677 729 LINE",
+"833 729 LINE SMOOTH",
+"932 729 OFFCURVE",
+"989 646 OFFCURVE",
+"991 549 CURVE",
+"1026 549 LINE",
+"1026 754 LINE",
+"376 754 LINE SMOOTH",
+"182 754 OFFCURVE",
+"30 578 OFFCURVE",
+"30 380 CURVE SMOOTH",
+"30 180 OFFCURVE",
+"182 0 OFFCURVE",
+"376 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 30 OFFCURVE",
+"190 96 OFFCURVE",
+"190 380 CURVE SMOOTH",
+"190 659 OFFCURVE",
+"239 724 OFFCURVE",
+"375 724 CURVE SMOOTH",
+"492 724 OFFCURVE",
+"543 658 OFFCURVE",
+"543 367 CURVE SMOOTH",
+"543 94 OFFCURVE",
+"490 30 OFFCURVE",
+"376 30 CURVE SMOOTH"
+);
+}
+);
+width = 1093;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 181 OFFCURVE",
+"202 0 OFFCURVE",
+"413 0 CURVE SMOOTH",
+"1144 0 LINE",
+"1144 245 LINE",
+"1104 245 LINE",
+"1102 131 OFFCURVE",
+"1037 30 OFFCURVE",
+"926 30 CURVE SMOOTH",
+"756 30 LINE",
+"756 356 LINE",
+"885 355 OFFCURVE",
+"933 311 OFFCURVE",
+"935 216 CURVE",
+"975 216 LINE",
+"975 516 LINE",
+"935 516 LINE",
+"933 428 OFFCURVE",
+"885 387 OFFCURVE",
+"756 386 CURVE",
+"756 724 LINE",
+"926 724 LINE SMOOTH",
+"1028 724 OFFCURVE",
+"1087 646 OFFCURVE",
+"1089 554 CURVE",
+"1129 554 LINE",
+"1129 754 LINE",
+"411 754 LINE SMOOTH",
+"202 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 378 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"230 654 OFFCURVE",
+"276 719 OFFCURVE",
+"410 719 CURVE SMOOTH",
+"545 719 OFFCURVE",
+"593 653 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 102 OFFCURVE",
+"545 35 OFFCURVE",
+"410 35 CURVE SMOOTH",
+"278 35 OFFCURVE",
+"230 99 OFFCURVE",
+"230 378 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"1144 0 LINE",
+"1144 245 LINE",
+"1104 245 LINE",
+"1102 131 OFFCURVE",
+"1037 30 OFFCURVE",
+"926 30 CURVE SMOOTH",
+"756 30 LINE",
+"756 356 LINE",
+"885 355 OFFCURVE",
+"933 311 OFFCURVE",
+"935 216 CURVE",
+"975 216 LINE",
+"975 516 LINE",
+"935 516 LINE",
+"933 428 OFFCURVE",
+"885 387 OFFCURVE",
+"756 386 CURVE",
+"756 724 LINE",
+"926 724 LINE SMOOTH",
+"1028 724 OFFCURVE",
+"1087 646 OFFCURVE",
+"1089 554 CURVE",
+"1129 554 LINE",
+"1129 754 LINE",
+"411 754 LINE SMOOTH",
+"202 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 181 OFFCURVE",
+"202 0 OFFCURVE",
+"413 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 35 OFFCURVE",
+"230 99 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 654 OFFCURVE",
+"276 719 OFFCURVE",
+"410 719 CURVE SMOOTH",
+"545 719 OFFCURVE",
+"593 653 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 102 OFFCURVE",
+"545 35 OFFCURVE",
+"410 35 CURVE SMOOTH"
+);
+}
+);
+width = 1179;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = E;
+unicode = 0152;
+},
+{
+glyphname = P;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{342, 0}";
+},
+{
+name = top;
+position = "{342, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"121 15 LINE",
+"255 15 LINE",
+"255 754 LINE",
+"121 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"11 0 LINE",
+"385 0 LINE",
+"385 25 LINE",
+"11 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 342 LINE SMOOTH",
+"522 342 OFFCURVE",
+"652 427 OFFCURVE",
+"652 552 CURVE SMOOTH",
+"652 669 OFFCURVE",
+"540 754 OFFCURVE",
+"397 754 CURVE SMOOTH",
+"11 754 LINE",
+"11 729 LINE",
+"357 729 LINE SMOOTH",
+"450 729 OFFCURVE",
+"497 700 OFFCURVE",
+"497 558 CURVE SMOOTH",
+"497 405 OFFCURVE",
+"443 372 OFFCURVE",
+"307 372 CURVE SMOOTH",
+"224 372 LINE",
+"224 342 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"307 342 LINE SMOOTH",
+"522 342 OFFCURVE",
+"652 427 OFFCURVE",
+"652 552 CURVE SMOOTH",
+"652 669 OFFCURVE",
+"540 754 OFFCURVE",
+"397 754 CURVE SMOOTH",
+"11 754 LINE",
+"11 729 LINE",
+"357 729 LINE SMOOTH",
+"450 729 OFFCURVE",
+"497 700 OFFCURVE",
+"497 558 CURVE SMOOTH",
+"497 405 OFFCURVE",
+"443 372 OFFCURVE",
+"307 372 CURVE SMOOTH",
+"224 372 LINE",
+"224 342 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"385 0 LINE",
+"385 25 LINE",
+"11 25 LINE",
+"11 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 15 LINE",
+"255 754 LINE",
+"121 754 LINE",
+"121 15 LINE"
+);
+}
+);
+width = 684;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{350, 0}";
+},
+{
+name = top;
+position = "{350, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 15 LINE",
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"391 0 LINE",
+"391 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"350 342 LINE SMOOTH",
+"565 342 OFFCURVE",
+"695 427 OFFCURVE",
+"695 552 CURVE SMOOTH",
+"695 669 OFFCURVE",
+"583 754 OFFCURVE",
+"440 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"390 724 LINE SMOOTH",
+"465 724 OFFCURVE",
+"505 696 OFFCURVE",
+"505 555 CURVE SMOOTH",
+"505 405 OFFCURVE",
+"460 372 OFFCURVE",
+"350 372 CURVE SMOOTH",
+"267 372 LINE",
+"267 342 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 342 LINE SMOOTH",
+"565 342 OFFCURVE",
+"695 427 OFFCURVE",
+"695 552 CURVE SMOOTH",
+"695 669 OFFCURVE",
+"583 754 OFFCURVE",
+"440 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"390 724 LINE SMOOTH",
+"465 724 OFFCURVE",
+"505 696 OFFCURVE",
+"505 555 CURVE SMOOTH",
+"505 405 OFFCURVE",
+"460 372 OFFCURVE",
+"350 372 CURVE SMOOTH",
+"267 372 LINE",
+"267 342 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 0 LINE",
+"391 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+}
+);
+width = 700;
+}
+);
+leftKerningGroup = P;
+unicode = 0050;
+},
+{
+glyphname = Thorn;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"391 0 LINE",
+"391 25 LINE",
+"261 25 LINE",
+"261 179 LINE",
+"313 179 LINE SMOOTH",
+"528 179 OFFCURVE",
+"658 264 OFFCURVE",
+"658 389 CURVE SMOOTH",
+"658 506 OFFCURVE",
+"546 591 OFFCURVE",
+"403 591 CURVE SMOOTH",
+"261 591 LINE",
+"261 728 LINE",
+"391 728 LINE",
+"391 753 LINE",
+"17 753 LINE",
+"17 728 LINE",
+"127 728 LINE",
+"127 25 LINE",
+"17 25 LINE",
+"17 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"261 566 LINE",
+"363 566 LINE SMOOTH",
+"456 566 OFFCURVE",
+"503 537 OFFCURVE",
+"503 395 CURVE SMOOTH",
+"503 242 OFFCURVE",
+"449 209 OFFCURVE",
+"313 209 CURVE SMOOTH",
+"261 209 LINE"
+);
+}
+);
+width = 680;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"391 0 LINE",
+"391 30 LINE",
+"273 30 LINE",
+"273 181 LINE",
+"350 181 LINE SMOOTH",
+"565 181 OFFCURVE",
+"695 266 OFFCURVE",
+"695 391 CURVE SMOOTH",
+"695 508 OFFCURVE",
+"583 593 OFFCURVE",
+"440 593 CURVE SMOOTH",
+"273 593 LINE",
+"273 724 LINE",
+"391 724 LINE",
+"391 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 563 LINE",
+"390 563 LINE SMOOTH",
+"465 563 OFFCURVE",
+"505 535 OFFCURVE",
+"505 394 CURVE SMOOTH",
+"505 244 OFFCURVE",
+"460 211 OFFCURVE",
+"350 211 CURVE SMOOTH",
+"273 211 LINE"
+);
+}
+);
+width = 700;
+}
+);
+unicode = 00DE;
+},
+{
+glyphname = Q;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{391, 0}";
+},
+{
+name = top;
+position = "{391, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"585 -12 OFFCURVE",
+"738 169 OFFCURVE",
+"738 377 CURVE SMOOTH",
+"738 585 OFFCURVE",
+"585 766 OFFCURVE",
+"391 766 CURVE SMOOTH",
+"197 766 OFFCURVE",
+"45 585 OFFCURVE",
+"45 377 CURVE SMOOTH",
+"45 169 OFFCURVE",
+"197 -12 OFFCURVE",
+"391 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"685 -226 LINE",
+"548 -226 OFFCURVE",
+"470 -195 OFFCURVE",
+"470 -49 CURVE SMOOTH",
+"470 -33 OFFCURVE",
+"471 -12 OFFCURVE",
+"473 7 CURVE",
+"312 7 LINE",
+"312 -192 OFFCURVE",
+"409 -256 OFFCURVE",
+"685 -256 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 18 OFFCURVE",
+"205 91 OFFCURVE",
+"205 377 CURVE SMOOTH",
+"205 663 OFFCURVE",
+"254 736 OFFCURVE",
+"390 736 CURVE SMOOTH",
+"526 736 OFFCURVE",
+"578 664 OFFCURVE",
+"578 378 CURVE SMOOTH",
+"578 92 OFFCURVE",
+"527 18 OFFCURVE",
+"391 18 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"585 -12 OFFCURVE",
+"738 169 OFFCURVE",
+"738 377 CURVE SMOOTH",
+"738 585 OFFCURVE",
+"585 766 OFFCURVE",
+"391 766 CURVE SMOOTH",
+"197 766 OFFCURVE",
+"45 585 OFFCURVE",
+"45 377 CURVE SMOOTH",
+"45 169 OFFCURVE",
+"197 -12 OFFCURVE",
+"391 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"685 -226 LINE",
+"548 -226 OFFCURVE",
+"470 -195 OFFCURVE",
+"470 -49 CURVE SMOOTH",
+"470 -33 OFFCURVE",
+"471 -12 OFFCURVE",
+"473 7 CURVE",
+"312 7 LINE",
+"312 -192 OFFCURVE",
+"409 -256 OFFCURVE",
+"685 -256 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 18 OFFCURVE",
+"205 91 OFFCURVE",
+"205 377 CURVE SMOOTH",
+"205 663 OFFCURVE",
+"254 736 OFFCURVE",
+"390 736 CURVE SMOOTH",
+"526 736 OFFCURVE",
+"578 664 OFFCURVE",
+"578 378 CURVE SMOOTH",
+"578 92 OFFCURVE",
+"527 18 OFFCURVE",
+"391 18 CURVE SMOOTH"
+);
+}
+);
+width = 782;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{412, 0}";
+},
+{
+name = top;
+position = "{412, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"620 -13 OFFCURVE",
+"783 173 OFFCURVE",
+"783 378 CURVE SMOOTH",
+"783 583 OFFCURVE",
+"620 763 OFFCURVE",
+"411 763 CURVE SMOOTH",
+"202 763 OFFCURVE",
+"40 583 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 173 OFFCURVE",
+"202 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"715 -201 LINE",
+"583 -201 OFFCURVE",
+"510 -175 OFFCURVE",
+"510 -48 CURVE SMOOTH",
+"510 -33 OFFCURVE",
+"511 -12 OFFCURVE",
+"513 7 CURVE",
+"312 7 LINE",
+"312 -176 OFFCURVE",
+"418 -236 OFFCURVE",
+"715 -236 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 22 OFFCURVE",
+"230 88 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 661 OFFCURVE",
+"276 728 OFFCURVE",
+"410 728 CURVE SMOOTH",
+"545 728 OFFCURVE",
+"593 660 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 91 OFFCURVE",
+"545 22 OFFCURVE",
+"410 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"620 -13 OFFCURVE",
+"783 173 OFFCURVE",
+"783 378 CURVE SMOOTH",
+"783 583 OFFCURVE",
+"620 763 OFFCURVE",
+"411 763 CURVE SMOOTH",
+"202 763 OFFCURVE",
+"40 583 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 173 OFFCURVE",
+"202 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"715 -201 LINE",
+"583 -201 OFFCURVE",
+"510 -175 OFFCURVE",
+"510 -48 CURVE SMOOTH",
+"510 -33 OFFCURVE",
+"511 -12 OFFCURVE",
+"513 7 CURVE",
+"312 7 LINE",
+"312 -176 OFFCURVE",
+"418 -236 OFFCURVE",
+"715 -236 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 22 OFFCURVE",
+"230 88 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 661 OFFCURVE",
+"276 728 OFFCURVE",
+"410 728 CURVE SMOOTH",
+"545 728 OFFCURVE",
+"593 660 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 91 OFFCURVE",
+"545 22 OFFCURVE",
+"410 22 CURVE SMOOTH"
+);
+}
+);
+width = 823;
+}
+);
+leftKerningGroup = O;
+unicode = 0051;
+},
+{
+glyphname = R;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{346, 0}";
+},
+{
+name = top;
+position = "{346, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"123 15 LINE",
+"257 15 LINE",
+"257 754 LINE",
+"123 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"13 754 LINE",
+"13 729 LINE",
+"359 729 LINE SMOOTH",
+"440 729 OFFCURVE",
+"479 706 OFFCURVE",
+"479 585 CURVE SMOOTH",
+"479 447 OFFCURVE",
+"429 417 OFFCURVE",
+"309 417 CURVE SMOOTH",
+"226 417 LINE",
+"226 387 LINE",
+"309 387 LINE SMOOTH",
+"513 387 OFFCURVE",
+"634 466 OFFCURVE",
+"634 582 CURVE SMOOTH",
+"634 691 OFFCURVE",
+"529 754 OFFCURVE",
+"399 754 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"13 0 LINE",
+"387 0 LINE",
+"387 25 LINE",
+"13 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"711 0 LINE",
+"711 25 LINE",
+"673 25 LINE SMOOTH",
+"621 25 OFFCURVE",
+"604 52 OFFCURVE",
+"604 144 CURVE SMOOTH",
+"604 196 LINE SMOOTH",
+"604 291 OFFCURVE",
+"515 374 OFFCURVE",
+"430 394 CURVE",
+"430 398 LINE",
+"393 398 LINE",
+"317 387 LINE",
+"395 387 OFFCURVE",
+"451 337 OFFCURVE",
+"455 232 CURVE SMOOTH",
+"458 153 LINE SMOOTH",
+"461 60 OFFCURVE",
+"535 0 OFFCURVE",
+"634 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"309 387 LINE SMOOTH",
+"513 387 OFFCURVE",
+"634 466 OFFCURVE",
+"634 582 CURVE SMOOTH",
+"634 691 OFFCURVE",
+"529 754 OFFCURVE",
+"399 754 CURVE SMOOTH",
+"13 754 LINE",
+"13 729 LINE",
+"359 729 LINE SMOOTH",
+"440 729 OFFCURVE",
+"479 706 OFFCURVE",
+"479 585 CURVE SMOOTH",
+"479 447 OFFCURVE",
+"429 417 OFFCURVE",
+"309 417 CURVE SMOOTH",
+"226 417 LINE",
+"226 387 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"387 0 LINE",
+"387 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"257 15 LINE",
+"257 754 LINE",
+"123 754 LINE",
+"123 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"711 0 LINE",
+"711 25 LINE",
+"673 25 LINE SMOOTH",
+"621 25 OFFCURVE",
+"604 52 OFFCURVE",
+"604 144 CURVE SMOOTH",
+"604 196 LINE SMOOTH",
+"604 291 OFFCURVE",
+"515 374 OFFCURVE",
+"430 394 CURVE",
+"430 398 LINE",
+"393 398 LINE",
+"317 387 LINE",
+"395 387 OFFCURVE",
+"451 337 OFFCURVE",
+"455 232 CURVE SMOOTH",
+"458 153 LINE SMOOTH",
+"461 60 OFFCURVE",
+"535 0 OFFCURVE",
+"634 0 CURVE SMOOTH"
+);
+}
+);
+width = 691;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{370, 0}";
+},
+{
+name = top;
+position = "{370, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE",
+"273 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"350 392 LINE SMOOTH",
+"553 392 OFFCURVE",
+"675 459 OFFCURVE",
+"675 582 CURVE SMOOTH",
+"675 691 OFFCURVE",
+"563 754 OFFCURVE",
+"420 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"370 724 LINE SMOOTH",
+"445 724 OFFCURVE",
+"485 700 OFFCURVE",
+"485 575 CURVE SMOOTH",
+"485 449 OFFCURVE",
+"446 422 OFFCURVE",
+"350 422 CURVE SMOOTH",
+"267 422 LINE",
+"267 392 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"391 0 LINE",
+"391 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"755 0 LINE",
+"755 32 LINE",
+"717 32 LINE SMOOTH",
+"665 32 OFFCURVE",
+"648 59 OFFCURVE",
+"648 151 CURVE SMOOTH",
+"648 196 LINE SMOOTH",
+"648 291 OFFCURVE",
+"554 374 OFFCURVE",
+"464 394 CURVE",
+"464 398 LINE",
+"397 398 LINE",
+"321 392 LINE",
+"396 392 OFFCURVE",
+"448 351 OFFCURVE",
+"452 262 CURVE SMOOTH",
+"457 153 LINE SMOOTH",
+"461 60 OFFCURVE",
+"538 0 OFFCURVE",
+"638 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 392 LINE SMOOTH",
+"553 392 OFFCURVE",
+"675 459 OFFCURVE",
+"675 582 CURVE SMOOTH",
+"675 691 OFFCURVE",
+"563 754 OFFCURVE",
+"420 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"370 724 LINE SMOOTH",
+"445 724 OFFCURVE",
+"485 700 OFFCURVE",
+"485 575 CURVE SMOOTH",
+"485 449 OFFCURVE",
+"446 422 OFFCURVE",
+"350 422 CURVE SMOOTH",
+"267 422 LINE",
+"267 392 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 0 LINE",
+"391 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"755 0 LINE",
+"755 32 LINE",
+"717 32 LINE SMOOTH",
+"665 32 OFFCURVE",
+"648 59 OFFCURVE",
+"648 151 CURVE SMOOTH",
+"648 196 LINE SMOOTH",
+"648 291 OFFCURVE",
+"554 374 OFFCURVE",
+"464 394 CURVE",
+"464 398 LINE",
+"397 398 LINE",
+"321 392 LINE",
+"396 392 OFFCURVE",
+"448 351 OFFCURVE",
+"452 262 CURVE SMOOTH",
+"457 153 LINE SMOOTH",
+"461 60 OFFCURVE",
+"538 0 OFFCURVE",
+"638 0 CURVE SMOOTH"
+);
+}
+);
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0052;
+},
+{
+glyphname = Racute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 21, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -20, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0154;
+},
+{
+glyphname = Rcaron;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 176, 1}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 156, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0158;
+},
+{
+glyphname = Rcommaaccent;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 260, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 277, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0156;
+},
+{
+glyphname = Rdblgrave;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 133, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 102, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0210;
+},
+{
+glyphname = Rdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 62, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 77, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 1E5A;
+},
+{
+glyphname = Rinvertedbreve;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 179, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 193, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0212;
+},
+{
+glyphname = S;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{287, 0}";
+},
+{
+name = top;
+position = "{287, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 47 LINE",
+"164 8 OFFCURVE",
+"211 -12 OFFCURVE",
+"283 -12 CURVE SMOOTH",
+"438 -12 OFFCURVE",
+"524 81 OFFCURVE",
+"524 232 CURVE SMOOTH",
+"524 372 OFFCURVE",
+"450 438 OFFCURVE",
+"307 477 CURVE SMOOTH",
+"204 505 OFFCURVE",
+"139 526 OFFCURVE",
+"139 608 CURVE SMOOTH",
+"139 681 OFFCURVE",
+"200 736 OFFCURVE",
+"283 736 CURVE SMOOTH",
+"374 736 OFFCURVE",
+"437 675 OFFCURVE",
+"469 549 CURVE",
+"494 550 LINE",
+"494 754 LINE",
+"469 754 LINE",
+"443 710 LINE",
+"394 749 OFFCURVE",
+"351 766 OFFCURVE",
+"287 766 CURVE SMOOTH",
+"169 766 OFFCURVE",
+"60 688 OFFCURVE",
+"60 543 CURVE SMOOTH",
+"60 425 OFFCURVE",
+"123 350 OFFCURVE",
+"267 316 CURVE SMOOTH",
+"383 289 OFFCURVE",
+"450 251 OFFCURVE",
+"450 165 CURVE SMOOTH",
+"450 92 OFFCURVE",
+"404 19 OFFCURVE",
+"291 19 CURVE SMOOTH",
+"163 19 OFFCURVE",
+"104 114 OFFCURVE",
+"80 210 CURVE",
+"54 210 LINE",
+"54 0 LINE",
+"79 0 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"438 -12 OFFCURVE",
+"524 81 OFFCURVE",
+"524 232 CURVE SMOOTH",
+"524 372 OFFCURVE",
+"450 438 OFFCURVE",
+"307 477 CURVE SMOOTH",
+"204 505 OFFCURVE",
+"129 526 OFFCURVE",
+"129 608 CURVE SMOOTH",
+"129 681 OFFCURVE",
+"200 736 OFFCURVE",
+"283 736 CURVE SMOOTH",
+"374 736 OFFCURVE",
+"437 675 OFFCURVE",
+"469 549 CURVE",
+"494 550 LINE",
+"494 754 LINE",
+"469 754 LINE",
+"443 710 LINE",
+"394 749 OFFCURVE",
+"351 766 OFFCURVE",
+"287 766 CURVE SMOOTH",
+"169 766 OFFCURVE",
+"60 688 OFFCURVE",
+"60 543 CURVE SMOOTH",
+"60 425 OFFCURVE",
+"123 350 OFFCURVE",
+"267 316 CURVE SMOOTH",
+"383 289 OFFCURVE",
+"460 251 OFFCURVE",
+"460 165 CURVE SMOOTH",
+"460 92 OFFCURVE",
+"404 19 OFFCURVE",
+"291 19 CURVE SMOOTH",
+"163 19 OFFCURVE",
+"104 114 OFFCURVE",
+"80 210 CURVE",
+"54 210 LINE",
+"54 0 LINE",
+"79 0 LINE",
+"115 47 LINE",
+"164 8 OFFCURVE",
+"211 -12 OFFCURVE",
+"283 -12 CURVE SMOOTH"
+);
+}
+);
+width = 574;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{285, 0}";
+},
+{
+name = top;
+position = "{285, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"231 763 OFFCURVE",
+"212 759 OFFCURVE",
+"198 755 CURVE SMOOTH",
+"182 751 OFFCURVE",
+"145 734 OFFCURVE",
+"132 724 CURVE SMOOTH",
+"118 713 OFFCURVE",
+"90 687 OFFCURVE",
+"82 676 CURVE SMOOTH",
+"79 672 OFFCURVE",
+"74 664 OFFCURVE",
+"71 661 CURVE SMOOTH",
+"59 649 OFFCURVE",
+"46 616 OFFCURVE",
+"38 583 CURVE SMOOTH",
+"32 561 OFFCURVE",
+"32 533 OFFCURVE",
+"35 492 CURVE",
+"38 470 OFFCURVE",
+"39 465 OFFCURVE",
+"44 450 CURVE SMOOTH",
+"50 431 OFFCURVE",
+"57 420 OFFCURVE",
+"63 414 CURVE SMOOTH",
+"66 411 OFFCURVE",
+"69 406 OFFCURVE",
+"72 401 CURVE SMOOTH",
+"76 394 OFFCURVE",
+"102 370 OFFCURVE",
+"115 357 CURVE SMOOTH",
+"124 349 OFFCURVE",
+"159 331 OFFCURVE",
+"178 323 CURVE SMOOTH",
+"196 315 OFFCURVE",
+"245 301 OFFCURVE",
+"270 298 CURVE",
+"270 298 OFFCURVE",
+"291 295 OFFCURVE",
+"291 293 CURVE",
+"296 291 OFFCURVE",
+"306 288 OFFCURVE",
+"320 287 CURVE",
+"335 283 OFFCURVE",
+"349 279 OFFCURVE",
+"355 276 CURVE SMOOTH",
+"361 274 OFFCURVE",
+"368 271 OFFCURVE",
+"370 271 CURVE SMOOTH",
+"374 271 OFFCURVE",
+"400 258 OFFCURVE",
+"411 251 CURVE SMOOTH",
+"428 241 OFFCURVE",
+"435 230 OFFCURVE",
+"452 205 CURVE",
+"458 193 OFFCURVE",
+"458 191 OFFCURVE",
+"458 167 CURVE",
+"460 144 OFFCURVE",
+"460 139 OFFCURVE",
+"455 124 CURVE",
+"450 104 OFFCURVE",
+"440 89 OFFCURVE",
+"422 67 CURVE",
+"400 44 OFFCURVE",
+"385 33 OFFCURVE",
+"366 26 CURVE SMOOTH",
+"339 16 OFFCURVE",
+"331 14 OFFCURVE",
+"300 13 CURVE SMOOTH",
+"270 13 OFFCURVE",
+"259 13 OFFCURVE",
+"231 17 CURVE",
+"223 20 OFFCURVE",
+"196 33 OFFCURVE",
+"195 36 CURVE",
+"193 36 OFFCURVE",
+"188 39 OFFCURVE",
+"185 41 CURVE",
+"159 51 OFFCURVE",
+"127 80 OFFCURVE",
+"99 121 CURVE SMOOTH",
+"93 129 OFFCURVE",
+"80 162 OFFCURVE",
+"72 185 CURVE",
+"68 200 OFFCURVE",
+"66 204 OFFCURVE",
+"59 207 CURVE SMOOTH",
+"52 210 OFFCURVE",
+"46 210 OFFCURVE",
+"35 208 CURVE SMOOTH",
+"30 207 OFFCURVE",
+"27 204 OFFCURVE",
+"26 199 CURVE",
+"22 193 OFFCURVE",
+"22 187 OFFCURVE",
+"24 125 CURVE",
+"24 66 OFFCURVE",
+"24 56 OFFCURVE",
+"24 38 CURVE",
+"22 25 OFFCURVE",
+"21 13 OFFCURVE",
+"22 6 CURVE",
+"22 -2 OFFCURVE",
+"24 -5 OFFCURVE",
+"29 -7 CURVE",
+"35 -12 OFFCURVE",
+"52 -12 OFFCURVE",
+"62 -7 CURVE",
+"62 -5 OFFCURVE",
+"80 5 OFFCURVE",
+"88 14 CURVE",
+"101 25 OFFCURVE",
+"113 33 OFFCURVE",
+"113 33 CURVE",
+"113 33 OFFCURVE",
+"135 26 OFFCURVE",
+"135 22 CURVE SMOOTH",
+"135 14 OFFCURVE",
+"159 8 OFFCURVE",
+"159 6 CURVE",
+"175 -5 OFFCURVE",
+"212 -17 OFFCURVE",
+"243 -22 CURVE SMOOTH",
+"258 -25 OFFCURVE",
+"308 -25 OFFCURVE",
+"322 -24 CURVE",
+"322 -22 OFFCURVE",
+"344 -20 OFFCURVE",
+"344 -20 CURVE",
+"358 -17 OFFCURVE",
+"388 -5 OFFCURVE",
+"407 5 CURVE SMOOTH",
+"458 31 OFFCURVE",
+"503 83 OFFCURVE",
+"523 136 CURVE SMOOTH",
+"537 172 OFFCURVE",
+"543 193 OFFCURVE",
+"543 232 CURVE",
+"546 278 OFFCURVE",
+"541 307 OFFCURVE",
+"524 349 CURVE SMOOTH",
+"508 390 OFFCURVE",
+"480 422 OFFCURVE",
+"440 447 CURVE SMOOTH",
+"430 453 OFFCURVE",
+"419 462 OFFCURVE",
+"416 464 CURVE SMOOTH",
+"407 469 OFFCURVE",
+"383 478 OFFCURVE",
+"382 477 CURVE",
+"382 477 OFFCURVE",
+"375 478 OFFCURVE",
+"366 481 CURVE SMOOTH",
+"331 495 OFFCURVE",
+"291 505 OFFCURVE",
+"264 506 CURVE",
+"258 508 OFFCURVE",
+"248 510 OFFCURVE",
+"243 511 CURVE",
+"237 511 OFFCURVE",
+"225 514 OFFCURVE",
+"217 519 CURVE",
+"193 523 OFFCURVE",
+"175 528 OFFCURVE",
+"167 533 CURVE SMOOTH",
+"157 538 OFFCURVE",
+"140 552 OFFCURVE",
+"134 560 CURVE",
+"118 575 OFFCURVE",
+"112 603 OFFCURVE",
+"115 629 CURVE",
+"115 651 OFFCURVE",
+"115 663 OFFCURVE",
+"137 674 CURVE",
+"142 680 OFFCURVE",
+"148 685 OFFCURVE",
+"148 687 CURVE SMOOTH",
+"148 687 OFFCURVE",
+"148 691 OFFCURVE",
+"151 694 CURVE SMOOTH",
+"157 701 OFFCURVE",
+"174 709 OFFCURVE",
+"190 713 CURVE SMOOTH",
+"202 715 OFFCURVE",
+"202 718 OFFCURVE",
+"215 722 CURVE SMOOTH",
+"225 726 OFFCURVE",
+"230 726 OFFCURVE",
+"262 727 CURVE SMOOTH",
+"287 727 OFFCURVE",
+"302 727 OFFCURVE",
+"311 726 CURVE",
+"326 722 OFFCURVE",
+"359 705 OFFCURVE",
+"370 697 CURVE SMOOTH",
+"374 694 OFFCURVE",
+"383 688 OFFCURVE",
+"385 685 CURVE",
+"391 682 OFFCURVE",
+"395 677 OFFCURVE",
+"397 674 CURVE",
+"401 671 OFFCURVE",
+"406 659 OFFCURVE",
+"416 649 CURVE",
+"431 626 OFFCURVE",
+"440 605 OFFCURVE",
+"450 578 CURVE",
+"453 566 OFFCURVE",
+"458 556 OFFCURVE",
+"461 553 CURVE SMOOTH",
+"465 547 OFFCURVE",
+"465 547 OFFCURVE",
+"480 547 CURVE SMOOTH",
+"491 547 OFFCURVE",
+"493 548 OFFCURVE",
+"496 552 CURVE SMOOTH",
+"499 556 OFFCURVE",
+"499 556 OFFCURVE",
+"498 610 CURVE SMOOTH",
+"498 633 OFFCURVE",
+"496 671 OFFCURVE",
+"496 696 CURVE SMOOTH",
+"496 740 LINE",
+"491 745 LINE",
+"488 746 OFFCURVE",
+"485 749 OFFCURVE",
+"475 746 CURVE",
+"461 746 OFFCURVE",
+"461 746 OFFCURVE",
+"436 727 CURVE",
+"432 722 OFFCURVE",
+"424 717 OFFCURVE",
+"422 715 CURVE",
+"417 713 OFFCURVE",
+"416 715 OFFCURVE",
+"411 718 CURVE",
+"410 722 OFFCURVE",
+"407 724 OFFCURVE",
+"405 724 CURVE SMOOTH",
+"405 724 OFFCURVE",
+"402 726 OFFCURVE",
+"399 727 CURVE",
+"397 729 OFFCURVE",
+"394 730 OFFCURVE",
+"392 730 CURVE SMOOTH",
+"391 730 OFFCURVE",
+"382 734 OFFCURVE",
+"374 738 CURVE SMOOTH",
+"349 752 OFFCURVE",
+"329 759 OFFCURVE",
+"306 762 CURVE SMOOTH",
+"292 763 OFFCURVE",
+"256 765 OFFCURVE",
+"245 763 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"457 -13 OFFCURVE",
+"544 80 OFFCURVE",
+"544 237 CURVE SMOOTH",
+"544 391 OFFCURVE",
+"461 460 OFFCURVE",
+"310 497 CURVE SMOOTH",
+"231 516 OFFCURVE",
+"120 531 OFFCURVE",
+"120 617 CURVE SMOOTH",
+"120 685 OFFCURVE",
+"189 728 OFFCURVE",
+"276 728 CURVE SMOOTH",
+"371 728 OFFCURVE",
+"435 677 OFFCURVE",
+"474 550 CURVE",
+"504 550 LINE",
+"504 754 LINE",
+"473 754 LINE",
+"434 712 LINE",
+"381 745 OFFCURVE",
+"338 763 OFFCURVE",
+"278 763 CURVE SMOOTH",
+"155 763 OFFCURVE",
+"43 690 OFFCURVE",
+"43 537 CURVE SMOOTH",
+"43 397 OFFCURVE",
+"138 331 OFFCURVE",
+"278 296 CURVE SMOOTH",
+"356 276 OFFCURVE",
+"465 264 OFFCURVE",
+"465 159 CURVE SMOOTH",
+"465 82 OFFCURVE",
+"406 22 OFFCURVE",
+"295 22 CURVE SMOOTH",
+"159 22 OFFCURVE",
+"89 111 OFFCURVE",
+"66 210 CURVE",
+"35 210 LINE",
+"35 0 LINE",
+"65 0 LINE",
+"112 48 LINE",
+"161 12 OFFCURVE",
+"216 -13 OFFCURVE",
+"298 -13 CURVE SMOOTH"
+);
+}
+);
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 0053;
+},
+{
+glyphname = Sacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -38, 304}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -105, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 015A;
+},
+{
+glyphname = Scaron;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 117, 1}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 71, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 0160;
+},
+{
+glyphname = Scedilla;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 182, 6}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 168, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 015E;
+},
+{
+glyphname = Scircumflex;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -3, 304}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -11, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 015C;
+},
+{
+glyphname = Scommaaccent;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 201, 0}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 192, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 0218;
+},
+{
+glyphname = Sdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 3, 0}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -8, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 1E62;
+},
+{
+glyphname = T;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{353, 0}";
+},
+{
+name = center;
+position = "{353, 377}";
+},
+{
+name = top;
+position = "{353, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"677 754 LINE",
+"29 754 LINE",
+"29 509 LINE",
+"64 509 LINE",
+"66 623 OFFCURVE",
+"120 724 OFFCURVE",
+"214 729 CURVE",
+"290 729 LINE",
+"290 25 LINE",
+"160 25 LINE",
+"160 0 LINE",
+"554 0 LINE",
+"554 25 LINE",
+"424 25 LINE",
+"424 729 LINE",
+"484 729 LINE SMOOTH",
+"583 729 OFFCURVE",
+"640 626 OFFCURVE",
+"642 509 CURVE",
+"677 509 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"554 0 LINE",
+"554 25 LINE",
+"424 25 LINE",
+"424 729 LINE",
+"484 729 LINE SMOOTH",
+"583 729 OFFCURVE",
+"640 626 OFFCURVE",
+"642 509 CURVE",
+"677 509 LINE",
+"677 754 LINE",
+"29 754 LINE",
+"29 509 LINE",
+"64 509 LINE",
+"66 623 OFFCURVE",
+"120 724 OFFCURVE",
+"214 729 CURVE",
+"290 729 LINE",
+"290 25 LINE",
+"160 25 LINE",
+"160 0 LINE"
+);
+}
+);
+width = 705;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{362, 0}";
+},
+{
+name = center;
+position = "{362, 377}";
+},
+{
+name = top;
+position = "{362, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"158 0 LINE",
+"559 0 LINE",
+"559 30 LINE",
+"441 30 LINE",
+"441 724 LINE",
+"491 724 LINE SMOOTH",
+"602 724 OFFCURVE",
+"667 623 OFFCURVE",
+"669 509 CURVE",
+"709 509 LINE",
+"709 754 LINE",
+"15 754 LINE",
+"15 509 LINE",
+"55 509 LINE",
+"57 623 OFFCURVE",
+"122 724 OFFCURVE",
+"233 724 CURVE SMOOTH",
+"283 724 LINE",
+"283 30 LINE",
+"158 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"559 0 LINE",
+"559 30 LINE",
+"441 30 LINE",
+"441 724 LINE",
+"491 724 LINE SMOOTH",
+"602 724 OFFCURVE",
+"667 623 OFFCURVE",
+"669 509 CURVE",
+"709 509 LINE",
+"709 754 LINE",
+"15 754 LINE",
+"15 509 LINE",
+"55 509 LINE",
+"57 623 OFFCURVE",
+"122 724 OFFCURVE",
+"233 724 CURVE SMOOTH",
+"283 724 LINE",
+"283 30 LINE",
+"158 30 LINE",
+"158 0 LINE"
+);
+}
+);
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 0054;
+},
+{
+glyphname = Tbar;
+lastChange = "2016-08-22 12:16:12 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 565, 406}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 107, 393}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+unicode = 0166;
+},
+{
+glyphname = Tcaron;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 183, 1}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 148, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 0164;
+},
+{
+glyphname = Tcedilla;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 248, 6}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 245, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 0162;
+},
+{
+glyphname = Tcommaaccent;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 267, 0}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 269, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 021A;
+},
+{
+glyphname = Tdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 69, 0}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 69, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 1E6C;
+},
+{
+glyphname = U;
+lastChange = "2022-03-23 16:32:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{369, 0}";
+},
+{
+name = ogonek;
+position = "{663, 10}";
+},
+{
+name = top;
+position = "{399, 754}";
+},
+{
+name = topright;
+position = "{680, 701}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"10 729 LINE",
+"127 729 LINE",
+"127 194 LINE SMOOTH",
+"127 53 OFFCURVE",
+"231 -13 OFFCURVE",
+"391 -13 CURVE SMOOTH",
+"549 -13 OFFCURVE",
+"629 52 OFFCURVE",
+"629 195 CURVE SMOOTH",
+"629 729 LINE",
+"734 729 LINE",
+"734 754 LINE",
+"491 754 LINE",
+"491 729 LINE",
+"596 729 LINE",
+"596 195 LINE SMOOTH",
+"596 79 OFFCURVE",
+"529 22 OFFCURVE",
+"422 22 CURVE SMOOTH",
+"322 22 OFFCURVE",
+"261 71 OFFCURVE",
+"261 195 CURVE SMOOTH",
+"261 729 LINE",
+"356 729 LINE",
+"356 754 LINE",
+"10 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"545 -12 OFFCURVE",
+"625 53 OFFCURVE",
+"625 196 CURVE SMOOTH",
+"625 729 LINE",
+"730 729 LINE",
+"730 754 LINE",
+"487 754 LINE",
+"487 729 LINE",
+"592 729 LINE",
+"592 196 LINE SMOOTH",
+"592 80 OFFCURVE",
+"525 23 OFFCURVE",
+"418 23 CURVE SMOOTH",
+"318 23 OFFCURVE",
+"257 72 OFFCURVE",
+"257 196 CURVE SMOOTH",
+"257 729 LINE",
+"352 729 LINE",
+"352 754 LINE",
+"6 754 LINE",
+"6 729 LINE",
+"123 729 LINE",
+"123 195 LINE SMOOTH",
+"123 54 OFFCURVE",
+"227 -12 OFFCURVE",
+"387 -12 CURVE SMOOTH"
+);
+}
+);
+width = 737;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{387, 0}";
+},
+{
+name = ogonek;
+position = "{697, 10}";
+},
+{
+name = top;
+position = "{387, 754}";
+},
+{
+name = topright;
+position = "{605, 700}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"22 746 OFFCURVE",
+"21 738 OFFCURVE",
+"24 729 CURVE",
+"26 719 OFFCURVE",
+"30 719 OFFCURVE",
+"68 719 CURVE",
+"107 721 OFFCURVE",
+"115 719 OFFCURVE",
+"119 714 CURVE",
+"119 711 OFFCURVE",
+"121 674 OFFCURVE",
+"121 633 CURVE SMOOTH",
+"121 589 OFFCURVE",
+"121 555 OFFCURVE",
+"121 552 CURVE SMOOTH",
+"121 550 OFFCURVE",
+"121 522 OFFCURVE",
+"121 489 CURVE SMOOTH",
+"119 388 OFFCURVE",
+"118 258 OFFCURVE",
+"118 239 CURVE SMOOTH",
+"118 203 OFFCURVE",
+"121 147 OFFCURVE",
+"122 143 CURVE",
+"124 142 OFFCURVE",
+"126 136 OFFCURVE",
+"126 131 CURVE",
+"132 108 OFFCURVE",
+"148 75 OFFCURVE",
+"160 64 CURVE",
+"184 36 OFFCURVE",
+"193 30 OFFCURVE",
+"204 22 CURVE SMOOTH",
+"210 17 OFFCURVE",
+"217 14 OFFCURVE",
+"218 14 CURVE SMOOTH",
+"220 14 OFFCURVE",
+"227 9 OFFCURVE",
+"232 6 CURVE SMOOTH",
+"253 -5 OFFCURVE",
+"304 -19 OFFCURVE",
+"338 -24 CURVE",
+"366 -27 OFFCURVE",
+"434 -27 OFFCURVE",
+"471 -25 CURVE",
+"507 -22 OFFCURVE",
+"526 -17 OFFCURVE",
+"555 -5 CURVE",
+"596 14 OFFCURVE",
+"617 31 OFFCURVE",
+"645 75 CURVE SMOOTH",
+"667 108 OFFCURVE",
+"680 145 OFFCURVE",
+"680 213 CURVE",
+"682 247 OFFCURVE",
+"682 397 OFFCURVE",
+"682 602 CURVE SMOOTH",
+"682 686 OFFCURVE",
+"682 692 OFFCURVE",
+"690 700 CURVE",
+"700 714 OFFCURVE",
+"706 714 OFFCURVE",
+"745 716 CURVE",
+"778 716 LINE",
+"784 721 LINE",
+"793 732 OFFCURVE",
+"785 752 OFFCURVE",
+"768 752 CURVE SMOOTH",
+"751 752 OFFCURVE",
+"651 752 OFFCURVE",
+"604 752 CURVE SMOOTH",
+"552 752 LINE",
+"546 747 LINE",
+"542 741 OFFCURVE",
+"540 729 OFFCURVE",
+"545 722 CURVE",
+"545 719 OFFCURVE",
+"552 719 OFFCURVE",
+"565 717 CURVE",
+"590 716 OFFCURVE",
+"615 713 OFFCURVE",
+"620 711 CURVE SMOOTH",
+"626 709 OFFCURVE",
+"640 699 OFFCURVE",
+"640 691 CURVE SMOOTH",
+"640 684 OFFCURVE",
+"640 606 OFFCURVE",
+"640 586 CURVE SMOOTH",
+"640 577 OFFCURVE",
+"640 569 OFFCURVE",
+"640 561 CURVE SMOOTH",
+"640 547 OFFCURVE",
+"640 464 OFFCURVE",
+"640 431 CURVE",
+"638 419 OFFCURVE",
+"638 408 OFFCURVE",
+"638 405 CURVE SMOOTH",
+"638 401 OFFCURVE",
+"638 391 OFFCURVE",
+"638 381 CURVE SMOOTH",
+"638 371 OFFCURVE",
+"638 358 OFFCURVE",
+"638 351 CURVE",
+"640 334 OFFCURVE",
+"640 283 OFFCURVE",
+"642 276 CURVE",
+"642 273 OFFCURVE",
+"640 250 OFFCURVE",
+"640 223 CURVE",
+"637 176 OFFCURVE",
+"637 173 OFFCURVE",
+"626 128 CURVE SMOOTH",
+"620 101 OFFCURVE",
+"607 81 OFFCURVE",
+"580 55 CURVE SMOOTH",
+"565 40 OFFCURVE",
+"554 33 OFFCURVE",
+"521 25 CURVE",
+"502 18 LINE",
+"455 18 LINE SMOOTH",
+"405 18 OFFCURVE",
+"402 18 OFFCURVE",
+"372 33 CURVE SMOOTH",
+"347 45 OFFCURVE",
+"342 50 OFFCURVE",
+"322 81 CURVE SMOOTH",
+"313 95 OFFCURVE",
+"310 105 OFFCURVE",
+"309 114 CURVE",
+"307 120 OFFCURVE",
+"307 130 OFFCURVE",
+"305 136 CURVE",
+"301 159 OFFCURVE",
+"301 208 OFFCURVE",
+"301 286 CURVE SMOOTH",
+"302 373 OFFCURVE",
+"302 505 OFFCURVE",
+"302 627 CURVE",
+"301 672 OFFCURVE",
+"302 704 OFFCURVE",
+"304 708 CURVE SMOOTH",
+"308 717 OFFCURVE",
+"314 717 OFFCURVE",
+"352 716 CURVE",
+"352 716 OFFCURVE",
+"374 716 OFFCURVE",
+"374 717 CURVE",
+"396 717 OFFCURVE",
+"396 719 OFFCURVE",
+"396 722 CURVE SMOOTH",
+"396 729 OFFCURVE",
+"396 742 OFFCURVE",
+"396 749 CURVE",
+"390 752 LINE",
+"342 752 LINE SMOOTH",
+"315 752 OFFCURVE",
+"280 752 OFFCURVE",
+"262 752 CURVE SMOOTH",
+"244 752 OFFCURVE",
+"185 752 OFFCURVE",
+"130 752 CURVE",
+"36 754 OFFCURVE",
+"32 754 OFFCURVE",
+"29 750 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"230 467 OFFCURVE",
+"230 467 OFFCURVE",
+"227 467 CURVE SMOOTH",
+"221 467 OFFCURVE",
+"219 469 OFFCURVE",
+"222 471 CURVE",
+"226 472 OFFCURVE",
+"227 472 OFFCURVE",
+"229 469 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"574 -13 OFFCURVE",
+"659 51 OFFCURVE",
+"659 195 CURVE SMOOTH",
+"659 724 LINE",
+"764 724 LINE",
+"764 754 LINE",
+"526 754 LINE",
+"526 724 LINE",
+"621 724 LINE",
+"621 200 LINE SMOOTH",
+"621 84 OFFCURVE",
+"553 27 OFFCURVE",
+"441 27 CURVE SMOOTH",
+"337 27 OFFCURVE",
+"270 76 OFFCURVE",
+"270 200 CURVE SMOOTH",
+"270 724 LINE",
+"376 724 LINE",
+"376 754 LINE",
+"15 754 LINE",
+"15 724 LINE",
+"112 724 LINE",
+"112 194 LINE SMOOTH",
+"112 53 OFFCURVE",
+"229 -13 OFFCURVE",
+"403 -13 CURVE SMOOTH"
+);
+}
+);
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0055;
+},
+{
+glyphname = Uacute;
+lastChange = "2022-03-23 16:33:53 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 74, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -3, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 00DA;
+},
+{
+glyphname = Ubreve;
+lastChange = "2022-03-23 16:33:53 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 104, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 89, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 016C;
+},
+{
+glyphname = Ucircumflex;
+lastChange = "2022-03-23 16:33:53 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 109, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 91, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 00DB;
+},
+{
+glyphname = Udblgrave;
+lastChange = "2022-03-23 16:33:53 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 186, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0214;
+},
+{
+glyphname = Udieresis;
+lastChange = "2022-03-23 16:32:33 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 235, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 217, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 00DC;
+},
+{
+glyphname = Udotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 85, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 94, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE4;
+},
+{
+glyphname = Ugrave;
+lastChange = "2022-03-23 16:33:53 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 112, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 138, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 00D9;
+},
+{
+glyphname = Uhookabove;
+lastChange = "2022-03-23 16:33:53 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 114, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 103, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE6;
+},
+{
+glyphname = Uhorn;
+lastChange = "2016-08-22 12:18:08 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{369, 0}";
+},
+{
+name = ogonek;
+position = "{663, 10}";
+},
+{
+name = top;
+position = "{369, 754}";
+},
+{
+name = topright;
+position = "{680, 701}";
+}
+);
+components = (
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 368, 251}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"545 -12 OFFCURVE",
+"625 53 OFFCURVE",
+"625 196 CURVE SMOOTH",
+"625 754 LINE",
+"487 754 LINE",
+"487 729 LINE",
+"592 729 LINE",
+"592 196 LINE SMOOTH",
+"592 80 OFFCURVE",
+"525 23 OFFCURVE",
+"418 23 CURVE SMOOTH",
+"318 23 OFFCURVE",
+"257 72 OFFCURVE",
+"257 196 CURVE SMOOTH",
+"257 729 LINE",
+"352 729 LINE",
+"352 754 LINE",
+"6 754 LINE",
+"6 729 LINE",
+"123 729 LINE",
+"123 195 LINE SMOOTH",
+"123 54 OFFCURVE",
+"227 -12 OFFCURVE",
+"387 -12 CURVE SMOOTH"
+);
+}
+);
+width = 737;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{387, 0}";
+},
+{
+name = ogonek;
+position = "{697, 10}";
+},
+{
+name = top;
+position = "{387, 754}";
+},
+{
+name = topright;
+position = "{605, 700}";
+}
+);
+components = (
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 406, 250}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"574 -13 OFFCURVE",
+"659 51 OFFCURVE",
+"659 195 CURVE SMOOTH",
+"659 754 LINE",
+"526 754 LINE",
+"526 724 LINE",
+"621 724 LINE",
+"621 200 LINE SMOOTH",
+"621 84 OFFCURVE",
+"553 27 OFFCURVE",
+"441 27 CURVE SMOOTH",
+"337 27 OFFCURVE",
+"270 76 OFFCURVE",
+"270 200 CURVE SMOOTH",
+"270 724 LINE",
+"376 724 LINE",
+"376 754 LINE",
+"15 754 LINE",
+"15 724 LINE",
+"112 724 LINE",
+"112 194 LINE SMOOTH",
+"112 53 OFFCURVE",
+"229 -13 OFFCURVE",
+"403 -13 CURVE SMOOTH"
+);
+}
+);
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 01AF;
+},
+{
+glyphname = Uhornacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 44, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -3, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE8;
+},
+{
+glyphname = Uhorndotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 85, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 94, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EF0;
+},
+{
+glyphname = Uhorngrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 82, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 138, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEA;
+},
+{
+glyphname = Uhornhookabove;
+lastChange = "2016-08-22 12:17:06 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 140, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 164, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEC;
+},
+{
+glyphname = Uhorntilde;
+lastChange = "2016-08-22 12:17:21 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 148, 277}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 148, 289}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEE;
+},
+{
+glyphname = Uhungarumlaut;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = U;
+},
+{
+alignment = -1;
+name = hungarumlaut.case;
+transform = "{1, 0, 0, 1, 272, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+alignment = -1;
+name = U;
+},
+{
+alignment = -1;
+name = hungarumlaut.case;
+transform = "{1, 0, 0, 1, 226, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0170;
+},
+{
+glyphname = Uinvertedbreve;
+lastChange = "2016-08-22 12:18:27 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+alignment = -1;
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 263, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+alignment = -1;
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 272, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0216;
+},
+{
+glyphname = Umacron;
+lastChange = "2022-03-23 16:33:53 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 231, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 215, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 016A;
+},
+{
+glyphname = Uogonek;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = U;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 250, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+alignment = -1;
+name = U;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 265, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0172;
+},
+{
+glyphname = Uring;
+lastChange = "2022-03-23 16:33:53 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 298, 40}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 279, 80}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 016E;
+},
+{
+glyphname = Utilde;
+lastChange = "2022-03-23 16:33:53 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 108, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 74, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0168;
+},
+{
+glyphname = V;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{357, 0}";
+},
+{
+name = top;
+position = "{357, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"237 739 LINE",
+"103 739 LINE",
+"359 -9 LINE",
+"389 -9 LINE",
+"437 160 LINE",
+"427 194 LINE",
+"423 194 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"357 754 LINE",
+"10 754 LINE",
+"10 729 LINE",
+"357 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"735 754 LINE",
+"491 754 LINE",
+"491 729 LINE",
+"735 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"417 165 LINE",
+"359 -9 LINE",
+"389 -9 LINE",
+"645 739 LINE",
+"612 739 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"373 -12 LINE",
+"421 160 LINE",
+"411 194 LINE",
+"407 194 LINE",
+"221 739 LINE",
+"87 739 LINE",
+"343 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"373 -12 LINE",
+"629 739 LINE",
+"596 739 LINE",
+"401 165 LINE",
+"343 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 729 LINE",
+"341 754 LINE",
+"-6 754 LINE",
+"-6 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"719 729 LINE",
+"719 754 LINE",
+"475 754 LINE",
+"475 729 LINE"
+);
+}
+);
+width = 714;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{334, 0}";
+},
+{
+name = top;
+position = "{334, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"66 754 OFFCURVE",
+"43 754 OFFCURVE",
+"19 752 CURVE",
+"-32 752 OFFCURVE",
+"-32 752 OFFCURVE",
+"-33 740 CURVE",
+"-35 730 OFFCURVE",
+"-33 724 OFFCURVE",
+"-25 719 CURVE",
+"-25 717 OFFCURVE",
+"-25 717 OFFCURVE",
+"-2 719 CURVE",
+"16 722 OFFCURVE",
+"39 722 OFFCURVE",
+"41 719 CURVE SMOOTH",
+"43 717 OFFCURVE",
+"50 702 OFFCURVE",
+"56 686 CURVE SMOOTH",
+"62 671 OFFCURVE",
+"70 655 OFFCURVE",
+"73 652 CURVE",
+"74 649 OFFCURVE",
+"76 642 OFFCURVE",
+"77 638 CURVE SMOOTH",
+"77 635 OFFCURVE",
+"84 621 OFFCURVE",
+"90 606 CURVE",
+"97 594 OFFCURVE",
+"101 578 OFFCURVE",
+"101 577 CURVE SMOOTH",
+"101 575 OFFCURVE",
+"103 572 OFFCURVE",
+"105 569 CURVE SMOOTH",
+"106 567 OFFCURVE",
+"109 559 OFFCURVE",
+"111 553 CURVE SMOOTH",
+"113 546 OFFCURVE",
+"119 532 OFFCURVE",
+"123 522 CURVE",
+"127 512 OFFCURVE",
+"135 497 OFFCURVE",
+"136 489 CURVE",
+"139 481 OFFCURVE",
+"142 473 OFFCURVE",
+"144 470 CURVE SMOOTH",
+"150 462 OFFCURVE",
+"157 439 OFFCURVE",
+"163 421 CURVE",
+"185 393 OFFCURVE",
+"185 380 OFFCURVE",
+"185 369 CURVE",
+"206 340 OFFCURVE",
+"206 328 OFFCURVE",
+"206 317 CURVE",
+"209 309 OFFCURVE",
+"215 291 OFFCURVE",
+"220 278 CURVE",
+"227 264 OFFCURVE",
+"232 250 OFFCURVE",
+"233 245 CURVE SMOOTH",
+"235 240 OFFCURVE",
+"236 234 OFFCURVE",
+"239 231 CURVE SMOOTH",
+"241 228 OFFCURVE",
+"245 220 OFFCURVE",
+"248 212 CURVE",
+"248 195 OFFCURVE",
+"269 166 OFFCURVE",
+"269 158 CURVE",
+"273 150 OFFCURVE",
+"278 136 OFFCURVE",
+"287 114 CURVE",
+"288 106 OFFCURVE",
+"292 98 OFFCURVE",
+"295 93 CURVE SMOOTH",
+"296 90 OFFCURVE",
+"300 81 OFFCURVE",
+"301 74 CURVE",
+"305 61 OFFCURVE",
+"311 37 OFFCURVE",
+"320 26 CURVE",
+"321 20 OFFCURVE",
+"323 16 OFFCURVE",
+"323 14 CURVE SMOOTH",
+"323 9 OFFCURVE",
+"332 -2 OFFCURVE",
+"336 -5 CURVE",
+"336 -7 OFFCURVE",
+"357 -7 OFFCURVE",
+"357 -4 CURVE",
+"358 -4 OFFCURVE",
+"360 1 OFFCURVE",
+"361 3 CURVE",
+"361 9 OFFCURVE",
+"385 50 OFFCURVE",
+"385 66 CURVE SMOOTH",
+"385 74 OFFCURVE",
+"402 117 OFFCURVE",
+"410 144 CURVE",
+"434 209 OFFCURVE",
+"445 240 OFFCURVE",
+"445 244 CURVE SMOOTH",
+"445 245 OFFCURVE",
+"448 255 OFFCURVE",
+"451 263 CURVE SMOOTH",
+"455 273 OFFCURVE",
+"461 288 OFFCURVE",
+"463 296 CURVE SMOOTH",
+"466 304 OFFCURVE",
+"471 318 OFFCURVE",
+"474 325 CURVE SMOOTH",
+"477 333 OFFCURVE",
+"479 342 OFFCURVE",
+"480 343 CURVE",
+"480 345 OFFCURVE",
+"483 353 OFFCURVE",
+"485 359 CURVE SMOOTH",
+"487 366 OFFCURVE",
+"490 374 OFFCURVE",
+"492 375 CURVE SMOOTH",
+"494 378 OFFCURVE",
+"496 385 OFFCURVE",
+"497 391 CURVE SMOOTH",
+"499 399 OFFCURVE",
+"504 408 OFFCURVE",
+"507 416 CURVE SMOOTH",
+"515 442 OFFCURVE",
+"520 455 OFFCURVE",
+"523 462 CURVE",
+"527 480 OFFCURVE",
+"531 497 OFFCURVE",
+"552 549 CURVE",
+"556 559 OFFCURVE",
+"561 572 OFFCURVE",
+"564 582 CURVE SMOOTH",
+"567 590 OFFCURVE",
+"572 611 OFFCURVE",
+"580 627 CURVE",
+"586 644 OFFCURVE",
+"592 662 OFFCURVE",
+"593 668 CURVE",
+"601 692 OFFCURVE",
+"611 708 OFFCURVE",
+"630 716 CURVE SMOOTH",
+"638 719 OFFCURVE",
+"641 719 OFFCURVE",
+"664 719 CURVE",
+"695 717 OFFCURVE",
+"697 717 OFFCURVE",
+"702 727 CURVE SMOOTH",
+"707 735 OFFCURVE",
+"705 746 OFFCURVE",
+"697 749 CURVE SMOOTH",
+"692 752 OFFCURVE",
+"686 752 OFFCURVE",
+"581 752 CURVE SMOOTH",
+"471 752 LINE",
+"467 748 LINE",
+"467 743 OFFCURVE",
+"467 732 OFFCURVE",
+"467 727 CURVE",
+"471 720 OFFCURVE",
+"488 717 OFFCURVE",
+"497 719 CURVE SMOOTH",
+"503 720 OFFCURVE",
+"510 720 OFFCURVE",
+"523 719 CURVE SMOOTH",
+"545 716 OFFCURVE",
+"556 712 OFFCURVE",
+"561 702 CURVE",
+"564 694 OFFCURVE",
+"564 692 OFFCURVE",
+"562 681 CURVE SMOOTH",
+"561 675 OFFCURVE",
+"559 668 OFFCURVE",
+"559 668 CURVE",
+"557 667 OFFCURVE",
+"554 659 OFFCURVE",
+"552 651 CURVE",
+"548 640 OFFCURVE",
+"542 624 OFFCURVE",
+"537 610 CURVE SMOOTH",
+"532 597 OFFCURVE",
+"523 570 OFFCURVE",
+"516 553 CURVE",
+"510 535 OFFCURVE",
+"504 515 OFFCURVE",
+"502 510 CURVE SMOOTH",
+"492 489 OFFCURVE",
+"472 432 OFFCURVE",
+"469 419 CURVE",
+"466 411 OFFCURVE",
+"459 390 OFFCURVE",
+"453 370 CURVE",
+"450 364 OFFCURVE",
+"448 358 OFFCURVE",
+"448 353 CURVE",
+"447 350 OFFCURVE",
+"445 343 OFFCURVE",
+"443 338 CURVE",
+"440 333 OFFCURVE",
+"437 323 OFFCURVE",
+"434 315 CURVE",
+"426 288 OFFCURVE",
+"423 281 OFFCURVE",
+"420 275 CURVE SMOOTH",
+"415 264 OFFCURVE",
+"410 264 OFFCURVE",
+"407 273 CURVE",
+"406 280 OFFCURVE",
+"398 299 OFFCURVE",
+"390 313 CURVE",
+"388 320 OFFCURVE",
+"383 331 OFFCURVE",
+"380 342 CURVE SMOOTH",
+"377 351 OFFCURVE",
+"372 366 OFFCURVE",
+"366 374 CURVE",
+"363 382 OFFCURVE",
+"360 391 OFFCURVE",
+"360 393 CURVE SMOOTH",
+"360 394 OFFCURVE",
+"353 410 OFFCURVE",
+"347 426 CURVE SMOOTH",
+"341 442 OFFCURVE",
+"334 464 OFFCURVE",
+"331 470 CURVE SMOOTH",
+"328 478 OFFCURVE",
+"325 488 OFFCURVE",
+"323 491 CURVE SMOOTH",
+"321 494 OFFCURVE",
+"320 500 OFFCURVE",
+"318 505 CURVE",
+"317 512 OFFCURVE",
+"309 533 OFFCURVE",
+"300 556 CURVE SMOOTH",
+"298 561 OFFCURVE",
+"293 572 OFFCURVE",
+"288 584 CURVE SMOOTH",
+"277 608 OFFCURVE",
+"272 622 OFFCURVE",
+"263 651 CURVE",
+"258 662 OFFCURVE",
+"253 676 OFFCURVE",
+"252 683 CURVE",
+"248 687 OFFCURVE",
+"247 697 OFFCURVE",
+"247 702 CURVE SMOOTH",
+"247 716 OFFCURVE",
+"252 717 OFFCURVE",
+"274 717 CURVE SMOOTH",
+"301 717 OFFCURVE",
+"313 719 OFFCURVE",
+"317 725 CURVE",
+"317 732 OFFCURVE",
+"317 740 OFFCURVE",
+"317 746 CURVE",
+"312 752 LINE",
+"195 752 LINE SMOOTH",
+"131 752 OFFCURVE",
+"77 754 OFFCURVE",
+"74 754 CURVE SMOOTH",
+"73 754 OFFCURVE",
+"69 754 OFFCURVE",
+"68 754 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"347 -9 LINE",
+"413 205 LINE",
+"407 242 LINE",
+"403 242 LINE",
+"222 739 LINE",
+"49 739 LINE",
+"321 -9 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"347 -9 LINE",
+"622 739 LINE",
+"589 739 LINE",
+"373 150 LINE",
+"321 -9 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 724 LINE",
+"307 754 LINE",
+"-25 754 LINE",
+"-25 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"687 724 LINE",
+"687 754 LINE",
+"466 754 LINE",
+"466 724 LINE"
+);
+}
+);
+width = 667;
+}
+);
+unicode = 0056;
+},
+{
+glyphname = W;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{454, 0}";
+},
+{
+name = top;
+position = "{454, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"181 739 LINE",
+"47 739 LINE",
+"303 -12 LINE",
+"333 -12 LINE",
+"381 160 LINE",
+"372 192 LINE",
+"368 192 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"673 754 LINE",
+"-26 754 LINE",
+"-26 729 LINE",
+"673 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 163 LINE",
+"303 -12 LINE",
+"333 -12 LINE",
+"510 487 LINE",
+"476 487 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"451 739 LINE",
+"317 739 LINE",
+"573 -12 LINE",
+"603 -12 LINE",
+"651 160 LINE",
+"644 189 LINE",
+"640 189 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"626 160 LINE",
+"573 -12 LINE",
+"603 -12 LINE",
+"864 739 LINE",
+"831 739 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"932 754 LINE",
+"724 754 LINE",
+"724 729 LINE",
+"932 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"500 495 LINE",
+"532 495 LINE",
+"621 742 LINE",
+"586 742 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"333 -12 LINE",
+"455 333 LINE",
+"573 -12 LINE",
+"603 -12 LINE",
+"860 729 LINE",
+"932 729 LINE",
+"932 754 LINE",
+"724 754 LINE",
+"724 729 LINE",
+"827 729 LINE",
+"640 192 LINE",
+"636 192 LINE",
+"533 499 LINE",
+"616 729 LINE",
+"673 729 LINE",
+"673 754 LINE",
+"-26 754 LINE",
+"-26 729 LINE",
+"50 729 LINE",
+"303 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 729 LINE",
+"320 729 LINE",
+"439 381 LINE",
+"372 192 LINE",
+"368 192 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"454 729 LINE",
+"581 729 LINE",
+"517 545 LINE"
+);
+}
+);
+width = 907;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{510, 0}";
+},
+{
+name = top;
+position = "{510, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"227 739 LINE",
+"54 739 LINE",
+"338 -9 LINE",
+"364 -9 LINE",
+"439 178 LINE",
+"435 208 LINE",
+"431 208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"770 754 LINE",
+"-20 754 LINE",
+"-20 724 LINE",
+"770 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1039 754 LINE",
+"818 754 LINE",
+"818 724 LINE",
+"1039 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"708 150 LINE",
+"656 -9 LINE",
+"682 -9 LINE",
+"957 739 LINE",
+"924 739 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"545 739 LINE",
+"372 739 LINE",
+"656 -9 LINE",
+"682 -9 LINE",
+"744 195 LINE",
+"738 232 LINE",
+"734 232 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"410 150 LINE",
+"358 -9 LINE",
+"384 -9 LINE",
+"547 393 LINE",
+"514 393 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 454 LINE",
+"607 454 LINE",
+"711 737 LINE",
+"678 737 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"384 -9 LINE",
+"524 337 LINE",
+"656 -9 LINE",
+"682 -9 LINE",
+"951 724 LINE",
+"1039 724 LINE",
+"1039 754 LINE",
+"818 754 LINE",
+"818 724 LINE",
+"918 724 LINE",
+"738 232 LINE",
+"734 232 LINE",
+"629 514 LINE",
+"706 724 LINE",
+"770 724 LINE",
+"770 754 LINE",
+"-20 754 LINE",
+"-20 724 LINE",
+"59 724 LINE",
+"338 -9 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"233 724 LINE",
+"377 724 LINE",
+"508 379 LINE",
+"435 208 LINE",
+"431 208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"550 724 LINE",
+"673 724 LINE",
+"612 558 LINE"
+);
+}
+);
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 0057;
+},
+{
+glyphname = Wacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 129, 304}";
+}
+);
+layerId = UUID0;
+width = 907;
+},
+{
+components = (
+{
+name = W;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 120, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 1E82;
+},
+{
+glyphname = Wcircumflex;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 164, 304}";
+}
+);
+layerId = UUID0;
+width = 907;
+},
+{
+components = (
+{
+name = W;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 214, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 0174;
+},
+{
+glyphname = Wdieresis;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 290, 0}";
+}
+);
+layerId = UUID0;
+width = 907;
+},
+{
+components = (
+{
+name = W;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 340, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 1E84;
+},
+{
+glyphname = Wgrave;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 167, 304}";
+}
+);
+layerId = UUID0;
+width = 907;
+},
+{
+components = (
+{
+name = W;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 261, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 1E80;
+},
+{
+glyphname = X;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{337, 0}";
+},
+{
+name = top;
+position = "{337, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"223 739 LINE",
+"73 739 LINE",
+"487 0 LINE",
+"632 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"337 754 LINE",
+"-7 754 LINE",
+"-7 729 LINE",
+"337 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"674 754 LINE",
+"425 754 LINE",
+"425 729 LINE",
+"674 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"337 400 LINE",
+"374 400 LINE",
+"584 739 LINE",
+"551 739 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"696 25 LINE",
+"354 25 LINE",
+"354 0 LINE",
+"696 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 25 LINE",
+"-22 25 LINE",
+"-22 0 LINE",
+"240 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 20 LINE",
+"107 20 LINE",
+"329 379 LINE",
+"293 379 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"240 0 LINE",
+"240 25 LINE",
+"110 25 LINE",
+"300 333 LINE",
+"473 25 LINE",
+"354 25 LINE",
+"354 0 LINE",
+"696 0 LINE",
+"696 25 LINE",
+"618 25 LINE",
+"393 431 LINE",
+"578 729 LINE",
+"674 729 LINE",
+"674 754 LINE",
+"425 754 LINE",
+"425 729 LINE",
+"544 729 LINE",
+"376 462 LINE",
+"228 729 LINE",
+"337 729 LINE",
+"337 754 LINE",
+"-7 754 LINE",
+"-7 729 LINE",
+"78 729 LINE",
+"283 363 LINE",
+"73 25 LINE",
+"-22 25 LINE",
+"-22 0 LINE"
+);
+}
+);
+width = 674;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{360, 0}";
+},
+{
+name = top;
+position = "{360, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"237 739 LINE",
+"49 739 LINE",
+"488 0 LINE",
+"677 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"347 754 LINE",
+"-15 754 LINE",
+"-15 724 LINE",
+"347 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"676 754 LINE",
+"445 754 LINE",
+"445 724 LINE",
+"676 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 356 LINE",
+"345 350 LINE",
+"597 739 LINE",
+"561 739 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-11 0 LINE",
+"240 0 LINE",
+"240 30 LINE",
+"-11 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"363 398 LINE",
+"330 404 LINE",
+"78 15 LINE",
+"114 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 0 LINE",
+"734 0 LINE",
+"734 30 LINE",
+"379 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"240 0 LINE",
+"240 30 LINE",
+"124 30 LINE",
+"304 308 LINE",
+"470 30 LINE",
+"379 30 LINE",
+"379 0 LINE",
+"734 0 LINE",
+"734 30 LINE",
+"659 30 LINE",
+"409 449 LINE",
+"587 724 LINE",
+"676 724 LINE",
+"676 754 LINE",
+"445 754 LINE",
+"445 724 LINE",
+"551 724 LINE",
+"392 479 LINE",
+"246 724 LINE",
+"347 724 LINE",
+"347 754 LINE",
+"-15 754 LINE",
+"-15 724 LINE",
+"58 724 LINE",
+"287 338 LINE",
+"87 30 LINE",
+"-11 30 LINE",
+"-11 0 LINE"
+);
+}
+);
+width = 719;
+}
+);
+unicode = 0058;
+},
+{
+glyphname = Y;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{329, 0}";
+},
+{
+name = top;
+position = "{329, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"271 15 LINE",
+"405 15 LINE",
+"405 384 LINE",
+"271 384 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"151 0 LINE",
+"525 0 LINE",
+"525 25 LINE",
+"151 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"191 739 LINE",
+"41 739 LINE",
+"284 321 LINE",
+"401 375 LINE",
+"390 402 LINE",
+"386 402 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 754 LINE",
+"-42 754 LINE",
+"-42 729 LINE",
+"305 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"698 754 LINE",
+"433 754 LINE",
+"433 729 LINE",
+"698 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"360 347 LINE",
+"397 347 LINE",
+"608 739 LINE",
+"575 739 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"525 0 LINE",
+"525 25 LINE",
+"405 25 LINE",
+"405 362 LINE",
+"602 729 LINE",
+"698 729 LINE",
+"698 754 LINE",
+"433 754 LINE",
+"433 729 LINE",
+"569 729 LINE",
+"390 402 LINE",
+"386 402 LINE",
+"197 729 LINE",
+"305 729 LINE",
+"305 754 LINE",
+"-42 754 LINE",
+"-42 729 LINE",
+"47 729 LINE",
+"271 343 LINE",
+"271 25 LINE",
+"151 25 LINE",
+"151 0 LINE"
+);
+}
+);
+width = 657;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{383, 0}";
+},
+{
+name = top;
+position = "{383, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"317 15 LINE",
+"475 15 LINE",
+"475 384 LINE",
+"317 384 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 0 LINE",
+"593 0 LINE",
+"593 30 LINE",
+"202 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 739 LINE",
+"69 739 LINE",
+"375 234 LINE",
+"406 234 LINE",
+"472 368 LINE",
+"468 403 LINE",
+"464 403 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 754 LINE",
+"10 754 LINE",
+"10 724 LINE",
+"362 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"756 754 LINE",
+"521 754 LINE",
+"521 724 LINE",
+"756 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 301 LINE",
+"454 301 LINE",
+"675 739 LINE",
+"637 739 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"593 0 LINE",
+"593 30 LINE",
+"475 30 LINE",
+"475 342 LINE",
+"667 724 LINE",
+"756 724 LINE",
+"756 754 LINE",
+"521 754 LINE",
+"521 724 LINE",
+"629 724 LINE",
+"468 403 LINE",
+"464 403 LINE",
+"276 724 LINE",
+"362 724 LINE",
+"362 754 LINE",
+"10 754 LINE",
+"10 724 LINE",
+"78 724 LINE",
+"317 329 LINE",
+"317 30 LINE",
+"202 30 LINE",
+"202 0 LINE"
+);
+}
+);
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 0059;
+},
+{
+glyphname = Yacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 4, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -7, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 00DD;
+},
+{
+glyphname = Ycircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 39, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 0176;
+},
+{
+glyphname = Ydieresis;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 165, 0}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 213, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 0178;
+},
+{
+glyphname = Ydotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 45, 0}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 90, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF4;
+},
+{
+glyphname = Ygrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 42, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 134, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF2;
+},
+{
+glyphname = Yhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 44, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF6;
+},
+{
+glyphname = Ytilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 38, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 70, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF8;
+},
+{
+glyphname = Z;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{326, 0}";
+},
+{
+name = top;
+position = "{326, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"15 0 LINE",
+"601 0 LINE",
+"601 245 LINE",
+"566 245 LINE",
+"564 128 OFFCURVE",
+"507 25 OFFCURVE",
+"408 25 CURVE SMOOTH",
+"15 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"601 754 LINE",
+"65 754 LINE",
+"65 549 LINE",
+"100 549 LINE",
+"102 646 OFFCURVE",
+"159 729 OFFCURVE",
+"258 729 CURVE SMOOTH",
+"601 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 32 LINE",
+"15 7 LINE",
+"180 18 LINE",
+"180 29 LINE",
+"601 719 LINE",
+"601 737 LINE",
+"439 731 LINE",
+"439 725 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"193 18 LINE",
+"193 29 LINE",
+"608 719 LINE",
+"608 737 LINE",
+"446 731 LINE",
+"446 725 LINE",
+"28 32 LINE",
+"28 7 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 0 LINE",
+"608 245 LINE",
+"573 245 LINE",
+"571 128 OFFCURVE",
+"514 25 OFFCURVE",
+"415 25 CURVE SMOOTH",
+"28 25 LINE",
+"28 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"103 549 LINE",
+"105 646 OFFCURVE",
+"162 729 OFFCURVE",
+"261 729 CURVE SMOOTH",
+"608 729 LINE",
+"608 754 LINE",
+"68 754 LINE",
+"68 549 LINE"
+);
+}
+);
+width = 651;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{311, 0}";
+},
+{
+name = top;
+position = "{311, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"81 751 OFFCURVE",
+"78 747 OFFCURVE",
+"78 692 CURVE SMOOTH",
+"78 658 OFFCURVE",
+"76 638 OFFCURVE",
+"72 581 CURVE",
+"69 553 OFFCURVE",
+"72 547 OFFCURVE",
+"90 544 CURVE",
+"97 542 OFFCURVE",
+"100 544 OFFCURVE",
+"103 547 CURVE SMOOTH",
+"106 551 OFFCURVE",
+"110 556 OFFCURVE",
+"112 561 CURVE SMOOTH",
+"114 567 OFFCURVE",
+"117 576 OFFCURVE",
+"118 581 CURVE SMOOTH",
+"120 586 OFFCURVE",
+"123 594 OFFCURVE",
+"125 600 CURVE SMOOTH",
+"134 621 OFFCURVE",
+"143 638 OFFCURVE",
+"151 648 CURVE SMOOTH",
+"156 655 OFFCURVE",
+"162 661 OFFCURVE",
+"164 666 CURVE",
+"169 673 OFFCURVE",
+"184 684 OFFCURVE",
+"193 691 CURVE",
+"197 692 OFFCURVE",
+"201 697 OFFCURVE",
+"206 698 CURVE",
+"216 708 OFFCURVE",
+"234 714 OFFCURVE",
+"254 717 CURVE",
+"270 722 OFFCURVE",
+"397 722 OFFCURVE",
+"409 719 CURVE SMOOTH",
+"415 717 OFFCURVE",
+"415 716 OFFCURVE",
+"417 711 CURVE",
+"417 703 OFFCURVE",
+"407 683 OFFCURVE",
+"395 663 CURVE SMOOTH",
+"392 658 OFFCURVE",
+"387 650 OFFCURVE",
+"385 644 CURVE SMOOTH",
+"384 639 OFFCURVE",
+"379 633 OFFCURVE",
+"377 630 CURVE SMOOTH",
+"373 626 OFFCURVE",
+"367 616 OFFCURVE",
+"362 606 CURVE SMOOTH",
+"357 597 OFFCURVE",
+"350 586 OFFCURVE",
+"347 581 CURVE SMOOTH",
+"340 571 OFFCURVE",
+"323 541 OFFCURVE",
+"315 526 CURVE",
+"314 521 OFFCURVE",
+"309 514 OFFCURVE",
+"307 511 CURVE SMOOTH",
+"304 506 OFFCURVE",
+"300 501 OFFCURVE",
+"300 500 CURVE SMOOTH",
+"298 497 OFFCURVE",
+"295 491 OFFCURVE",
+"292 484 CURVE",
+"287 478 OFFCURVE",
+"276 459 OFFCURVE",
+"270 444 CURVE SMOOTH",
+"264 430 OFFCURVE",
+"254 414 OFFCURVE",
+"250 411 CURVE SMOOTH",
+"247 408 OFFCURVE",
+"243 400 OFFCURVE",
+"242 396 CURVE SMOOTH",
+"240 392 OFFCURVE",
+"232 380 OFFCURVE",
+"225 369 CURVE SMOOTH",
+"214 350 OFFCURVE",
+"197 324 OFFCURVE",
+"189 308 CURVE SMOOTH",
+"187 305 OFFCURVE",
+"181 294 OFFCURVE",
+"175 286 CURVE",
+"170 275 OFFCURVE",
+"165 266 OFFCURVE",
+"162 261 CURVE SMOOTH",
+"160 256 OFFCURVE",
+"156 249 OFFCURVE",
+"153 246 CURVE SMOOTH",
+"150 242 OFFCURVE",
+"148 238 OFFCURVE",
+"147 236 CURVE",
+"147 233 OFFCURVE",
+"145 230 OFFCURVE",
+"142 225 CURVE SMOOTH",
+"137 217 OFFCURVE",
+"120 189 OFFCURVE",
+"120 186 CURVE SMOOTH",
+"120 186 OFFCURVE",
+"117 181 OFFCURVE",
+"114 175 CURVE",
+"110 171 OFFCURVE",
+"103 163 OFFCURVE",
+"100 156 CURVE SMOOTH",
+"93 142 OFFCURVE",
+"78 116 OFFCURVE",
+"70 104 CURVE",
+"67 97 OFFCURVE",
+"59 86 OFFCURVE",
+"53 77 CURVE SMOOTH",
+"47 67 OFFCURVE",
+"40 55 OFFCURVE",
+"37 52 CURVE SMOOTH",
+"23 36 OFFCURVE",
+"18 14 OFFCURVE",
+"25 2 CURVE",
+"31 -4 OFFCURVE",
+"39 -6 OFFCURVE",
+"85 -4 CURVE SMOOTH",
+"131 -3 OFFCURVE",
+"209 -3 OFFCURVE",
+"559 -6 CURVE SMOOTH",
+"580 -6 OFFCURVE",
+"602 -6 OFFCURVE",
+"604 -4 CURVE",
+"614 -3 OFFCURVE",
+"616 2 OFFCURVE",
+"618 52 CURVE",
+"618 75 OFFCURVE",
+"620 106 OFFCURVE",
+"623 119 CURVE",
+"626 155 OFFCURVE",
+"626 167 OFFCURVE",
+"627 191 CURVE SMOOTH",
+"627 202 OFFCURVE",
+"629 216 OFFCURVE",
+"629 219 CURVE SMOOTH",
+"632 236 OFFCURVE",
+"623 246 OFFCURVE",
+"604 242 CURVE",
+"595 241 OFFCURVE",
+"593 241 OFFCURVE",
+"589 231 CURVE",
+"585 225 OFFCURVE",
+"582 216 OFFCURVE",
+"581 211 CURVE SMOOTH",
+"579 205 OFFCURVE",
+"576 192 OFFCURVE",
+"570 183 CURVE",
+"567 172 OFFCURVE",
+"562 161 OFFCURVE",
+"560 158 CURVE",
+"560 152 OFFCURVE",
+"554 142 OFFCURVE",
+"547 133 CURVE",
+"542 124 OFFCURVE",
+"535 114 OFFCURVE",
+"534 111 CURVE SMOOTH",
+"531 102 OFFCURVE",
+"502 72 OFFCURVE",
+"487 61 CURVE SMOOTH",
+"465 44 OFFCURVE",
+"435 33 OFFCURVE",
+"409 29 CURVE SMOOTH",
+"392 27 OFFCURVE",
+"232 27 OFFCURVE",
+"229 29 CURVE",
+"226 29 OFFCURVE",
+"226 33 OFFCURVE",
+"226 34 CURVE SMOOTH",
+"226 39 OFFCURVE",
+"236 59 OFFCURVE",
+"245 72 CURVE",
+"253 86 OFFCURVE",
+"266 106 OFFCURVE",
+"284 139 CURVE",
+"284 156 OFFCURVE",
+"306 172 OFFCURVE",
+"306 175 CURVE",
+"315 186 OFFCURVE",
+"343 234 OFFCURVE",
+"347 247 CURVE SMOOTH",
+"350 255 OFFCURVE",
+"359 267 OFFCURVE",
+"364 275 CURVE SMOOTH",
+"369 284 OFFCURVE",
+"378 296 OFFCURVE",
+"381 300 CURVE",
+"382 308 OFFCURVE",
+"387 317 OFFCURVE",
+"392 324 CURVE SMOOTH",
+"395 330 OFFCURVE",
+"398 336 OFFCURVE",
+"398 338 CURVE SMOOTH",
+"398 338 OFFCURVE",
+"402 341 OFFCURVE",
+"404 344 CURVE SMOOTH",
+"407 347 OFFCURVE",
+"410 355 OFFCURVE",
+"414 361 CURVE",
+"415 366 OFFCURVE",
+"422 375 OFFCURVE",
+"426 383 CURVE SMOOTH",
+"430 389 OFFCURVE",
+"435 399 OFFCURVE",
+"439 405 CURVE",
+"439 409 OFFCURVE",
+"450 424 OFFCURVE",
+"460 439 CURVE SMOOTH",
+"480 471 OFFCURVE",
+"483 481 OFFCURVE",
+"493 494 CURVE",
+"510 521 OFFCURVE",
+"522 544 OFFCURVE",
+"534 566 CURVE",
+"539 578 OFFCURVE",
+"546 589 OFFCURVE",
+"549 592 CURVE SMOOTH",
+"551 594 OFFCURVE",
+"560 605 OFFCURVE",
+"564 614 CURVE",
+"575 626 OFFCURVE",
+"585 641 OFFCURVE",
+"585 650 CURVE",
+"590 658 OFFCURVE",
+"599 671 OFFCURVE",
+"602 678 CURVE",
+"607 684 OFFCURVE",
+"615 697 OFFCURVE",
+"618 703 CURVE",
+"634 725 OFFCURVE",
+"635 742 OFFCURVE",
+"623 750 CURVE",
+"615 753 OFFCURVE",
+"585 756 OFFCURVE",
+"570 753 CURVE",
+"565 753 OFFCURVE",
+"537 751 OFFCURVE",
+"510 751 CURVE SMOOTH",
+"456 751 OFFCURVE",
+"201 753 OFFCURVE",
+"143 753 CURVE",
+"122 755 OFFCURVE",
+"101 755 OFFCURVE",
+"97 753 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"195 23 LINE",
+"195 36 LINE",
+"616 714 LINE",
+"616 732 LINE",
+"424 726 LINE",
+"424 720 LINE",
+"10 39 LINE",
+"10 7 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"606 0 LINE",
+"606 245 LINE",
+"566 245 LINE",
+"564 133 OFFCURVE",
+"491 32 OFFCURVE",
+"368 32 CURVE SMOOTH",
+"10 32 LINE",
+"10 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"100 549 LINE",
+"102 643 OFFCURVE",
+"171 724 OFFCURVE",
+"288 724 CURVE SMOOTH",
+"616 724 LINE",
+"616 754 LINE",
+"60 754 LINE",
+"60 549 LINE"
+);
+}
+);
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 005A;
+},
+{
+glyphname = Zacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = Z;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 1, 304}";
+}
+);
+layerId = UUID0;
+width = 651;
+},
+{
+components = (
+{
+name = Z;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -79, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 0179;
+},
+{
+glyphname = Zcaron;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = Z;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 156, 1}";
+}
+);
+layerId = UUID0;
+width = 651;
+},
+{
+components = (
+{
+name = Z;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 97, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 017D;
+},
+{
+glyphname = Zdotaccent;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = Z;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 251, 5}";
+}
+);
+layerId = UUID0;
+width = 651;
+},
+{
+components = (
+{
+name = Z;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 232, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 017B;
+},
+{
+glyphname = Zdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = Z;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 42, 0}";
+}
+);
+layerId = UUID0;
+width = 651;
+},
+{
+components = (
+{
+name = Z;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 18, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 1E92;
+},
+{
+glyphname = a;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = ogonek;
+position = "{455, 10}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"292 146 LINE SMOOTH",
+"292 77 OFFCURVE",
+"252 43 OFFCURVE",
+"207 43 CURVE SMOOTH",
+"166 43 OFFCURVE",
+"141 69 OFFCURVE",
+"141 119 CURVE SMOOTH",
+"141 184 OFFCURVE",
+"183 227 OFFCURVE",
+"292 227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"266 421 OFFCURVE",
+"292 404 OFFCURVE",
+"292 372 CURVE SMOOTH",
+"292 253 LINE",
+"115 253 OFFCURVE",
+"25 188 OFFCURVE",
+"25 99 CURVE SMOOTH",
+"25 30 OFFCURVE",
+"78 -12 OFFCURVE",
+"147 -12 CURVE SMOOTH",
+"204 -12 OFFCURVE",
+"266 17 OFFCURVE",
+"292 62 CURVE",
+"296 62 LINE",
+"305 17 OFFCURVE",
+"336 -12 OFFCURVE",
+"383 -12 CURVE SMOOTH",
+"418 -12 OFFCURVE",
+"446 4 OFFCURVE",
+"473 39 CURVE",
+"459 55 LINE",
+"443 38 OFFCURVE",
+"434 32 OFFCURVE",
+"425 32 CURVE SMOOTH",
+"415 32 OFFCURVE",
+"402 38 OFFCURVE",
+"402 51 CURVE SMOOTH",
+"402 355 LINE SMOOTH",
+"402 412 OFFCURVE",
+"339 452 OFFCURVE",
+"240 452 CURVE SMOOTH",
+"125 452 OFFCURVE",
+"58 399 OFFCURVE",
+"58 345 CURVE SMOOTH",
+"58 317 OFFCURVE",
+"77 294 OFFCURVE",
+"110 294 CURVE SMOOTH",
+"140 294 OFFCURVE",
+"165 312 OFFCURVE",
+"165 342 CURVE SMOOTH",
+"165 364 OFFCURVE",
+"151 371 OFFCURVE",
+"151 385 CURVE SMOOTH",
+"151 404 OFFCURVE",
+"174 421 OFFCURVE",
+"220 421 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"222 -12 OFFCURVE",
+"283 19 OFFCURVE",
+"308 62 CURVE",
+"312 62 LINE",
+"322 15 OFFCURVE",
+"353 -12 OFFCURVE",
+"400 -12 CURVE SMOOTH",
+"441 -12 OFFCURVE",
+"473 9 OFFCURVE",
+"505 55 CURVE",
+"491 71 LINE",
+"467 44 OFFCURVE",
+"452 32 OFFCURVE",
+"440 32 CURVE SMOOTH",
+"428 32 OFFCURVE",
+"418 42 OFFCURVE",
+"418 55 CURVE SMOOTH",
+"418 359 LINE SMOOTH",
+"418 420 OFFCURVE",
+"350 462 OFFCURVE",
+"253 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"72 415 OFFCURVE",
+"72 355 CURVE SMOOTH",
+"72 325 OFFCURVE",
+"92 304 OFFCURVE",
+"124 304 CURVE SMOOTH",
+"156 304 OFFCURVE",
+"179 324 OFFCURVE",
+"179 352 CURVE SMOOTH",
+"179 374 OFFCURVE",
+"165 381 OFFCURVE",
+"165 395 CURVE SMOOTH",
+"165 416 OFFCURVE",
+"193 431 OFFCURVE",
+"233 431 CURVE SMOOTH",
+"280 431 OFFCURVE",
+"308 410 OFFCURVE",
+"308 375 CURVE SMOOTH",
+"308 253 LINE",
+"143 253 OFFCURVE",
+"41 195 OFFCURVE",
+"41 100 CURVE SMOOTH",
+"41 33 OFFCURVE",
+"91 -12 OFFCURVE",
+"163 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 43 OFFCURVE",
+"157 71 OFFCURVE",
+"157 119 CURVE SMOOTH",
+"157 190 OFFCURVE",
+"208 227 OFFCURVE",
+"308 227 CURVE",
+"308 146 LINE SMOOTH",
+"308 84 OFFCURVE",
+"274 43 OFFCURVE",
+"223 43 CURVE SMOOTH"
+);
+}
+);
+width = 506;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{271, 0}";
+},
+{
+name = ogonek;
+position = "{487, 10}";
+},
+{
+name = top;
+position = "{271, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"321 150 LINE SMOOTH",
+"321 80 OFFCURVE",
+"286 45 OFFCURVE",
+"245 45 CURVE SMOOTH",
+"208 45 OFFCURVE",
+"187 76 OFFCURVE",
+"187 124 CURVE SMOOTH",
+"187 184 OFFCURVE",
+"221 225 OFFCURVE",
+"321 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"296 429 OFFCURVE",
+"321 410 OFFCURVE",
+"321 378 CURVE SMOOTH",
+"321 256 LINE",
+"131 256 OFFCURVE",
+"42 190 OFFCURVE",
+"42 102 CURVE SMOOTH",
+"42 31 OFFCURVE",
+"96 -13 OFFCURVE",
+"171 -13 CURVE SMOOTH",
+"231 -13 OFFCURVE",
+"295 14 OFFCURVE",
+"321 56 CURVE",
+"325 56 LINE",
+"335 14 OFFCURVE",
+"371 -13 OFFCURVE",
+"425 -13 CURVE SMOOTH",
+"466 -13 OFFCURVE",
+"506 3 OFFCURVE",
+"536 44 CURVE",
+"516 64 LINE",
+"500 49 OFFCURVE",
+"491 46 OFFCURVE",
+"483 46 CURVE SMOOTH",
+"472 46 OFFCURVE",
+"459 52 OFFCURVE",
+"459 76 CURVE SMOOTH",
+"459 376 LINE SMOOTH",
+"459 427 OFFCURVE",
+"384 462 OFFCURVE",
+"276 462 CURVE SMOOTH",
+"139 462 OFFCURVE",
+"74 405 OFFCURVE",
+"74 343 CURVE SMOOTH",
+"74 306 OFFCURVE",
+"97 275 OFFCURVE",
+"139 275 CURVE SMOOTH",
+"179 275 OFFCURVE",
+"209 302 OFFCURVE",
+"209 340 CURVE SMOOTH",
+"209 370 OFFCURVE",
+"190 381 OFFCURVE",
+"190 396 CURVE SMOOTH",
+"190 416 OFFCURVE",
+"221 429 OFFCURVE",
+"254 429 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"245 -12 OFFCURVE",
+"297 22 OFFCURVE",
+"321 57 CURVE",
+"325 57 LINE",
+"335 15 OFFCURVE",
+"366 -12 OFFCURVE",
+"421 -12 CURVE SMOOTH",
+"470 -12 OFFCURVE",
+"508 9 OFFCURVE",
+"546 55 CURVE",
+"526 78 LINE",
+"503 52 OFFCURVE",
+"493 45 OFFCURVE",
+"482 45 CURVE SMOOTH",
+"468 45 OFFCURVE",
+"459 56 OFFCURVE",
+"459 68 CURVE SMOOTH",
+"459 359 LINE SMOOTH",
+"459 420 OFFCURVE",
+"382 462 OFFCURVE",
+"275 462 CURVE SMOOTH",
+"158 462 OFFCURVE",
+"73 411 OFFCURVE",
+"73 343 CURVE SMOOTH",
+"73 304 OFFCURVE",
+"101 274 OFFCURVE",
+"140 274 CURVE SMOOTH",
+"179 274 OFFCURVE",
+"210 305 OFFCURVE",
+"210 340 CURVE SMOOTH",
+"210 368 OFFCURVE",
+"189 375 OFFCURVE",
+"189 393 CURVE SMOOTH",
+"189 414 OFFCURVE",
+"217 429 OFFCURVE",
+"252 429 CURVE SMOOTH",
+"293 429 OFFCURVE",
+"321 408 OFFCURVE",
+"321 373 CURVE SMOOTH",
+"321 256 LINE",
+"152 256 OFFCURVE",
+"42 197 OFFCURVE",
+"42 101 CURVE SMOOTH",
+"42 33 OFFCURVE",
+"98 -12 OFFCURVE",
+"177 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 43 OFFCURVE",
+"187 72 OFFCURVE",
+"187 118 CURVE SMOOTH",
+"187 189 OFFCURVE",
+"235 225 OFFCURVE",
+"321 225 CURVE",
+"321 146 LINE SMOOTH",
+"321 84 OFFCURVE",
+"287 43 OFFCURVE",
+"244 43 CURVE SMOOTH"
+);
+}
+);
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0061;
+},
+{
+glyphname = aacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -72, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -119, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E1;
+},
+{
+glyphname = abreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0103;
+},
+{
+glyphname = abreveacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAF;
+},
+{
+glyphname = abrevedotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB7;
+},
+{
+glyphname = abrevegrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB1;
+},
+{
+glyphname = abrevehookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB3;
+},
+{
+glyphname = abrevetilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB5;
+},
+{
+glyphname = acircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E2;
+},
+{
+glyphname = acircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA5;
+},
+{
+glyphname = acircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAD;
+},
+{
+glyphname = acircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA7;
+},
+{
+glyphname = acircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA9;
+},
+{
+glyphname = acircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAB;
+},
+{
+glyphname = adblgrave;
+lastChange = "2022-03-23 16:30:18 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dblgravecomb;
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, -23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0201;
+},
+{
+glyphname = adieresis;
+lastChange = "2022-03-23 16:28:08 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dieresiscomb;
+transform = "{1, 0, 0, 1, 99, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dieresiscomb;
+transform = "{1, 0, 0, 1, 109, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E4;
+},
+{
+glyphname = adotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA1;
+},
+{
+glyphname = agrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -34, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 22, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E0;
+},
+{
+glyphname = ahookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -32, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -13, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA3;
+},
+{
+glyphname = ainvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 86, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 94, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0203;
+},
+{
+glyphname = amacron;
+lastChange = "2016-08-22 12:20:05 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 87, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 97, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0101;
+},
+{
+glyphname = aogonek;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = a;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 245, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+alignment = -1;
+name = a;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 283, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0105;
+},
+{
+glyphname = aring;
+lastChange = "2022-03-23 16:29:00 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = ringcomb;
+transform = "{1, 0, 0, 1, 141, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = ringcomb;
+transform = "{1, 0, 0, 1, 159, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E5;
+},
+{
+glyphname = aringacute;
+lastChange = "2022-03-23 16:29:33 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = ringcomb;
+transform = "{1, 0, 0, 1, 141, 0}";
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -72, 273}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = ringcomb;
+transform = "{1, 0, 0, 1, 159, 0}";
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -119, 273}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 01FB;
+},
+{
+glyphname = atilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -38, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E3;
+},
+{
+glyphname = ae;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"307 145 LINE SMOOTH",
+"307 76 OFFCURVE",
+"267 42 OFFCURVE",
+"222 42 CURVE SMOOTH",
+"181 42 OFFCURVE",
+"156 69 OFFCURVE",
+"156 119 CURVE SMOOTH",
+"156 184 OFFCURVE",
+"198 227 OFFCURVE",
+"307 227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 421 OFFCURVE",
+"307 404 OFFCURVE",
+"307 372 CURVE SMOOTH",
+"307 253 LINE",
+"129 253 OFFCURVE",
+"40 187 OFFCURVE",
+"40 97 CURVE SMOOTH",
+"40 34 OFFCURVE",
+"84 -13 OFFCURVE",
+"167 -13 CURVE SMOOTH",
+"226 -13 OFFCURVE",
+"298 11 OFFCURVE",
+"340 101 CURVE",
+"344 101 LINE",
+"417 50 LINE",
+"417 355 LINE SMOOTH",
+"417 412 OFFCURVE",
+"354 451 OFFCURVE",
+"255 451 CURVE SMOOTH",
+"140 451 OFFCURVE",
+"73 399 OFFCURVE",
+"73 345 CURVE SMOOTH",
+"73 317 OFFCURVE",
+"92 294 OFFCURVE",
+"125 294 CURVE SMOOTH",
+"155 294 OFFCURVE",
+"180 312 OFFCURVE",
+"180 342 CURVE SMOOTH",
+"180 364 OFFCURVE",
+"166 371 OFFCURVE",
+"166 385 CURVE SMOOTH",
+"166 404 OFFCURVE",
+"189 421 OFFCURVE",
+"235 421 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"590 289 LINE",
+"379 289 LINE",
+"379 264 LINE",
+"706 264 LINE",
+"706 270 LINE SMOOTH",
+"706 384 OFFCURVE",
+"621 454 OFFCURVE",
+"520 454 CURVE SMOOTH",
+"390 454 OFFCURVE",
+"312 339 OFFCURVE",
+"312 224 CURVE SMOOTH",
+"312 101 OFFCURVE",
+"403 -13 OFFCURVE",
+"523 -13 CURVE SMOOTH",
+"605 -13 OFFCURVE",
+"681 40 OFFCURVE",
+"709 138 CURVE",
+"681 138 LINE",
+"645 49 OFFCURVE",
+"593 17 OFFCURVE",
+"523 17 CURVE SMOOTH",
+"444 17 OFFCURVE",
+"417 58 OFFCURVE",
+"417 220 CURVE SMOOTH",
+"417 378 OFFCURVE",
+"443 427 OFFCURVE",
+"510 427 CURVE SMOOTH",
+"563 427 OFFCURVE",
+"590 396 OFFCURVE",
+"590 336 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"613 -12 OFFCURVE",
+"687 46 OFFCURVE",
+"713 139 CURVE",
+"685 139 LINE",
+"650 52 OFFCURVE",
+"598 18 OFFCURVE",
+"528 18 CURVE SMOOTH",
+"448 18 OFFCURVE",
+"421 62 OFFCURVE",
+"421 225 CURVE SMOOTH",
+"421 384 OFFCURVE",
+"447 435 OFFCURVE",
+"514 435 CURVE SMOOTH",
+"567 435 OFFCURVE",
+"594 404 OFFCURVE",
+"594 344 CURVE SMOOTH",
+"594 287 LINE",
+"383 287 LINE",
+"383 262 LINE",
+"710 262 LINE",
+"710 268 LINE SMOOTH",
+"710 382 OFFCURVE",
+"626 462 OFFCURVE",
+"521 462 CURVE SMOOTH",
+"396 462 OFFCURVE",
+"314 347 OFFCURVE",
+"314 228 CURVE SMOOTH",
+"314 102 OFFCURVE",
+"407 -12 OFFCURVE",
+"527 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 43 OFFCURVE",
+"160 71 OFFCURVE",
+"160 119 CURVE SMOOTH",
+"160 190 OFFCURVE",
+"211 227 OFFCURVE",
+"311 227 CURVE",
+"311 146 LINE SMOOTH",
+"311 84 OFFCURVE",
+"277 43 OFFCURVE",
+"226 43 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 -12 OFFCURVE",
+"308 35 OFFCURVE",
+"339 109 CURVE",
+"343 109 LINE",
+"421 55 LINE",
+"421 359 LINE SMOOTH",
+"421 420 OFFCURVE",
+"353 462 OFFCURVE",
+"256 462 CURVE SMOOTH",
+"154 462 OFFCURVE",
+"75 415 OFFCURVE",
+"75 355 CURVE SMOOTH",
+"75 325 OFFCURVE",
+"95 304 OFFCURVE",
+"127 304 CURVE SMOOTH",
+"159 304 OFFCURVE",
+"182 324 OFFCURVE",
+"182 352 CURVE SMOOTH",
+"182 374 OFFCURVE",
+"168 381 OFFCURVE",
+"168 395 CURVE SMOOTH",
+"168 416 OFFCURVE",
+"196 431 OFFCURVE",
+"236 431 CURVE SMOOTH",
+"283 431 OFFCURVE",
+"311 410 OFFCURVE",
+"311 375 CURVE SMOOTH",
+"311 253 LINE",
+"146 253 OFFCURVE",
+"44 195 OFFCURVE",
+"44 99 CURVE SMOOTH",
+"44 33 OFFCURVE",
+"93 -12 OFFCURVE",
+"168 -12 CURVE SMOOTH"
+);
+}
+);
+width = 755;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"321 150 LINE SMOOTH",
+"321 80 OFFCURVE",
+"286 45 OFFCURVE",
+"245 45 CURVE SMOOTH",
+"208 45 OFFCURVE",
+"187 74 OFFCURVE",
+"187 119 CURVE SMOOTH",
+"187 179 OFFCURVE",
+"221 220 OFFCURVE",
+"321 220 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"296 418 OFFCURVE",
+"321 399 OFFCURVE",
+"321 367 CURVE SMOOTH",
+"321 251 LINE",
+"131 251 OFFCURVE",
+"42 185 OFFCURVE",
+"42 97 CURVE SMOOTH",
+"42 29 OFFCURVE",
+"96 -13 OFFCURVE",
+"171 -13 CURVE SMOOTH",
+"231 -13 OFFCURVE",
+"295 14 OFFCURVE",
+"321 56 CURVE",
+"325 56 LINE",
+"459 76 LINE",
+"459 365 LINE SMOOTH",
+"459 416 OFFCURVE",
+"384 451 OFFCURVE",
+"276 451 CURVE SMOOTH",
+"139 451 OFFCURVE",
+"74 394 OFFCURVE",
+"74 332 CURVE SMOOTH",
+"74 295 OFFCURVE",
+"97 264 OFFCURVE",
+"139 264 CURVE SMOOTH",
+"179 264 OFFCURVE",
+"209 291 OFFCURVE",
+"209 329 CURVE SMOOTH",
+"209 360 OFFCURVE",
+"190 370 OFFCURVE",
+"190 385 CURVE SMOOTH",
+"190 405 OFFCURVE",
+"221 418 OFFCURVE",
+"254 418 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"637 279 LINE",
+"431 279 LINE",
+"431 249 LINE",
+"778 249 LINE",
+"778 260 LINE SMOOTH",
+"778 380 OFFCURVE",
+"687 454 OFFCURVE",
+"568 454 CURVE SMOOTH",
+"419 454 OFFCURVE",
+"324 338 OFFCURVE",
+"324 224 CURVE SMOOTH",
+"324 101 OFFCURVE",
+"434 -13 OFFCURVE",
+"574 -13 CURVE SMOOTH",
+"674 -13 OFFCURVE",
+"753 46 OFFCURVE",
+"781 138 CURVE",
+"748 138 LINE",
+"709 53 OFFCURVE",
+"649 22 OFFCURVE",
+"579 22 CURVE SMOOTH",
+"503 22 OFFCURVE",
+"479 59 OFFCURVE",
+"479 218 CURVE SMOOTH",
+"479 373 OFFCURVE",
+"502 422 OFFCURVE",
+"566 422 CURVE SMOOTH",
+"613 422 OFFCURVE",
+"637 393 OFFCURVE",
+"637 336 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"653 -13 OFFCURVE",
+"735 49 OFFCURVE",
+"761 138 CURVE",
+"728 138 LINE",
+"689 53 OFFCURVE",
+"629 22 OFFCURVE",
+"559 22 CURVE SMOOTH",
+"483 22 OFFCURVE",
+"459 60 OFFCURVE",
+"459 222 CURVE SMOOTH",
+"459 380 OFFCURVE",
+"482 430 OFFCURVE",
+"545 430 CURVE SMOOTH",
+"593 430 OFFCURVE",
+"617 401 OFFCURVE",
+"617 344 CURVE SMOOTH",
+"617 283 LINE",
+"411 283 LINE",
+"411 253 LINE",
+"758 253 LINE",
+"758 264 LINE SMOOTH",
+"758 386 OFFCURVE",
+"664 462 OFFCURVE",
+"553 462 CURVE SMOOTH",
+"414 462 OFFCURVE",
+"334 343 OFFCURVE",
+"334 228 CURVE SMOOTH",
+"334 103 OFFCURVE",
+"429 -13 OFFCURVE",
+"558 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 43 OFFCURVE",
+"187 72 OFFCURVE",
+"187 118 CURVE SMOOTH",
+"187 189 OFFCURVE",
+"235 225 OFFCURVE",
+"321 225 CURVE",
+"321 146 LINE SMOOTH",
+"321 84 OFFCURVE",
+"287 43 OFFCURVE",
+"244 43 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"261 -12 OFFCURVE",
+"332 30 OFFCURVE",
+"357 115 CURVE",
+"361 115 LINE",
+"459 68 LINE",
+"459 359 LINE SMOOTH",
+"459 420 OFFCURVE",
+"382 462 OFFCURVE",
+"275 462 CURVE SMOOTH",
+"158 462 OFFCURVE",
+"73 411 OFFCURVE",
+"73 343 CURVE SMOOTH",
+"73 304 OFFCURVE",
+"101 274 OFFCURVE",
+"140 274 CURVE SMOOTH",
+"179 274 OFFCURVE",
+"210 305 OFFCURVE",
+"210 340 CURVE SMOOTH",
+"210 368 OFFCURVE",
+"189 375 OFFCURVE",
+"189 393 CURVE SMOOTH",
+"189 414 OFFCURVE",
+"217 429 OFFCURVE",
+"252 429 CURVE SMOOTH",
+"293 429 OFFCURVE",
+"321 408 OFFCURVE",
+"321 373 CURVE SMOOTH",
+"321 256 LINE",
+"152 256 OFFCURVE",
+"42 197 OFFCURVE",
+"42 101 CURVE SMOOTH",
+"42 33 OFFCURVE",
+"97 -12 OFFCURVE",
+"180 -12 CURVE SMOOTH"
+);
+}
+);
+width = 796;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = e;
+unicode = 00E6;
+},
+{
+glyphname = aeacute;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+name = ae;
+},
+{
+name = acutecomb;
+}
+);
+layerId = UUID0;
+width = 755;
+},
+{
+components = (
+{
+alignment = -1;
+name = ae;
+},
+{
+alignment = -1;
+name = acutecomb;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 816;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = e;
+unicode = 01FD;
+},
+{
+glyphname = b;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{285, 0}";
+},
+{
+name = top;
+position = "{285, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"3 729 LINE",
+"192 729 LINE",
+"192 754 LINE",
+"3 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"82 15 LINE",
+"192 15 LINE",
+"192 738 LINE",
+"82 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"3 0 LINE",
+"192 0 LINE",
+"192 25 LINE",
+"3 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 22 OFFCURVE",
+"192 88 OFFCURVE",
+"192 213 CURVE",
+"172 57 LINE",
+"196 57 LINE",
+"219 18 OFFCURVE",
+"267 -13 OFFCURVE",
+"322 -13 CURVE SMOOTH",
+"422 -13 OFFCURVE",
+"523 83 OFFCURVE",
+"523 220 CURVE SMOOTH",
+"523 352 OFFCURVE",
+"429 454 OFFCURVE",
+"324 454 CURVE SMOOTH",
+"261 454 OFFCURVE",
+"218 420 OFFCURVE",
+"196 381 CURVE",
+"172 381 LINE",
+"192 234 LINE",
+"192 366 OFFCURVE",
+"247 419 OFFCURVE",
+"317 419 CURVE SMOOTH",
+"374 419 OFFCURVE",
+"395 384 OFFCURVE",
+"395 219 CURVE SMOOTH",
+"395 62 OFFCURVE",
+"376 22 OFFCURVE",
+"319 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"430 -12 OFFCURVE",
+"524 83 OFFCURVE",
+"524 225 CURVE SMOOTH",
+"524 367 OFFCURVE",
+"431 462 OFFCURVE",
+"331 462 CURVE SMOOTH",
+"269 462 OFFCURVE",
+"219 432 OFFCURVE",
+"197 392 CURVE",
+"173 392 LINE",
+"193 240 LINE",
+"193 370 OFFCURVE",
+"246 428 OFFCURVE",
+"318 428 CURVE SMOOTH",
+"374 428 OFFCURVE",
+"396 389 OFFCURVE",
+"396 224 CURVE SMOOTH",
+"396 59 OFFCURVE",
+"375 22 OFFCURVE",
+"319 22 CURVE SMOOTH",
+"247 22 OFFCURVE",
+"193 80 OFFCURVE",
+"193 210 CURVE",
+"173 58 LINE",
+"197 58 LINE",
+"219 18 OFFCURVE",
+"268 -12 OFFCURVE",
+"330 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 0 LINE",
+"193 25 LINE",
+"4 25 LINE",
+"4 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 15 LINE",
+"193 738 LINE",
+"83 738 LINE",
+"83 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 729 LINE",
+"193 754 LINE",
+"4 754 LINE",
+"4 729 LINE"
+);
+}
+);
+width = 570;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{315, 0}";
+},
+{
+name = top;
+position = "{315, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"239 0 LINE",
+"239 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 414 OFFCURVE",
+"430 372 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"429 63 OFFCURVE",
+"407 27 OFFCURVE",
+"355 27 CURVE SMOOTH",
+"286 27 OFFCURVE",
+"238 92 OFFCURVE",
+"238 217 CURVE",
+"218 55 LINE",
+"242 55 LINE",
+"262 17 OFFCURVE",
+"299 -13 OFFCURVE",
+"363 -13 CURVE SMOOTH",
+"478 -13 OFFCURVE",
+"584 84 OFFCURVE",
+"585 224 CURVE SMOOTH",
+"585 362 OFFCURVE",
+"485 454 OFFCURVE",
+"377 454 CURVE SMOOTH",
+"313 454 OFFCURVE",
+"268 422 OFFCURVE",
+"243 379 CURVE",
+"219 379 LINE",
+"238 218 LINE",
+"239 346 OFFCURVE",
+"288 414 OFFCURVE",
+"358 414 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"486 -12 OFFCURVE",
+"585 83 OFFCURVE",
+"585 225 CURVE SMOOTH",
+"585 367 OFFCURVE",
+"487 462 OFFCURVE",
+"377 462 CURVE SMOOTH",
+"315 462 OFFCURVE",
+"265 432 OFFCURVE",
+"243 392 CURVE",
+"219 392 LINE",
+"239 240 LINE",
+"239 364 OFFCURVE",
+"287 423 OFFCURVE",
+"353 423 CURVE SMOOTH",
+"405 423 OFFCURVE",
+"430 386 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"430 63 OFFCURVE",
+"406 27 OFFCURVE",
+"354 27 CURVE SMOOTH",
+"288 27 OFFCURVE",
+"239 85 OFFCURVE",
+"239 210 CURVE",
+"219 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 0 LINE",
+"239 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 0062;
+},
+{
+glyphname = c;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"377 -12 OFFCURVE",
+"441 53 OFFCURVE",
+"467 149 CURVE",
+"439 149 LINE",
+"403 54 OFFCURVE",
+"357 18 OFFCURVE",
+"284 18 CURVE SMOOTH",
+"207 18 OFFCURVE",
+"179 62 OFFCURVE",
+"179 224 CURVE SMOOTH",
+"179 395 OFFCURVE",
+"210 435 OFFCURVE",
+"288 435 CURVE SMOOTH",
+"329 435 OFFCURVE",
+"351 425 OFFCURVE",
+"351 403 CURVE SMOOTH",
+"351 379 OFFCURVE",
+"327 375 OFFCURVE",
+"327 341 CURVE SMOOTH",
+"327 304 OFFCURVE",
+"357 285 OFFCURVE",
+"389 285 CURVE SMOOTH",
+"424 285 OFFCURVE",
+"449 309 OFFCURVE",
+"449 348 CURVE SMOOTH",
+"449 415 OFFCURVE",
+"377 462 OFFCURVE",
+"289 462 CURVE SMOOTH",
+"150 462 OFFCURVE",
+"49 343 OFFCURVE",
+"49 226 CURVE SMOOTH",
+"49 107 OFFCURVE",
+"154 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+}
+);
+width = 505;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{260, 0}";
+},
+{
+name = top;
+position = "{260, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"332 422 OFFCURVE",
+"347 414 OFFCURVE",
+"347 398 CURVE SMOOTH",
+"347 377 OFFCURVE",
+"318 364 OFFCURVE",
+"318 323 CURVE SMOOTH",
+"318 282 OFFCURVE",
+"347 257 OFFCURVE",
+"390 257 CURVE SMOOTH",
+"435 257 OFFCURVE",
+"469 285 OFFCURVE",
+"469 331 CURVE SMOOTH",
+"469 403 OFFCURVE",
+"388 454 OFFCURVE",
+"293 454 CURVE SMOOTH",
+"149 454 OFFCURVE",
+"45 338 OFFCURVE",
+"45 222 CURVE SMOOTH",
+"45 102 OFFCURVE",
+"155 -13 OFFCURVE",
+"292 -13 CURVE SMOOTH",
+"395 -13 OFFCURVE",
+"463 52 OFFCURVE",
+"490 148 CURVE",
+"457 148 LINE",
+"420 57 OFFCURVE",
+"372 22 OFFCURVE",
+"300 22 CURVE SMOOTH",
+"224 22 OFFCURVE",
+"200 61 OFFCURVE",
+"200 215 CURVE SMOOTH",
+"200 388 OFFCURVE",
+"230 422 OFFCURVE",
+"299 422 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"395 -13 OFFCURVE",
+"463 52 OFFCURVE",
+"490 148 CURVE",
+"457 148 LINE",
+"421 58 OFFCURVE",
+"373 21 OFFCURVE",
+"301 21 CURVE SMOOTH",
+"226 21 OFFCURVE",
+"200 61 OFFCURVE",
+"200 210 CURVE SMOOTH",
+"200 393 OFFCURVE",
+"239 430 OFFCURVE",
+"297 430 CURVE SMOOTH",
+"328 430 OFFCURVE",
+"347 419 OFFCURVE",
+"347 399 CURVE SMOOTH",
+"347 374 OFFCURVE",
+"318 370 OFFCURVE",
+"318 331 CURVE SMOOTH",
+"318 291 OFFCURVE",
+"347 265 OFFCURVE",
+"390 265 CURVE SMOOTH",
+"435 265 OFFCURVE",
+"469 292 OFFCURVE",
+"469 339 CURVE SMOOTH",
+"469 411 OFFCURVE",
+"388 462 OFFCURVE",
+"293 462 CURVE SMOOTH",
+"149 462 OFFCURVE",
+"45 344 OFFCURVE",
+"45 226 CURVE SMOOTH",
+"45 104 OFFCURVE",
+"155 -13 OFFCURVE",
+"292 -13 CURVE SMOOTH"
+);
+}
+);
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 0063;
+},
+{
+glyphname = cacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -72, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -130, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 0107;
+},
+{
+glyphname = ccaron;
+lastChange = "2016-08-22 12:22:57 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 88, -9}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 70, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 010D;
+},
+{
+glyphname = ccedilla;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 148, 6}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 143, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 00E7;
+},
+{
+glyphname = ccircumflex;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -36, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 0109;
+},
+{
+glyphname = cdotaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 179, -3}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 172, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 010B;
+},
+{
+glyphname = d;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{284, 0}";
+},
+{
+name = center;
+position = "{284, 225}";
+},
+{
+name = top;
+position = "{284, 450}";
+},
+{
+name = topright;
+position = "{548, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"304 -12 OFFCURVE",
+"353 18 OFFCURVE",
+"375 58 CURVE",
+"399 58 LINE",
+"379 210 LINE",
+"379 80 OFFCURVE",
+"325 22 OFFCURVE",
+"253 22 CURVE SMOOTH",
+"197 22 OFFCURVE",
+"176 59 OFFCURVE",
+"176 224 CURVE SMOOTH",
+"176 389 OFFCURVE",
+"198 428 OFFCURVE",
+"254 428 CURVE SMOOTH",
+"326 428 OFFCURVE",
+"379 370 OFFCURVE",
+"379 240 CURVE",
+"399 392 LINE",
+"375 392 LINE",
+"353 432 OFFCURVE",
+"303 462 OFFCURVE",
+"241 462 CURVE SMOOTH",
+"141 462 OFFCURVE",
+"48 367 OFFCURVE",
+"48 225 CURVE SMOOTH",
+"48 83 OFFCURVE",
+"142 -12 OFFCURVE",
+"242 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"379 25 LINE",
+"379 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 15 LINE",
+"489 738 LINE",
+"379 738 LINE",
+"379 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 729 LINE",
+"489 754 LINE",
+"280 754 LINE",
+"280 729 LINE"
+);
+}
+);
+width = 568;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{316, 0}";
+},
+{
+name = center;
+position = "{316, 225}";
+},
+{
+name = top;
+position = "{316, 450}";
+},
+{
+name = topright;
+position = "{611, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"530 754 LINE",
+"301 754 LINE",
+"301 724 LINE",
+"530 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 738 LINE",
+"392 738 LINE",
+"392 15 LINE",
+"530 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 30 LINE",
+"392 30 LINE",
+"392 0 LINE",
+"611 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 27 OFFCURVE",
+"200 69 OFFCURVE",
+"200 213 CURVE SMOOTH",
+"200 379 OFFCURVE",
+"224 414 OFFCURVE",
+"275 414 CURVE SMOOTH",
+"344 414 OFFCURVE",
+"392 349 OFFCURVE",
+"392 224 CURVE",
+"412 386 LINE",
+"388 386 LINE",
+"368 420 OFFCURVE",
+"321 454 OFFCURVE",
+"258 454 CURVE SMOOTH",
+"150 454 OFFCURVE",
+"45 354 OFFCURVE",
+"45 216 CURVE SMOOTH",
+"45 79 OFFCURVE",
+"145 -13 OFFCURVE",
+"253 -13 CURVE SMOOTH",
+"317 -13 OFFCURVE",
+"362 19 OFFCURVE",
+"387 62 CURVE",
+"411 62 LINE",
+"392 223 LINE",
+"391 95 OFFCURVE",
+"342 27 OFFCURVE",
+"272 27 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"317 -12 OFFCURVE",
+"366 18 OFFCURVE",
+"388 58 CURVE",
+"412 58 LINE",
+"392 210 LINE",
+"392 83 OFFCURVE",
+"342 27 OFFCURVE",
+"276 27 CURVE SMOOTH",
+"221 27 OFFCURVE",
+"200 63 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 385 OFFCURVE",
+"222 423 OFFCURVE",
+"277 423 CURVE SMOOTH",
+"343 423 OFFCURVE",
+"392 367 OFFCURVE",
+"392 240 CURVE",
+"412 392 LINE",
+"388 392 LINE",
+"366 432 OFFCURVE",
+"316 462 OFFCURVE",
+"254 462 CURVE SMOOTH",
+"148 462 OFFCURVE",
+"45 367 OFFCURVE",
+"45 225 CURVE SMOOTH",
+"45 83 OFFCURVE",
+"149 -12 OFFCURVE",
+"255 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 0 LINE",
+"611 30 LINE",
+"392 30 LINE",
+"392 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 15 LINE",
+"530 738 LINE",
+"392 738 LINE",
+"392 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 724 LINE",
+"530 754 LINE",
+"293 754 LINE",
+"293 724 LINE"
+);
+}
+);
+width = 631;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = d;
+unicode = 0064;
+},
+{
+glyphname = eth;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"431 -13 OFFCURVE",
+"544 103 OFFCURVE",
+"544 297 CURVE SMOOTH",
+"544 544 OFFCURVE",
+"361 716 OFFCURVE",
+"169 752 CURVE",
+"160 725 LINE",
+"330 683 OFFCURVE",
+"392 576 OFFCURVE",
+"392 416 CURVE",
+"389 415 LINE",
+"357 435 OFFCURVE",
+"319 444 OFFCURVE",
+"277 444 CURVE SMOOTH",
+"139 444 OFFCURVE",
+"27 345 OFFCURVE",
+"27 219 CURVE SMOOTH",
+"27 84 OFFCURVE",
+"155 -13 OFFCURVE",
+"287 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 17 OFFCURVE",
+"172 54 OFFCURVE",
+"172 212 CURVE SMOOTH",
+"172 375 OFFCURVE",
+"203 414 OFFCURVE",
+"275 414 CURVE SMOOTH",
+"323 414 OFFCURVE",
+"366 397 OFFCURVE",
+"396 358 CURVE",
+"404 307 OFFCURVE",
+"406 245 OFFCURVE",
+"406 201 CURVE SMOOTH",
+"406 51 OFFCURVE",
+"375 17 OFFCURVE",
+"290 17 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 557 LINE",
+"519 662 LINE",
+"508 695 LINE",
+"204 590 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"431 -13 OFFCURVE",
+"544 103 OFFCURVE",
+"544 297 CURVE SMOOTH",
+"544 544 OFFCURVE",
+"361 716 OFFCURVE",
+"169 752 CURVE",
+"160 725 LINE",
+"330 683 OFFCURVE",
+"392 576 OFFCURVE",
+"392 416 CURVE",
+"389 415 LINE",
+"357 435 OFFCURVE",
+"319 444 OFFCURVE",
+"277 444 CURVE SMOOTH",
+"139 444 OFFCURVE",
+"27 345 OFFCURVE",
+"27 219 CURVE SMOOTH",
+"27 84 OFFCURVE",
+"155 -13 OFFCURVE",
+"287 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 17 OFFCURVE",
+"172 54 OFFCURVE",
+"172 212 CURVE SMOOTH",
+"172 375 OFFCURVE",
+"203 414 OFFCURVE",
+"275 414 CURVE SMOOTH",
+"323 414 OFFCURVE",
+"366 397 OFFCURVE",
+"396 358 CURVE",
+"404 307 OFFCURVE",
+"406 245 OFFCURVE",
+"406 201 CURVE SMOOTH",
+"406 51 OFFCURVE",
+"375 17 OFFCURVE",
+"290 17 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"519 662 LINE",
+"508 695 LINE",
+"204 590 LINE",
+"216 557 LINE"
+);
+}
+);
+width = 579;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"493 -11 OFFCURVE",
+"622 107 OFFCURVE",
+"622 301 CURVE SMOOTH",
+"622 531 OFFCURVE",
+"439 726 OFFCURVE",
+"235 734 CURVE",
+"225 705 LINE",
+"341 687 OFFCURVE",
+"425 578 OFFCURVE",
+"435 413 CURVE",
+"432 412 LINE",
+"400 434 OFFCURVE",
+"366 446 OFFCURVE",
+"314 446 CURVE SMOOTH",
+"184 446 OFFCURVE",
+"65 357 OFFCURVE",
+"65 235 CURVE SMOOTH",
+"65 96 OFFCURVE",
+"192 -11 OFFCURVE",
+"339 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 24 OFFCURVE",
+"240 75 OFFCURVE",
+"240 217 CURVE SMOOTH",
+"240 374 OFFCURVE",
+"282 406 OFFCURVE",
+"338 406 CURVE SMOOTH",
+"390 406 OFFCURVE",
+"424 379 OFFCURVE",
+"444 345 CURVE",
+"454 305 OFFCURVE",
+"454 257 OFFCURVE",
+"454 223 CURVE SMOOTH",
+"454 74 OFFCURVE",
+"425 24 OFFCURVE",
+"347 24 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"266 527 LINE",
+"609 672 LINE",
+"588 715 LINE",
+"244 570 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"493 -11 OFFCURVE",
+"622 107 OFFCURVE",
+"622 301 CURVE SMOOTH",
+"622 531 OFFCURVE",
+"439 726 OFFCURVE",
+"235 734 CURVE",
+"225 705 LINE",
+"341 687 OFFCURVE",
+"425 578 OFFCURVE",
+"435 413 CURVE",
+"432 412 LINE",
+"400 434 OFFCURVE",
+"366 446 OFFCURVE",
+"314 446 CURVE SMOOTH",
+"184 446 OFFCURVE",
+"65 357 OFFCURVE",
+"65 235 CURVE SMOOTH",
+"65 96 OFFCURVE",
+"192 -11 OFFCURVE",
+"339 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 24 OFFCURVE",
+"240 75 OFFCURVE",
+"240 217 CURVE SMOOTH",
+"240 374 OFFCURVE",
+"282 406 OFFCURVE",
+"338 406 CURVE SMOOTH",
+"390 406 OFFCURVE",
+"424 379 OFFCURVE",
+"444 345 CURVE",
+"454 305 OFFCURVE",
+"454 257 OFFCURVE",
+"454 223 CURVE SMOOTH",
+"454 74 OFFCURVE",
+"425 24 OFFCURVE",
+"347 24 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 672 LINE",
+"588 715 LINE",
+"244 570 LINE",
+"266 527 LINE"
+);
+}
+);
+width = 692;
+}
+);
+unicode = 00F0;
+},
+{
+glyphname = dcaron;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = d;
+},
+{
+alignment = -1;
+name = caron.alt;
+}
+);
+layerId = UUID0;
+width = 639;
+},
+{
+components = (
+{
+alignment = -1;
+name = d;
+},
+{
+alignment = -1;
+name = caron.alt;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 728;
+}
+);
+leftKerningGroup = d;
+unicode = 010F;
+},
+{
+glyphname = dcroat;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"558 576 LINE",
+"558 611 LINE",
+"263 611 LINE",
+"263 576 LINE"
+);
+}
+);
+width = 568;
+},
+{
+components = (
+{
+name = d;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"611 567 LINE",
+"611 611 LINE",
+"253 611 LINE",
+"253 567 LINE"
+);
+}
+);
+width = 631;
+}
+);
+leftKerningGroup = d;
+unicode = 0111;
+},
+{
+glyphname = ddotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+},
+{
+name = dotbelowcomb;
+}
+);
+layerId = UUID0;
+width = 568;
+},
+{
+components = (
+{
+name = d;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 631;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = d;
+unicode = 1E0D;
+},
+{
+glyphname = dz;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 568, 0}";
+}
+);
+layerId = UUID0;
+width = 1048;
+},
+{
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 631, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1107;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = z;
+unicode = 01F3;
+},
+{
+glyphname = dzcaron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = dz;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 643, -9}";
+}
+);
+layerId = UUID0;
+width = 1048;
+},
+{
+components = (
+{
+name = dz;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 679, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1107;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = z;
+unicode = 01C6;
+},
+{
+glyphname = e;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = ogonek;
+position = "{454, 10}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"365 -12 OFFCURVE",
+"436 45 OFFCURVE",
+"463 139 CURVE",
+"435 139 LINE",
+"399 50 OFFCURVE",
+"347 18 OFFCURVE",
+"277 18 CURVE SMOOTH",
+"198 18 OFFCURVE",
+"171 63 OFFCURVE",
+"171 225 CURVE SMOOTH",
+"171 383 OFFCURVE",
+"197 435 OFFCURVE",
+"264 435 CURVE SMOOTH",
+"317 435 OFFCURVE",
+"344 404 OFFCURVE",
+"344 344 CURVE SMOOTH",
+"344 287 LINE",
+"133 287 LINE",
+"133 262 LINE",
+"460 262 LINE",
+"460 268 LINE SMOOTH",
+"460 382 OFFCURVE",
+"377 462 OFFCURVE",
+"269 462 CURVE SMOOTH",
+"131 462 OFFCURVE",
+"41 347 OFFCURVE",
+"41 225 CURVE SMOOTH",
+"41 103 OFFCURVE",
+"145 -12 OFFCURVE",
+"274 -12 CURVE SMOOTH"
+);
+}
+);
+width = 505;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{269, 0}";
+},
+{
+name = ogonek;
+position = "{483, 10}";
+},
+{
+name = top;
+position = "{269, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"358 279 LINE",
+"152 279 LINE",
+"152 249 LINE",
+"499 249 LINE",
+"499 260 LINE SMOOTH",
+"499 380 OFFCURVE",
+"408 454 OFFCURVE",
+"289 454 CURVE SMOOTH",
+"140 454 OFFCURVE",
+"45 338 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 101 OFFCURVE",
+"155 -13 OFFCURVE",
+"295 -13 CURVE SMOOTH",
+"395 -13 OFFCURVE",
+"474 46 OFFCURVE",
+"502 138 CURVE",
+"469 138 LINE",
+"430 53 OFFCURVE",
+"370 22 OFFCURVE",
+"300 22 CURVE SMOOTH",
+"224 22 OFFCURVE",
+"200 59 OFFCURVE",
+"200 218 CURVE SMOOTH",
+"200 373 OFFCURVE",
+"223 422 OFFCURVE",
+"287 422 CURVE SMOOTH",
+"334 422 OFFCURVE",
+"358 393 OFFCURVE",
+"358 336 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"395 -13 OFFCURVE",
+"474 46 OFFCURVE",
+"502 138 CURVE",
+"469 138 LINE",
+"430 53 OFFCURVE",
+"370 22 OFFCURVE",
+"300 22 CURVE SMOOTH",
+"224 22 OFFCURVE",
+"200 60 OFFCURVE",
+"200 222 CURVE SMOOTH",
+"200 380 OFFCURVE",
+"223 430 OFFCURVE",
+"286 430 CURVE SMOOTH",
+"334 430 OFFCURVE",
+"358 401 OFFCURVE",
+"358 344 CURVE SMOOTH",
+"358 283 LINE",
+"152 283 LINE",
+"152 253 LINE",
+"499 253 LINE",
+"499 264 LINE SMOOTH",
+"499 386 OFFCURVE",
+"408 462 OFFCURVE",
+"289 462 CURVE SMOOTH",
+"140 462 OFFCURVE",
+"45 344 OFFCURVE",
+"45 228 CURVE SMOOTH",
+"45 103 OFFCURVE",
+"155 -13 OFFCURVE",
+"295 -13 CURVE SMOOTH"
+);
+}
+);
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0065;
+},
+{
+glyphname = eacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -72, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -121, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 00E9;
+},
+{
+glyphname = ebreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -29, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0115;
+},
+{
+glyphname = ecaron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 88, -9}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 79, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 011B;
+},
+{
+glyphname = ecircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 00EA;
+},
+{
+glyphname = ecircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBF;
+},
+{
+glyphname = ecircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -24, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC7;
+},
+{
+glyphname = ecircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC1;
+},
+{
+glyphname = ecircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC3;
+},
+{
+glyphname = ecircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC5;
+},
+{
+glyphname = edblgrave;
+lastChange = "2022-03-23 16:30:18 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dblgravecomb;
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0205;
+},
+{
+glyphname = edieresis;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 99, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 107, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 00EB;
+},
+{
+glyphname = edotaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 179, -3}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 181, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0117;
+},
+{
+glyphname = edotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -24, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EB9;
+},
+{
+glyphname = egrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -34, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 20, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 00E8;
+},
+{
+glyphname = ehookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -32, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -15, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBB;
+},
+{
+glyphname = einvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 86, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 92, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0207;
+},
+{
+glyphname = emacron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 87, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 95, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0113;
+},
+{
+glyphname = eogonek;
+lastChange = "2022-02-25 09:08:39 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = e;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 190, 0}";
+}
+);
+layerId = UUID0;
+width = 508;
+},
+{
+components = (
+{
+alignment = -1;
+name = e;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 219, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0119;
+},
+{
+glyphname = etilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -38, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBD;
+},
+{
+glyphname = schwa;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"146 152 LINE",
+"357 152 LINE",
+"357 177 LINE",
+"30 177 LINE",
+"30 171 LINE SMOOTH",
+"30 57 OFFCURVE",
+"113 -13 OFFCURVE",
+"221 -13 CURVE SMOOTH",
+"359 -13 OFFCURVE",
+"449 103 OFFCURVE",
+"449 217 CURVE SMOOTH",
+"449 340 OFFCURVE",
+"347 454 OFFCURVE",
+"221 454 CURVE SMOOTH",
+"127 454 OFFCURVE",
+"54 397 OFFCURVE",
+"27 303 CURVE",
+"55 303 LINE",
+"92 392 OFFCURVE",
+"146 424 OFFCURVE",
+"218 424 CURVE SMOOTH",
+"294 424 OFFCURVE",
+"319 383 OFFCURVE",
+"319 221 CURVE SMOOTH",
+"319 63 OFFCURVE",
+"293 14 OFFCURVE",
+"226 14 CURVE SMOOTH",
+"173 14 OFFCURVE",
+"146 45 OFFCURVE",
+"146 105 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"374 -12 OFFCURVE",
+"464 103 OFFCURVE",
+"464 225 CURVE SMOOTH",
+"464 347 OFFCURVE",
+"360 462 OFFCURVE",
+"231 462 CURVE SMOOTH",
+"140 462 OFFCURVE",
+"69 405 OFFCURVE",
+"42 311 CURVE",
+"70 311 LINE",
+"106 400 OFFCURVE",
+"158 432 OFFCURVE",
+"228 432 CURVE SMOOTH",
+"307 432 OFFCURVE",
+"334 387 OFFCURVE",
+"334 225 CURVE SMOOTH",
+"334 67 OFFCURVE",
+"308 15 OFFCURVE",
+"241 15 CURVE SMOOTH",
+"188 15 OFFCURVE",
+"161 46 OFFCURVE",
+"161 106 CURVE SMOOTH",
+"161 163 LINE",
+"372 163 LINE",
+"372 188 LINE",
+"45 188 LINE",
+"45 182 LINE SMOOTH",
+"45 68 OFFCURVE",
+"128 -12 OFFCURVE",
+"236 -12 CURVE SMOOTH"
+);
+}
+);
+width = 508;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"397 -13 OFFCURVE",
+"492 105 OFFCURVE",
+"492 221 CURVE SMOOTH",
+"492 346 OFFCURVE",
+"382 462 OFFCURVE",
+"242 462 CURVE SMOOTH",
+"142 462 OFFCURVE",
+"63 403 OFFCURVE",
+"35 311 CURVE",
+"68 311 LINE",
+"107 396 OFFCURVE",
+"167 427 OFFCURVE",
+"237 427 CURVE SMOOTH",
+"313 427 OFFCURVE",
+"337 389 OFFCURVE",
+"337 227 CURVE SMOOTH",
+"337 69 OFFCURVE",
+"314 19 OFFCURVE",
+"251 19 CURVE SMOOTH",
+"203 19 OFFCURVE",
+"179 48 OFFCURVE",
+"179 105 CURVE",
+"179 166 LINE",
+"385 166 LINE",
+"385 196 LINE",
+"38 196 LINE",
+"38 185 LINE SMOOTH",
+"38 63 OFFCURVE",
+"129 -13 OFFCURVE",
+"248 -13 CURVE SMOOTH"
+);
+}
+);
+width = 537;
+}
+);
+unicode = 0259;
+},
+{
+glyphname = f;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{181, 0}";
+},
+{
+name = top;
+position = "{181, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 618 LINE SMOOTH",
+"226 704 OFFCURVE",
+"242 738 OFFCURVE",
+"282 738 CURVE SMOOTH",
+"298 738 OFFCURVE",
+"305 733 OFFCURVE",
+"305 721 CURVE SMOOTH",
+"305 704 OFFCURVE",
+"291 698 OFFCURVE",
+"291 674 CURVE SMOOTH",
+"291 646 OFFCURVE",
+"311 627 OFFCURVE",
+"341 627 CURVE SMOOTH",
+"374 627 OFFCURVE",
+"397 650 OFFCURVE",
+"397 685 CURVE SMOOTH",
+"397 733 OFFCURVE",
+"355 765 OFFCURVE",
+"287 765 CURVE SMOOTH",
+"171 765 OFFCURVE",
+"116 672 OFFCURVE",
+"116 478 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"339 0 LINE",
+"339 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"349 425 LINE",
+"349 450 LINE",
+"19 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 618 LINE SMOOTH",
+"226 704 OFFCURVE",
+"242 738 OFFCURVE",
+"282 738 CURVE SMOOTH",
+"298 738 OFFCURVE",
+"305 733 OFFCURVE",
+"305 721 CURVE SMOOTH",
+"305 704 OFFCURVE",
+"291 698 OFFCURVE",
+"291 674 CURVE SMOOTH",
+"291 646 OFFCURVE",
+"311 627 OFFCURVE",
+"341 627 CURVE SMOOTH",
+"374 627 OFFCURVE",
+"397 650 OFFCURVE",
+"397 685 CURVE SMOOTH",
+"397 733 OFFCURVE",
+"355 765 OFFCURVE",
+"287 765 CURVE SMOOTH",
+"171 765 OFFCURVE",
+"116 672 OFFCURVE",
+"116 478 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 0 LINE",
+"339 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 425 LINE",
+"349 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+}
+);
+width = 362;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{173, 0}";
+},
+{
+name = top;
+position = "{173, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 629 LINE SMOOTH",
+"241 712 OFFCURVE",
+"276 734 OFFCURVE",
+"317 734 CURVE SMOOTH",
+"340 734 OFFCURVE",
+"350 727 OFFCURVE",
+"350 715 CURVE SMOOTH",
+"350 697 OFFCURVE",
+"326 693 OFFCURVE",
+"326 659 CURVE SMOOTH",
+"326 621 OFFCURVE",
+"355 603 OFFCURVE",
+"387 603 CURVE SMOOTH",
+"427 603 OFFCURVE",
+"456 630 OFFCURVE",
+"456 670 CURVE SMOOTH",
+"456 722 OFFCURVE",
+"405 766 OFFCURVE",
+"323 766 CURVE SMOOTH",
+"188 766 OFFCURVE",
+"103 649 OFFCURVE",
+"103 479 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"342 0 LINE",
+"342 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"349 410 LINE",
+"349 440 LINE",
+"20 440 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 629 LINE SMOOTH",
+"241 712 OFFCURVE",
+"276 734 OFFCURVE",
+"317 734 CURVE SMOOTH",
+"340 734 OFFCURVE",
+"350 727 OFFCURVE",
+"350 715 CURVE SMOOTH",
+"350 697 OFFCURVE",
+"326 693 OFFCURVE",
+"326 659 CURVE SMOOTH",
+"326 621 OFFCURVE",
+"355 603 OFFCURVE",
+"387 603 CURVE SMOOTH",
+"427 603 OFFCURVE",
+"456 630 OFFCURVE",
+"456 670 CURVE SMOOTH",
+"456 722 OFFCURVE",
+"405 766 OFFCURVE",
+"323 766 CURVE SMOOTH",
+"188 766 OFFCURVE",
+"103 649 OFFCURVE",
+"103 479 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 0 LINE",
+"342 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 410 LINE",
+"349 440 LINE",
+"20 440 LINE",
+"20 410 LINE"
+);
+}
+);
+width = 346;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = f;
+unicode = 0066;
+},
+{
+glyphname = g;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{259, 0}";
+},
+{
+name = top;
+position = "{259, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"379 -326 OFFCURVE",
+"472 -232 OFFCURVE",
+"472 -90 CURVE SMOOTH",
+"472 0 OFFCURVE",
+"435 40 OFFCURVE",
+"349 40 CURVE SMOOTH",
+"142 40 LINE SMOOTH",
+"108 40 OFFCURVE",
+"87 56 OFFCURVE",
+"87 82 CURVE SMOOTH",
+"87 118 OFFCURVE",
+"126 141 OFFCURVE",
+"179 141 CURVE SMOOTH",
+"242 141 LINE SMOOTH",
+"332 141 OFFCURVE",
+"414 218 OFFCURVE",
+"414 301 CURVE SMOOTH",
+"414 327 OFFCURVE",
+"406 352 OFFCURVE",
+"392 375 CURVE",
+"394 400 OFFCURVE",
+"400 409 OFFCURVE",
+"411 409 CURVE SMOOTH",
+"435 409 OFFCURVE",
+"426 372 OFFCURVE",
+"463 372 CURVE SMOOTH",
+"488 372 OFFCURVE",
+"504 389 OFFCURVE",
+"504 414 CURVE SMOOTH",
+"504 442 OFFCURVE",
+"482 462 OFFCURVE",
+"450 462 CURVE SMOOTH",
+"415 462 OFFCURVE",
+"386 438 OFFCURVE",
+"371 402 CURVE",
+"339 438 OFFCURVE",
+"292 462 OFFCURVE",
+"242 462 CURVE SMOOTH",
+"152 462 OFFCURVE",
+"71 384 OFFCURVE",
+"71 301 CURVE SMOOTH",
+"71 246 OFFCURVE",
+"106 194 OFFCURVE",
+"156 165 CURVE",
+"86 158 OFFCURVE",
+"47 119 OFFCURVE",
+"47 52 CURVE SMOOTH",
+"47 -1 OFFCURVE",
+"71 -38 OFFCURVE",
+"120 -59 CURVE",
+"120 -63 LINE",
+"72 -89 OFFCURVE",
+"43 -132 OFFCURVE",
+"43 -181 CURVE SMOOTH",
+"43 -263 OFFCURVE",
+"127 -326 OFFCURVE",
+"240 -326 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"171 -296 OFFCURVE",
+"115 -244 OFFCURVE",
+"115 -172 CURVE SMOOTH",
+"115 -129 OFFCURVE",
+"135 -80 OFFCURVE",
+"159 -62 CURVE",
+"370 -62 LINE SMOOTH",
+"408 -62 OFFCURVE",
+"431 -88 OFFCURVE",
+"431 -132 CURVE SMOOTH",
+"431 -218 OFFCURVE",
+"345 -296 OFFCURVE",
+"249 -296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"187 168 OFFCURVE",
+"174 196 OFFCURVE",
+"174 300 CURVE SMOOTH",
+"174 403 OFFCURVE",
+"187 430 OFFCURVE",
+"241 430 CURVE SMOOTH",
+"297 430 OFFCURVE",
+"311 402 OFFCURVE",
+"311 300 CURVE SMOOTH",
+"311 197 OFFCURVE",
+"297 168 OFFCURVE",
+"241 168 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"379 -326 OFFCURVE",
+"472 -232 OFFCURVE",
+"472 -90 CURVE SMOOTH",
+"472 0 OFFCURVE",
+"435 40 OFFCURVE",
+"349 40 CURVE SMOOTH",
+"142 40 LINE SMOOTH",
+"108 40 OFFCURVE",
+"87 56 OFFCURVE",
+"87 82 CURVE SMOOTH",
+"87 118 OFFCURVE",
+"126 141 OFFCURVE",
+"179 141 CURVE SMOOTH",
+"242 141 LINE SMOOTH",
+"332 141 OFFCURVE",
+"414 218 OFFCURVE",
+"414 301 CURVE SMOOTH",
+"414 327 OFFCURVE",
+"406 352 OFFCURVE",
+"392 375 CURVE",
+"394 400 OFFCURVE",
+"400 409 OFFCURVE",
+"411 409 CURVE SMOOTH",
+"435 409 OFFCURVE",
+"426 372 OFFCURVE",
+"463 372 CURVE SMOOTH",
+"488 372 OFFCURVE",
+"504 389 OFFCURVE",
+"504 414 CURVE SMOOTH",
+"504 442 OFFCURVE",
+"482 462 OFFCURVE",
+"450 462 CURVE SMOOTH",
+"415 462 OFFCURVE",
+"386 438 OFFCURVE",
+"371 402 CURVE",
+"339 438 OFFCURVE",
+"292 462 OFFCURVE",
+"242 462 CURVE SMOOTH",
+"152 462 OFFCURVE",
+"71 384 OFFCURVE",
+"71 301 CURVE SMOOTH",
+"71 246 OFFCURVE",
+"106 194 OFFCURVE",
+"156 165 CURVE",
+"86 158 OFFCURVE",
+"47 119 OFFCURVE",
+"47 52 CURVE SMOOTH",
+"47 -1 OFFCURVE",
+"71 -38 OFFCURVE",
+"120 -59 CURVE",
+"120 -63 LINE",
+"72 -89 OFFCURVE",
+"43 -132 OFFCURVE",
+"43 -181 CURVE SMOOTH",
+"43 -263 OFFCURVE",
+"127 -326 OFFCURVE",
+"240 -326 CURVE SMOOTH",
+"240 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"171 -296 OFFCURVE",
+"115 -244 OFFCURVE",
+"115 -172 CURVE SMOOTH",
+"115 -129 OFFCURVE",
+"135 -80 OFFCURVE",
+"159 -62 CURVE",
+"370 -62 LINE SMOOTH",
+"408 -62 OFFCURVE",
+"431 -88 OFFCURVE",
+"431 -132 CURVE SMOOTH",
+"431 -218 OFFCURVE",
+"345 -296 OFFCURVE",
+"249 -296 CURVE SMOOTH",
+"249 -296 LINE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"187 168 OFFCURVE",
+"174 196 OFFCURVE",
+"174 300 CURVE SMOOTH",
+"174 403 OFFCURVE",
+"187 430 OFFCURVE",
+"241 430 CURVE SMOOTH",
+"297 430 OFFCURVE",
+"311 402 OFFCURVE",
+"311 300 CURVE SMOOTH",
+"311 197 OFFCURVE",
+"297 168 OFFCURVE",
+"241 168 CURVE SMOOTH"
+);
+}
+);
+width = 518;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{283, 0}";
+},
+{
+name = top;
+position = "{283, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"405 -324 OFFCURVE",
+"533 -251 OFFCURVE",
+"533 -92 CURVE SMOOTH",
+"533 20 OFFCURVE",
+"469 50 OFFCURVE",
+"368 50 CURVE SMOOTH",
+"156 50 LINE SMOOTH",
+"119 50 OFFCURVE",
+"103 68 OFFCURVE",
+"103 86 CURVE SMOOTH",
+"103 115 OFFCURVE",
+"145 137 OFFCURVE",
+"210 137 CURVE SMOOTH",
+"272 137 LINE SMOOTH",
+"385 137 OFFCURVE",
+"478 196 OFFCURVE",
+"478 299 CURVE SMOOTH",
+"478 323 OFFCURVE",
+"472 345 OFFCURVE",
+"463 365 CURVE",
+"465 389 OFFCURVE",
+"471 396 OFFCURVE",
+"483 396 CURVE SMOOTH",
+"509 396 OFFCURVE",
+"503 364 OFFCURVE",
+"542 364 CURVE SMOOTH",
+"571 364 OFFCURVE",
+"585 382 OFFCURVE",
+"585 406 CURVE SMOOTH",
+"585 443 OFFCURVE",
+"554 464 OFFCURVE",
+"521 464 CURVE SMOOTH",
+"482 464 OFFCURVE",
+"456 435 OFFCURVE",
+"442 397 CURVE",
+"404 439 OFFCURVE",
+"342 462 OFFCURVE",
+"272 462 CURVE SMOOTH",
+"159 462 OFFCURVE",
+"69 402 OFFCURVE",
+"69 299 CURVE SMOOTH",
+"69 236 OFFCURVE",
+"102 189 OFFCURVE",
+"154 163 CURVE",
+"79 150 OFFCURVE",
+"43 107 OFFCURVE",
+"43 47 CURVE SMOOTH",
+"43 -12 OFFCURVE",
+"79 -42 OFFCURVE",
+"136 -63 CURVE",
+"136 -67 LINE",
+"81 -89 OFFCURVE",
+"40 -128 OFFCURVE",
+"40 -181 CURVE SMOOTH",
+"40 -260 OFFCURVE",
+"133 -324 OFFCURVE",
+"264 -324 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 -289 OFFCURVE",
+"148 -238 OFFCURVE",
+"148 -168 CURVE SMOOTH",
+"148 -135 OFFCURVE",
+"159 -86 OFFCURVE",
+"178 -66 CURVE",
+"413 -66 LINE SMOOTH",
+"461 -66 OFFCURVE",
+"477 -83 OFFCURVE",
+"477 -124 CURVE SMOOTH",
+"477 -228 OFFCURVE",
+"377 -289 OFFCURVE",
+"283 -289 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 173 OFFCURVE",
+"209 194 OFFCURVE",
+"209 301 CURVE SMOOTH",
+"209 408 OFFCURVE",
+"224 431 OFFCURVE",
+"273 431 CURVE SMOOTH",
+"321 431 OFFCURVE",
+"338 409 OFFCURVE",
+"338 300 CURVE SMOOTH",
+"338 195 OFFCURVE",
+"322 173 OFFCURVE",
+"273 173 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"405 -324 OFFCURVE",
+"533 -251 OFFCURVE",
+"533 -92 CURVE SMOOTH",
+"533 20 OFFCURVE",
+"469 50 OFFCURVE",
+"368 50 CURVE SMOOTH",
+"156 50 LINE SMOOTH",
+"119 50 OFFCURVE",
+"103 68 OFFCURVE",
+"103 86 CURVE SMOOTH",
+"103 115 OFFCURVE",
+"145 137 OFFCURVE",
+"210 137 CURVE SMOOTH",
+"272 137 LINE SMOOTH",
+"385 137 OFFCURVE",
+"478 196 OFFCURVE",
+"478 299 CURVE SMOOTH",
+"478 323 OFFCURVE",
+"472 345 OFFCURVE",
+"463 365 CURVE",
+"465 389 OFFCURVE",
+"471 396 OFFCURVE",
+"483 396 CURVE SMOOTH",
+"509 396 OFFCURVE",
+"503 364 OFFCURVE",
+"542 364 CURVE SMOOTH",
+"571 364 OFFCURVE",
+"585 382 OFFCURVE",
+"585 406 CURVE SMOOTH",
+"585 443 OFFCURVE",
+"554 464 OFFCURVE",
+"521 464 CURVE SMOOTH",
+"482 464 OFFCURVE",
+"456 435 OFFCURVE",
+"442 397 CURVE",
+"404 439 OFFCURVE",
+"342 462 OFFCURVE",
+"272 462 CURVE SMOOTH",
+"159 462 OFFCURVE",
+"69 402 OFFCURVE",
+"69 299 CURVE SMOOTH",
+"69 236 OFFCURVE",
+"102 189 OFFCURVE",
+"154 163 CURVE",
+"79 150 OFFCURVE",
+"43 107 OFFCURVE",
+"43 47 CURVE SMOOTH",
+"43 -12 OFFCURVE",
+"79 -42 OFFCURVE",
+"136 -63 CURVE",
+"136 -67 LINE",
+"81 -89 OFFCURVE",
+"40 -128 OFFCURVE",
+"40 -181 CURVE SMOOTH",
+"40 -260 OFFCURVE",
+"133 -324 OFFCURVE",
+"264 -324 CURVE SMOOTH",
+"264 -324 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 -289 OFFCURVE",
+"148 -238 OFFCURVE",
+"148 -168 CURVE SMOOTH",
+"148 -135 OFFCURVE",
+"159 -86 OFFCURVE",
+"178 -66 CURVE",
+"413 -66 LINE SMOOTH",
+"461 -66 OFFCURVE",
+"477 -83 OFFCURVE",
+"477 -124 CURVE SMOOTH",
+"477 -228 OFFCURVE",
+"377 -289 OFFCURVE",
+"283 -289 CURVE SMOOTH",
+"283 -289 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 173 OFFCURVE",
+"209 194 OFFCURVE",
+"209 301 CURVE SMOOTH",
+"209 408 OFFCURVE",
+"224 431 OFFCURVE",
+"273 431 CURVE SMOOTH",
+"321 431 OFFCURVE",
+"338 409 OFFCURVE",
+"338 300 CURVE SMOOTH",
+"338 195 OFFCURVE",
+"322 173 OFFCURVE",
+"273 173 CURVE SMOOTH"
+);
+}
+);
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 0067;
+},
+{
+glyphname = gacute;
+lastChange = "2016-08-22 11:53:43 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -66, 0}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -107, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 01F5;
+},
+{
+glyphname = gbreve;
+lastChange = "2016-08-22 11:53:43 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -36, 0}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -15, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 011F;
+},
+{
+glyphname = gcircumflex;
+lastChange = "2016-08-22 11:53:43 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -13, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 011D;
+},
+{
+glyphname = gcommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = commaaccentcomb;
+transform = "{-1, 0, 0, -1, 345, 450}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = commaaccentcomb;
+transform = "{-1, 0, 0, -1, 376, 450}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 0123;
+},
+{
+glyphname = gdotaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 185, -3}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 195, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 0121;
+},
+{
+glyphname = h;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{298, 0}";
+},
+{
+name = center;
+position = "{298, 225}";
+},
+{
+name = top;
+position = "{298, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"17 415 LINE",
+"206 415 LINE",
+"206 440 LINE",
+"17 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"96 15 LINE",
+"206 15 LINE",
+"206 424 LINE",
+"96 424 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"17 0 LINE",
+"271 0 LINE",
+"271 25 LINE",
+"17 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"311 0 LINE",
+"565 0 LINE",
+"565 25 LINE",
+"311 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 343 LINE SMOOTH",
+"497 404 OFFCURVE",
+"441 452 OFFCURVE",
+"362 452 CURVE SMOOTH",
+"285 452 OFFCURVE",
+"238 412 OFFCURVE",
+"210 357 CURVE",
+"186 357 LINE",
+"206 212 LINE",
+"206 329 OFFCURVE",
+"260 418 OFFCURVE",
+"327 418 CURVE SMOOTH",
+"365 418 OFFCURVE",
+"387 393 OFFCURVE",
+"387 343 CURVE SMOOTH",
+"387 15 LINE",
+"497 15 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"506 15 LINE",
+"506 353 LINE SMOOTH",
+"506 414 OFFCURVE",
+"449 462 OFFCURVE",
+"368 462 CURVE SMOOTH",
+"289 462 OFFCURVE",
+"242 422 OFFCURVE",
+"213 367 CURVE",
+"189 367 LINE",
+"209 222 LINE",
+"209 339 OFFCURVE",
+"264 428 OFFCURVE",
+"333 428 CURVE SMOOTH",
+"373 428 OFFCURVE",
+"396 403 OFFCURVE",
+"396 353 CURVE SMOOTH",
+"396 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"274 0 LINE",
+"274 25 LINE",
+"20 25 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 0 LINE",
+"574 25 LINE",
+"320 25 LINE",
+"320 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 15 LINE",
+"209 738 LINE",
+"99 738 LINE",
+"99 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 729 LINE",
+"209 754 LINE",
+"20 754 LINE",
+"20 729 LINE"
+);
+}
+);
+width = 596;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{310, 0}";
+},
+{
+name = center;
+position = "{310, 225}";
+},
+{
+name = top;
+position = "{310, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"335 0 LINE",
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 342 LINE SMOOTH",
+"541 403 OFFCURVE",
+"482 451 OFFCURVE",
+"396 451 CURVE SMOOTH",
+"318 451 OFFCURVE",
+"269 415 OFFCURVE",
+"243 356 CURVE",
+"219 356 LINE",
+"239 201 LINE",
+"239 318 OFFCURVE",
+"292 407 OFFCURVE",
+"358 407 CURVE SMOOTH",
+"386 407 OFFCURVE",
+"403 390 OFFCURVE",
+"403 357 CURVE SMOOTH",
+"403 15 LINE",
+"541 15 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"541 15 LINE",
+"541 353 LINE SMOOTH",
+"541 414 OFFCURVE",
+"483 462 OFFCURVE",
+"395 462 CURVE SMOOTH",
+"319 462 OFFCURVE",
+"269 426 OFFCURVE",
+"243 367 CURVE",
+"219 367 LINE",
+"239 212 LINE",
+"239 330 OFFCURVE",
+"292 418 OFFCURVE",
+"359 418 CURVE SMOOTH",
+"386 418 OFFCURVE",
+"403 404 OFFCURVE",
+"403 358 CURVE SMOOTH",
+"403 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE",
+"335 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 619;
+}
+);
+leftKerningGroup = h;
+rightKerningGroup = h;
+unicode = 0068;
+},
+{
+glyphname = hbar;
+lastChange = "2016-08-22 12:23:51 +0000";
+layers = (
+{
+components = (
+{
+name = h;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 417, 578}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = h;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, -27, 573}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 619;
+}
+);
+rightKerningGroup = h;
+unicode = 0127;
+},
+{
+glyphname = hcircumflex;
+lastChange = "2016-08-22 12:24:05 +0000";
+layers = (
+{
+components = (
+{
+name = h;
+},
+{
+alignment = -1;
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 88, 31}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = h;
+},
+{
+alignment = -1;
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 127, 29}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 619;
+}
+);
+leftKerningGroup = h;
+rightKerningGroup = h;
+unicode = 0125;
+},
+{
+glyphname = hdotbelow;
+lastChange = "2016-08-22 11:53:20 +0000";
+layers = (
+{
+components = (
+{
+name = h;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 14, 0}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = h;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 17, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 619;
+}
+);
+leftKerningGroup = h;
+rightKerningGroup = h;
+unicode = 1E25;
+},
+{
+glyphname = i;
+lastChange = "2016-08-22 12:07:32 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = top;
+position = "{175, 450}";
+}
+);
+components = (
+{
+name = idotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 91, -3}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{160, 0}";
+},
+{
+name = top;
+position = "{177, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"239 410 LINE",
+"239 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 424 LINE",
+"101 424 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 610 OFFCURVE",
+"124 573 OFFCURVE",
+"167 573 CURVE SMOOTH",
+"211 573 OFFCURVE",
+"248 610 OFFCURVE",
+"248 653 CURVE SMOOTH",
+"248 697 OFFCURVE",
+"211 734 OFFCURVE",
+"167 734 CURVE SMOOTH",
+"124 734 OFFCURVE",
+"87 697 OFFCURVE",
+"87 653 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = idotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 72, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 0069;
+},
+{
+glyphname = idotless;
+lastChange = "2016-08-22 10:12:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = ogonek;
+position = "{297, 10}";
+},
+{
+name = top;
+position = "{165, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"224 15 LINE",
+"224 425 LINE",
+"114 425 LINE",
+"114 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 25 LINE",
+"35 25 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 416 LINE",
+"224 441 LINE",
+"25 441 LINE",
+"25 416 LINE"
+);
+}
+);
+width = 330;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{160, 0}";
+},
+{
+name = ogonek;
+position = "{287, 10}";
+},
+{
+name = top;
+position = "{160, 450}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 319;
+}
+);
+unicode = 0131;
+},
+{
+glyphname = iacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -160, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -230, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 00ED;
+},
+{
+glyphname = ibreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -130, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -138, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 012D;
+},
+{
+glyphname = icircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -125, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -136, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 00EE;
+},
+{
+glyphname = idblgrave;
+lastChange = "2022-03-23 16:30:18 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, -88, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, -134, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 0209;
+},
+{
+glyphname = idieresis;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, -2, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 00EF;
+},
+{
+glyphname = idotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = i;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -119, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = i;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -133, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 1ECB;
+},
+{
+glyphname = igrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -122, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -89, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 00EC;
+},
+{
+glyphname = ihookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -120, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -124, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 1EC9;
+},
+{
+glyphname = iinvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, -2, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, -17, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 020B;
+},
+{
+glyphname = ij;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = i;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 310, 0}";
+}
+);
+layerId = UUID0;
+width = 640;
+},
+{
+components = (
+{
+name = i;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 319, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 637;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = j;
+unicode = 0133;
+},
+{
+glyphname = imacron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, -14, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 012B;
+},
+{
+glyphname = iogonek;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = idotless;
+},
+{
+alignment = -1;
+name = dotaccent;
+transform = "{1, 0, 0, 1, 91, -3}";
+},
+{
+alignment = -1;
+name = ogonek;
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+alignment = -1;
+name = idotless;
+},
+{
+alignment = -1;
+name = dotaccent;
+transform = "{1, 0, 0, 1, 72, -7}";
+},
+{
+alignment = -1;
+name = ogonek;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 012F;
+},
+{
+glyphname = itilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -126, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -153, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 0129;
+},
+{
+glyphname = j;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"146 -326 OFFCURVE",
+"224 -236 OFFCURVE",
+"224 -47 CURVE SMOOTH",
+"224 450 LINE",
+"25 450 LINE",
+"25 425 LINE",
+"114 425 LINE",
+"114 -197 LINE SMOOTH",
+"114 -273 OFFCURVE",
+"95 -293 OFFCURVE",
+"79 -293 CURVE SMOOTH",
+"71 -293 OFFCURVE",
+"61 -288 OFFCURVE",
+"61 -274 CURVE SMOOTH",
+"61 -266 OFFCURVE",
+"64 -251 OFFCURVE",
+"64 -242 CURVE SMOOTH",
+"64 -215 OFFCURVE",
+"39 -198 OFFCURVE",
+"13 -198 CURVE SMOOTH",
+"-18 -198 OFFCURVE",
+"-42 -221 OFFCURVE",
+"-42 -256 CURVE SMOOTH",
+"-42 -295 OFFCURVE",
+"-11 -326 OFFCURVE",
+"47 -326 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"99 631 OFFCURVE",
+"129 601 OFFCURVE",
+"165 601 CURVE SMOOTH",
+"201 601 OFFCURVE",
+"231 631 OFFCURVE",
+"231 667 CURVE SMOOTH",
+"231 703 OFFCURVE",
+"201 733 OFFCURVE",
+"165 733 CURVE SMOOTH",
+"129 733 OFFCURVE",
+"99 703 OFFCURVE",
+"99 667 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = jdotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 91, -3}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"156 -322 OFFCURVE",
+"239 -205 OFFCURVE",
+"239 -35 CURVE SMOOTH",
+"239 450 LINE",
+"15 450 LINE",
+"15 420 LINE",
+"101 420 LINE",
+"101 -185 LINE SMOOTH",
+"101 -264 OFFCURVE",
+"81 -285 OFFCURVE",
+"57 -285 CURVE SMOOTH",
+"43 -285 OFFCURVE",
+"36 -278 OFFCURVE",
+"36 -266 CURVE SMOOTH",
+"36 -250 OFFCURVE",
+"50 -245 OFFCURVE",
+"50 -217 CURVE SMOOTH",
+"50 -176 OFFCURVE",
+"21 -159 OFFCURVE",
+"-11 -159 CURVE SMOOTH",
+"-51 -159 OFFCURVE",
+"-80 -186 OFFCURVE",
+"-80 -225 CURVE SMOOTH",
+"-80 -278 OFFCURVE",
+"-26 -322 OFFCURVE",
+"43 -322 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 610 OFFCURVE",
+"124 573 OFFCURVE",
+"167 573 CURVE SMOOTH",
+"211 573 OFFCURVE",
+"248 610 OFFCURVE",
+"248 653 CURVE SMOOTH",
+"248 697 OFFCURVE",
+"211 734 OFFCURVE",
+"167 734 CURVE SMOOTH",
+"124 734 OFFCURVE",
+"87 697 OFFCURVE",
+"87 653 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = jdotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 71, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 318;
+}
+);
+leftKerningGroup = j;
+rightKerningGroup = j;
+unicode = 006A;
+},
+{
+glyphname = jdotless;
+lastChange = "2016-08-22 12:24:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = top;
+position = "{165, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"15 416 LINE",
+"114 416 LINE",
+"114 -185 LINE SMOOTH",
+"114 -261 OFFCURVE",
+"95 -281 OFFCURVE",
+"79 -281 CURVE SMOOTH",
+"71 -281 OFFCURVE",
+"61 -276 OFFCURVE",
+"61 -262 CURVE SMOOTH",
+"61 -254 OFFCURVE",
+"64 -239 OFFCURVE",
+"64 -230 CURVE SMOOTH",
+"64 -203 OFFCURVE",
+"39 -186 OFFCURVE",
+"13 -186 CURVE SMOOTH",
+"-18 -186 OFFCURVE",
+"-42 -209 OFFCURVE",
+"-42 -244 CURVE SMOOTH",
+"-42 -283 OFFCURVE",
+"-11 -314 OFFCURVE",
+"47 -314 CURVE SMOOTH",
+"146 -314 OFFCURVE",
+"224 -224 OFFCURVE",
+"224 -35 CURVE SMOOTH",
+"224 441 LINE",
+"15 441 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"146 -326 OFFCURVE",
+"224 -236 OFFCURVE",
+"224 -47 CURVE SMOOTH",
+"224 450 LINE",
+"25 450 LINE",
+"25 425 LINE",
+"114 425 LINE",
+"114 -197 LINE SMOOTH",
+"114 -273 OFFCURVE",
+"95 -293 OFFCURVE",
+"79 -293 CURVE SMOOTH",
+"71 -293 OFFCURVE",
+"61 -288 OFFCURVE",
+"61 -274 CURVE SMOOTH",
+"61 -266 OFFCURVE",
+"64 -251 OFFCURVE",
+"64 -242 CURVE SMOOTH",
+"64 -215 OFFCURVE",
+"39 -198 OFFCURVE",
+"13 -198 CURVE SMOOTH",
+"-18 -198 OFFCURVE",
+"-42 -221 OFFCURVE",
+"-42 -256 CURVE SMOOTH",
+"-42 -295 OFFCURVE",
+"-11 -326 OFFCURVE",
+"47 -326 CURVE SMOOTH",
+"47 -326 LINE SMOOTH"
+);
+}
+);
+width = 330;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{159, 0}";
+},
+{
+name = top;
+position = "{159, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"15 420 LINE",
+"239 420 LINE",
+"239 450 LINE",
+"15 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 450 LINE",
+"101 -185 LINE SMOOTH",
+"101 -264 OFFCURVE",
+"81 -285 OFFCURVE",
+"57 -285 CURVE SMOOTH",
+"43 -285 OFFCURVE",
+"36 -278 OFFCURVE",
+"36 -266 CURVE SMOOTH",
+"36 -250 OFFCURVE",
+"50 -245 OFFCURVE",
+"50 -217 CURVE SMOOTH",
+"50 -176 OFFCURVE",
+"21 -159 OFFCURVE",
+"-11 -159 CURVE SMOOTH",
+"-51 -159 OFFCURVE",
+"-80 -186 OFFCURVE",
+"-80 -225 CURVE SMOOTH",
+"-80 -278 OFFCURVE",
+"-26 -322 OFFCURVE",
+"43 -322 CURVE SMOOTH",
+"156 -322 OFFCURVE",
+"239 -205 OFFCURVE",
+"239 -35 CURVE SMOOTH",
+"239 450 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"156 -322 OFFCURVE",
+"239 -205 OFFCURVE",
+"239 -35 CURVE SMOOTH",
+"239 450 LINE",
+"15 450 LINE",
+"15 420 LINE",
+"101 420 LINE",
+"101 -185 LINE SMOOTH",
+"101 -264 OFFCURVE",
+"81 -285 OFFCURVE",
+"57 -285 CURVE SMOOTH",
+"43 -285 OFFCURVE",
+"36 -278 OFFCURVE",
+"36 -266 CURVE SMOOTH",
+"36 -250 OFFCURVE",
+"50 -245 OFFCURVE",
+"50 -217 CURVE SMOOTH",
+"50 -176 OFFCURVE",
+"21 -159 OFFCURVE",
+"-11 -159 CURVE SMOOTH",
+"-51 -159 OFFCURVE",
+"-80 -186 OFFCURVE",
+"-80 -225 CURVE SMOOTH",
+"-80 -278 OFFCURVE",
+"-26 -322 OFFCURVE",
+"43 -322 CURVE SMOOTH",
+"43 -322 LINE SMOOTH"
+);
+}
+);
+width = 318;
+}
+);
+unicode = 0237;
+},
+{
+glyphname = jcircumflex;
+lastChange = "2016-08-22 12:24:23 +0000";
+layers = (
+{
+components = (
+{
+name = jdotless;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -125, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = jdotless;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -137, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 318;
+}
+);
+leftKerningGroup = j;
+rightKerningGroup = j;
+unicode = 0135;
+},
+{
+glyphname = k;
+lastChange = "2016-10-31 09:59:46 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{261, 0}";
+},
+{
+name = top;
+position = "{261, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"12 729 LINE",
+"201 729 LINE",
+"201 754 LINE",
+"12 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"91 15 LINE",
+"201 15 LINE",
+"201 738 LINE",
+"91 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"12 0 LINE",
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 15 LINE",
+"529 15 LINE",
+"300 306 LINE",
+"208 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 425 LINE",
+"517 425 LINE",
+"517 450 LINE",
+"285 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"208 249 LINE",
+"251 249 LINE",
+"434 433 LINE",
+"391 433 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"529 15 LINE",
+"300 306 LINE",
+"208 249 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE",
+"12 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 15 LINE",
+"201 738 LINE",
+"91 738 LINE",
+"91 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"434 433 LINE",
+"391 433 LINE",
+"208 249 LINE",
+"251 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 729 LINE",
+"201 754 LINE",
+"12 754 LINE",
+"12 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"517 425 LINE",
+"517 450 LINE",
+"285 450 LINE",
+"285 425 LINE"
+);
+}
+);
+width = 522;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{309, 0}";
+},
+{
+name = top;
+position = "{309, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 0 LINE",
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 15 LINE",
+"581 15 LINE",
+"352 321 LINE",
+"235 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"332 420 LINE",
+"565 420 LINE",
+"565 450 LINE",
+"332 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"235 254 LINE",
+"235 249 LINE",
+"286 249 LINE",
+"492 432 LINE",
+"441 432 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"581 15 LINE",
+"352 321 LINE",
+"247 254 LINE",
+"413 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE",
+"339 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 432 LINE",
+"441 432 LINE",
+"247 254 LINE",
+"286 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"565 420 LINE",
+"565 450 LINE",
+"332 450 LINE",
+"332 420 LINE"
+);
+}
+);
+width = 618;
+}
+);
+leftKerningGroup = k;
+rightKerningGroup = k;
+unicode = 006B;
+},
+{
+glyphname = kcommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = k;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 175, 0}";
+}
+);
+layerId = UUID0;
+width = 522;
+},
+{
+components = (
+{
+name = k;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 216, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 618;
+}
+);
+leftKerningGroup = k;
+rightKerningGroup = k;
+unicode = 0137;
+},
+{
+glyphname = kgreenlandic;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"12 425 LINE",
+"201 425 LINE",
+"201 450 LINE",
+"12 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"91 15 LINE",
+"201 15 LINE",
+"201 434 LINE",
+"91 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"12 0 LINE",
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 15 LINE",
+"529 15 LINE",
+"300 306 LINE",
+"208 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 425 LINE",
+"517 425 LINE",
+"517 450 LINE",
+"285 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"208 249 LINE",
+"251 249 LINE",
+"434 433 LINE",
+"391 433 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"529 15 LINE",
+"300 306 LINE",
+"208 249 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE",
+"12 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 15 LINE",
+"201 434 LINE",
+"91 434 LINE",
+"91 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 425 LINE",
+"201 450 LINE",
+"12 450 LINE",
+"12 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 249 LINE",
+"434 433 LINE",
+"391 433 LINE",
+"208 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"517 425 LINE",
+"517 450 LINE",
+"285 450 LINE",
+"285 425 LINE"
+);
+}
+);
+width = 522;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 0 LINE",
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 15 LINE",
+"581 15 LINE",
+"352 301 LINE",
+"235 229 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"332 420 LINE",
+"565 420 LINE",
+"565 450 LINE",
+"332 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"235 234 LINE",
+"235 229 LINE",
+"286 229 LINE",
+"492 432 LINE",
+"441 432 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"581 15 LINE",
+"352 321 LINE",
+"247 254 LINE",
+"413 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE",
+"339 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 432 LINE",
+"441 432 LINE",
+"247 254 LINE",
+"286 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"565 420 LINE",
+"565 450 LINE",
+"332 450 LINE",
+"332 420 LINE"
+);
+}
+);
+width = 618;
+}
+);
+rightKerningGroup = k;
+unicode = 0138;
+},
+{
+glyphname = l;
+lastChange = "2021-12-17 13:38:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{148, 0}";
+},
+{
+name = center;
+position = "{148, 225}";
+},
+{
+name = top;
+position = "{148, 754}";
+},
+{
+name = topright;
+position = "{276, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 729 LINE",
+"189 729 LINE",
+"189 754 LINE",
+"0 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 15 LINE",
+"189 15 LINE",
+"189 738 LINE",
+"79 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 0 LINE",
+"189 0 LINE",
+"189 25 LINE",
+"0 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"243 22 OFFCURVE",
+"189 80 OFFCURVE",
+"189 210 CURVE",
+"169 58 LINE",
+"193 58 LINE",
+"215 18 OFFCURVE",
+"264 -12 OFFCURVE",
+"326 -12 CURVE SMOOTH",
+"426 -12 OFFCURVE",
+"520 83 OFFCURVE",
+"520 225 CURVE SMOOTH",
+"520 367 OFFCURVE",
+"427 462 OFFCURVE",
+"327 462 CURVE SMOOTH",
+"265 462 OFFCURVE",
+"215 432 OFFCURVE",
+"193 392 CURVE",
+"169 392 LINE",
+"189 240 LINE",
+"189 370 OFFCURVE",
+"242 428 OFFCURVE",
+"314 428 CURVE SMOOTH",
+"370 428 OFFCURVE",
+"392 389 OFFCURVE",
+"392 224 CURVE SMOOTH",
+"392 59 OFFCURVE",
+"371 22 OFFCURVE",
+"315 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"202 15 LINE",
+"202 738 LINE",
+"92 738 LINE",
+"92 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 0 LINE",
+"282 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 729 LINE",
+"202 754 LINE",
+"13 754 LINE",
+"13 729 LINE"
+);
+}
+);
+width = 296;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = center;
+position = "{165, 225}";
+},
+{
+name = top;
+position = "{168, 754}";
+},
+{
+name = topright;
+position = "{309, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"217 739 OFFCURVE",
+"145 734 OFFCURVE",
+"128 734 CURVE SMOOTH",
+"117 734 OFFCURVE",
+"96 734 OFFCURVE",
+"80 734 CURVE SMOOTH",
+"64 734 OFFCURVE",
+"46 734 OFFCURVE",
+"40 734 CURVE SMOOTH",
+"35 734 OFFCURVE",
+"27 734 OFFCURVE",
+"22 732 CURVE SMOOTH",
+"11 727 OFFCURVE",
+"8 713 OFFCURVE",
+"16 705 CURVE SMOOTH",
+"19 702 OFFCURVE",
+"22 702 OFFCURVE",
+"48 702 CURVE SMOOTH",
+"64 702 OFFCURVE",
+"80 703 OFFCURVE",
+"83 703 CURVE SMOOTH",
+"92 705 OFFCURVE",
+"95 702 OFFCURVE",
+"97 692 CURVE SMOOTH",
+"97 689 OFFCURVE",
+"97 643 OFFCURVE",
+"97 590 CURVE SMOOTH",
+"97 537 OFFCURVE",
+"97 475 OFFCURVE",
+"97 452 CURVE SMOOTH",
+"97 430 OFFCURVE",
+"97 396 OFFCURVE",
+"97 379 CURVE SMOOTH",
+"97 359 OFFCURVE",
+"97 331 OFFCURVE",
+"97 315 CURVE SMOOTH",
+"97 299 OFFCURVE",
+"97 270 OFFCURVE",
+"97 249 CURVE SMOOTH",
+"97 185 OFFCURVE",
+"97 135 OFFCURVE",
+"97 116 CURVE",
+"99 91 OFFCURVE",
+"96 39 OFFCURVE",
+"93 36 CURVE SMOOTH",
+"91 33 OFFCURVE",
+"85 33 OFFCURVE",
+"61 33 CURVE",
+"35 35 OFFCURVE",
+"30 33 OFFCURVE",
+"25 31 CURVE",
+"14 23 OFFCURVE",
+"17 9 OFFCURVE",
+"30 3 CURVE SMOOTH",
+"36 1 OFFCURVE",
+"40 -1 OFFCURVE",
+"62 1 CURVE SMOOTH",
+"93 3 OFFCURVE",
+"248 3 OFFCURVE",
+"261 1 CURVE",
+"261 1 OFFCURVE",
+"273 -1 OFFCURVE",
+"285 -2 CURVE SMOOTH",
+"303 -4 OFFCURVE",
+"309 -2 OFFCURVE",
+"318 4 CURVE",
+"318 9 OFFCURVE",
+"318 20 OFFCURVE",
+"318 27 CURVE",
+"313 33 LINE",
+"280 33 LINE SMOOTH",
+"262 33 OFFCURVE",
+"246 35 OFFCURVE",
+"245 35 CURVE SMOOTH",
+"243 36 OFFCURVE",
+"243 123 OFFCURVE",
+"243 385 CURVE SMOOTH",
+"243 705 OFFCURVE",
+"243 734 OFFCURVE",
+"240 735 CURVE",
+"238 739 OFFCURVE",
+"222 742 OFFCURVE",
+"221 740 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"314 0 LINE",
+"314 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 329;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = l;
+unicode = 006C;
+},
+{
+glyphname = lacute;
+lastChange = "2021-12-17 13:38:29 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -177, 304}";
+}
+);
+layerId = UUID0;
+width = 296;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -222, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 329;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = l;
+unicode = 013A;
+},
+{
+glyphname = lcaron;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = l;
+},
+{
+alignment = -1;
+name = caron.alt;
+transform = "{1, 0, 0, 1, 249, -9}";
+}
+);
+layerId = UUID0;
+width = 328;
+},
+{
+components = (
+{
+alignment = -1;
+name = l;
+},
+{
+alignment = -1;
+name = caron.alt;
+transform = "{1, 0, 0, 1, 287, -10}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 388;
+}
+);
+leftKerningGroup = l;
+unicode = 013E;
+},
+{
+glyphname = lcommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 62, 0}";
+}
+);
+layerId = UUID0;
+width = 296;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 72, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 329;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = l;
+unicode = 013C;
+},
+{
+glyphname = ldot;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = l;
+},
+{
+alignment = -1;
+name = periodcentered;
+transform = "{1, 0, 0, 1, 235, 57}";
+}
+);
+layerId = UUID0;
+width = 372;
+},
+{
+components = (
+{
+alignment = -1;
+name = l;
+},
+{
+alignment = -1;
+name = periodcentered;
+transform = "{1, 0, 0, 1, 246, 52}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 410;
+}
+);
+leftKerningGroup = l;
+unicode = 0140;
+},
+{
+glyphname = lj;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 296, 0}";
+}
+);
+layerId = UUID0;
+width = 626;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 329, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 647;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = j;
+unicode = 01C9;
+},
+{
+glyphname = lslash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"298 448 LINE",
+"298 488 LINE",
+"-10 327 LINE",
+"-10 287 LINE"
+);
+}
+);
+width = 296;
+},
+{
+components = (
+{
+name = l;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"328 448 LINE",
+"328 502 LINE",
+"20 341 LINE",
+"20 287 LINE"
+);
+}
+);
+width = 329;
+}
+);
+unicode = 0142;
+},
+{
+glyphname = m;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{438, 0}";
+},
+{
+name = top;
+position = "{438, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"786 15 LINE",
+"786 353 LINE SMOOTH",
+"786 414 OFFCURVE",
+"731 462 OFFCURVE",
+"654 462 CURVE SMOOTH",
+"579 462 OFFCURVE",
+"532 422 OFFCURVE",
+"505 367 CURVE",
+"481 367 LINE",
+"501 222 LINE",
+"501 339 OFFCURVE",
+"554 428 OFFCURVE",
+"619 428 CURVE SMOOTH",
+"655 428 OFFCURVE",
+"676 403 OFFCURVE",
+"676 353 CURVE SMOOTH",
+"676 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 0 LINE",
+"281 25 LINE",
+"27 25 LINE",
+"27 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 15 LINE",
+"216 434 LINE",
+"106 434 LINE",
+"106 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 0 LINE",
+"569 25 LINE",
+"315 25 LINE",
+"315 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 425 LINE",
+"216 450 LINE",
+"27 450 LINE",
+"27 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 15 LINE",
+"501 353 LINE SMOOTH",
+"501 414 OFFCURVE",
+"446 462 OFFCURVE",
+"369 462 CURVE SMOOTH",
+"294 462 OFFCURVE",
+"247 422 OFFCURVE",
+"220 367 CURVE",
+"196 367 LINE",
+"216 222 LINE",
+"216 339 OFFCURVE",
+"269 428 OFFCURVE",
+"334 428 CURVE SMOOTH",
+"370 428 OFFCURVE",
+"391 403 OFFCURVE",
+"391 353 CURVE SMOOTH",
+"391 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"854 0 LINE",
+"854 25 LINE",
+"600 25 LINE",
+"600 0 LINE"
+);
+}
+);
+width = 876;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{455, 0}";
+},
+{
+name = top;
+position = "{455, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"239 410 LINE",
+"239 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 424 LINE",
+"101 424 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"330 0 LINE",
+"599 0 LINE",
+"599 30 LINE",
+"330 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 342 LINE SMOOTH",
+"536 403 OFFCURVE",
+"477 451 OFFCURVE",
+"391 451 CURVE SMOOTH",
+"316 451 OFFCURVE",
+"268 415 OFFCURVE",
+"243 356 CURVE",
+"219 356 LINE",
+"239 201 LINE",
+"239 318 OFFCURVE",
+"290 407 OFFCURVE",
+"353 407 CURVE SMOOTH",
+"381 407 OFFCURVE",
+"398 390 OFFCURVE",
+"398 357 CURVE SMOOTH",
+"398 15 LINE",
+"536 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"626 0 LINE",
+"895 0 LINE",
+"895 30 LINE",
+"626 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"832 342 LINE SMOOTH",
+"832 403 OFFCURVE",
+"773 451 OFFCURVE",
+"687 451 CURVE SMOOTH",
+"612 451 OFFCURVE",
+"564 415 OFFCURVE",
+"539 356 CURVE",
+"515 356 LINE",
+"535 201 LINE",
+"535 318 OFFCURVE",
+"586 407 OFFCURVE",
+"649 407 CURVE SMOOTH",
+"677 407 OFFCURVE",
+"694 390 OFFCURVE",
+"694 357 CURVE SMOOTH",
+"694 15 LINE",
+"832 15 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"832 15 LINE",
+"832 353 LINE SMOOTH",
+"832 414 OFFCURVE",
+"773 462 OFFCURVE",
+"687 462 CURVE SMOOTH",
+"612 462 OFFCURVE",
+"564 426 OFFCURVE",
+"539 367 CURVE",
+"515 367 LINE",
+"535 212 LINE",
+"535 329 OFFCURVE",
+"586 418 OFFCURVE",
+"649 418 CURVE SMOOTH",
+"677 418 OFFCURVE",
+"694 401 OFFCURVE",
+"694 368 CURVE SMOOTH",
+"694 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 0 LINE",
+"599 30 LINE",
+"330 30 LINE",
+"330 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 15 LINE",
+"536 353 LINE SMOOTH",
+"536 414 OFFCURVE",
+"477 462 OFFCURVE",
+"391 462 CURVE SMOOTH",
+"316 462 OFFCURVE",
+"268 426 OFFCURVE",
+"243 367 CURVE",
+"219 367 LINE",
+"239 212 LINE",
+"239 329 OFFCURVE",
+"290 418 OFFCURVE",
+"353 418 CURVE SMOOTH",
+"381 418 OFFCURVE",
+"398 401 OFFCURVE",
+"398 368 CURVE SMOOTH",
+"398 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"895 0 LINE",
+"895 30 LINE",
+"626 30 LINE",
+"626 0 LINE"
+);
+}
+);
+width = 910;
+}
+);
+unicode = 006D;
+},
+{
+glyphname = n;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{298, 0}";
+},
+{
+name = top;
+position = "{298, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"508 15 LINE",
+"508 353 LINE SMOOTH",
+"508 414 OFFCURVE",
+"452 462 OFFCURVE",
+"373 462 CURVE SMOOTH",
+"296 462 OFFCURVE",
+"249 422 OFFCURVE",
+"221 367 CURVE",
+"197 367 LINE",
+"217 222 LINE",
+"217 339 OFFCURVE",
+"271 428 OFFCURVE",
+"338 428 CURVE SMOOTH",
+"376 428 OFFCURVE",
+"398 403 OFFCURVE",
+"398 353 CURVE SMOOTH",
+"398 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 0 LINE",
+"282 25 LINE",
+"28 25 LINE",
+"28 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 15 LINE",
+"217 434 LINE",
+"107 434 LINE",
+"107 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"576 0 LINE",
+"576 25 LINE",
+"322 25 LINE",
+"322 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 425 LINE",
+"217 450 LINE",
+"28 450 LINE",
+"28 425 LINE"
+);
+}
+);
+width = 596;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{307, 0}";
+},
+{
+name = top;
+position = "{307, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"239 410 LINE",
+"239 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 424 LINE",
+"101 424 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"335 0 LINE",
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 342 LINE SMOOTH",
+"541 403 OFFCURVE",
+"482 451 OFFCURVE",
+"396 451 CURVE SMOOTH",
+"318 451 OFFCURVE",
+"269 415 OFFCURVE",
+"243 356 CURVE",
+"219 356 LINE",
+"239 201 LINE",
+"239 318 OFFCURVE",
+"292 407 OFFCURVE",
+"358 407 CURVE SMOOTH",
+"386 407 OFFCURVE",
+"403 390 OFFCURVE",
+"403 357 CURVE SMOOTH",
+"403 15 LINE",
+"541 15 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"541 15 LINE",
+"541 353 LINE SMOOTH",
+"541 414 OFFCURVE",
+"482 462 OFFCURVE",
+"396 462 CURVE SMOOTH",
+"318 462 OFFCURVE",
+"269 426 OFFCURVE",
+"243 367 CURVE",
+"219 367 LINE",
+"239 212 LINE",
+"239 329 OFFCURVE",
+"292 418 OFFCURVE",
+"358 418 CURVE SMOOTH",
+"386 418 OFFCURVE",
+"403 401 OFFCURVE",
+"403 368 CURVE SMOOTH",
+"403 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE",
+"335 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 006E;
+},
+{
+glyphname = nacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -83, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 0144;
+},
+{
+glyphname = napostrophe;
+lastChange = "2016-08-22 12:26:02 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = quoteright;
+transform = "{1, 0, 0, 1, -60, 13}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = quoteright;
+transform = "{1, 0, 0, 1, -47, 80}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+rightKerningGroup = n;
+unicode = 0149;
+},
+{
+glyphname = ncaron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 133, -9}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 117, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 0148;
+},
+{
+glyphname = ncommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 212, 0}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 214, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 0146;
+},
+{
+glyphname = ndotaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 224, -3}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 219, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 1E45;
+},
+{
+glyphname = nj;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 596, 0}";
+}
+);
+layerId = UUID0;
+width = 926;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 614, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 932;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = j;
+unicode = 01CC;
+},
+{
+glyphname = ntilde;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 7, 0}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 00F1;
+},
+{
+glyphname = eng;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"28 425 LINE",
+"107 425 LINE",
+"107 25 LINE",
+"28 25 LINE",
+"28 0 LINE",
+"282 0 LINE",
+"282 25 LINE",
+"217 25 LINE",
+"217 230 LINE SMOOTH",
+"217 343 OFFCURVE",
+"272 428 OFFCURVE",
+"338 428 CURVE SMOOTH",
+"376 428 OFFCURVE",
+"398 403 OFFCURVE",
+"398 353 CURVE SMOOTH",
+"398 -197 LINE SMOOTH",
+"398 -273 OFFCURVE",
+"379 -293 OFFCURVE",
+"363 -293 CURVE SMOOTH",
+"355 -293 OFFCURVE",
+"345 -288 OFFCURVE",
+"345 -274 CURVE SMOOTH",
+"345 -266 OFFCURVE",
+"348 -251 OFFCURVE",
+"348 -242 CURVE SMOOTH",
+"348 -215 OFFCURVE",
+"323 -198 OFFCURVE",
+"297 -198 CURVE SMOOTH",
+"266 -198 OFFCURVE",
+"242 -221 OFFCURVE",
+"242 -256 CURVE SMOOTH",
+"242 -295 OFFCURVE",
+"273 -326 OFFCURVE",
+"331 -326 CURVE SMOOTH",
+"430 -326 OFFCURVE",
+"508 -236 OFFCURVE",
+"508 -47 CURVE SMOOTH",
+"508 353 LINE SMOOTH",
+"508 414 OFFCURVE",
+"452 462 OFFCURVE",
+"373 462 CURVE SMOOTH",
+"296 462 OFFCURVE",
+"249 422 OFFCURVE",
+"221 367 CURVE",
+"217 367 LINE",
+"217 450 LINE",
+"28 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"430 -326 OFFCURVE",
+"508 -236 OFFCURVE",
+"508 -47 CURVE SMOOTH",
+"508 353 LINE SMOOTH",
+"508 414 OFFCURVE",
+"452 462 OFFCURVE",
+"373 462 CURVE SMOOTH",
+"296 462 OFFCURVE",
+"249 422 OFFCURVE",
+"221 367 CURVE",
+"217 367 LINE",
+"217 450 LINE",
+"28 450 LINE",
+"28 425 LINE",
+"107 425 LINE",
+"107 25 LINE",
+"28 25 LINE",
+"28 0 LINE",
+"282 0 LINE",
+"282 25 LINE",
+"217 25 LINE",
+"217 230 LINE SMOOTH",
+"217 343 OFFCURVE",
+"272 428 OFFCURVE",
+"338 428 CURVE SMOOTH",
+"376 428 OFFCURVE",
+"398 403 OFFCURVE",
+"398 353 CURVE SMOOTH",
+"398 -197 LINE SMOOTH",
+"398 -273 OFFCURVE",
+"379 -293 OFFCURVE",
+"363 -293 CURVE SMOOTH",
+"355 -293 OFFCURVE",
+"345 -288 OFFCURVE",
+"345 -274 CURVE SMOOTH",
+"345 -266 OFFCURVE",
+"348 -251 OFFCURVE",
+"348 -242 CURVE SMOOTH",
+"348 -215 OFFCURVE",
+"323 -198 OFFCURVE",
+"297 -198 CURVE SMOOTH",
+"266 -198 OFFCURVE",
+"242 -221 OFFCURVE",
+"242 -256 CURVE SMOOTH",
+"242 -295 OFFCURVE",
+"273 -326 OFFCURVE",
+"331 -326 CURVE SMOOTH"
+);
+}
+);
+width = 607;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"101 420 LINE",
+"101 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"239 30 LINE",
+"239 220 LINE SMOOTH",
+"239 333 OFFCURVE",
+"293 418 OFFCURVE",
+"358 418 CURVE SMOOTH",
+"386 418 OFFCURVE",
+"403 401 OFFCURVE",
+"403 368 CURVE SMOOTH",
+"403 -185 LINE SMOOTH",
+"403 -264 OFFCURVE",
+"383 -285 OFFCURVE",
+"359 -285 CURVE SMOOTH",
+"345 -285 OFFCURVE",
+"338 -278 OFFCURVE",
+"338 -266 CURVE SMOOTH",
+"338 -250 OFFCURVE",
+"352 -245 OFFCURVE",
+"352 -217 CURVE SMOOTH",
+"352 -176 OFFCURVE",
+"323 -159 OFFCURVE",
+"291 -159 CURVE SMOOTH",
+"251 -159 OFFCURVE",
+"222 -186 OFFCURVE",
+"222 -225 CURVE SMOOTH",
+"222 -278 OFFCURVE",
+"276 -322 OFFCURVE",
+"345 -322 CURVE SMOOTH",
+"458 -322 OFFCURVE",
+"541 -205 OFFCURVE",
+"541 -35 CURVE SMOOTH",
+"541 353 LINE SMOOTH",
+"541 414 OFFCURVE",
+"482 462 OFFCURVE",
+"396 462 CURVE SMOOTH",
+"318 462 OFFCURVE",
+"269 426 OFFCURVE",
+"243 367 CURVE",
+"239 367 LINE",
+"239 450 LINE",
+"20 450 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"458 -322 OFFCURVE",
+"541 -205 OFFCURVE",
+"541 -35 CURVE SMOOTH",
+"541 353 LINE SMOOTH",
+"541 414 OFFCURVE",
+"482 462 OFFCURVE",
+"396 462 CURVE SMOOTH",
+"318 462 OFFCURVE",
+"269 426 OFFCURVE",
+"243 367 CURVE",
+"239 367 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE",
+"101 420 LINE",
+"101 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"239 30 LINE",
+"239 220 LINE SMOOTH",
+"239 333 OFFCURVE",
+"293 418 OFFCURVE",
+"358 418 CURVE SMOOTH",
+"386 418 OFFCURVE",
+"403 401 OFFCURVE",
+"403 368 CURVE SMOOTH",
+"403 -185 LINE SMOOTH",
+"403 -264 OFFCURVE",
+"383 -285 OFFCURVE",
+"359 -285 CURVE SMOOTH",
+"345 -285 OFFCURVE",
+"338 -278 OFFCURVE",
+"338 -266 CURVE SMOOTH",
+"338 -250 OFFCURVE",
+"352 -245 OFFCURVE",
+"352 -217 CURVE SMOOTH",
+"352 -176 OFFCURVE",
+"323 -159 OFFCURVE",
+"291 -159 CURVE SMOOTH",
+"251 -159 OFFCURVE",
+"222 -186 OFFCURVE",
+"222 -225 CURVE SMOOTH",
+"222 -278 OFFCURVE",
+"276 -322 OFFCURVE",
+"345 -322 CURVE SMOOTH"
+);
+}
+);
+width = 614;
+}
+);
+leftKerningGroup = n;
+unicode = 014B;
+},
+{
+glyphname = o;
+lastChange = "2016-08-22 09:33:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{281, 0}";
+},
+{
+name = center;
+position = "{281, 225}";
+},
+{
+name = ogonek;
+position = "{506, 10}";
+},
+{
+name = top;
+position = "{281, 450}";
+},
+{
+name = topright;
+position = "{429, 397}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH"
+);
+}
+);
+width = 562;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{295, 0}";
+},
+{
+name = center;
+position = "{295, 225}";
+},
+{
+name = ogonek;
+position = "{530, 10}";
+},
+{
+name = top;
+position = "{295, 450}";
+},
+{
+name = topright;
+position = "{341, 395}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"45 82 OFFCURVE",
+"156 -13 OFFCURVE",
+"294 -13 CURVE SMOOTH",
+"432 -13 OFFCURVE",
+"544 82 OFFCURVE",
+"544 220 CURVE SMOOTH",
+"544 358 OFFCURVE",
+"432 454 OFFCURVE",
+"294 454 CURVE SMOOTH",
+"156 454 OFFCURVE",
+"45 358 OFFCURVE",
+"45 220 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 383 OFFCURVE",
+"224 419 OFFCURVE",
+"294 419 CURVE SMOOTH",
+"364 419 OFFCURVE",
+"389 383 OFFCURVE",
+"389 220 CURVE SMOOTH",
+"389 57 OFFCURVE",
+"364 22 OFFCURVE",
+"294 22 CURVE SMOOTH",
+"224 22 OFFCURVE",
+"200 57 OFFCURVE",
+"200 220 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"432 -13 OFFCURVE",
+"544 84 OFFCURVE",
+"544 224 CURVE SMOOTH",
+"544 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -13 OFFCURVE",
+"294 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 22 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 22 OFFCURVE",
+"294 22 CURVE SMOOTH"
+);
+}
+);
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 006F;
+},
+{
+glyphname = oacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -95, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F3;
+},
+{
+glyphname = obreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -14, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 014F;
+},
+{
+glyphname = ocircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F4;
+},
+{
+glyphname = ocircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED1;
+},
+{
+glyphname = ocircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED9;
+},
+{
+glyphname = ocircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED3;
+},
+{
+glyphname = ocircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED5;
+},
+{
+glyphname = ocircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED7;
+},
+{
+glyphname = odblgrave;
+lastChange = "2022-03-23 16:30:18 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 28, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 020D;
+},
+{
+glyphname = odieresis;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 127, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 133, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F6;
+},
+{
+glyphname = odotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ECD;
+},
+{
+glyphname = ograve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 46, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F2;
+},
+{
+glyphname = ohookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -4, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ECF;
+},
+{
+glyphname = ohorn;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 117, -53}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 142, -55}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 01A1;
+},
+{
+glyphname = ohornacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -95, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDB;
+},
+{
+glyphname = ohorndotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EE3;
+},
+{
+glyphname = ohorngrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 46, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDD;
+},
+{
+glyphname = ohornhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -4, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDF;
+},
+{
+glyphname = ohorntilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -10, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -18, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EE1;
+},
+{
+glyphname = ohungarumlaut;
+lastChange = "2022-01-26 09:45:27 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = o;
+},
+{
+alignment = -1;
+name = hungarumlaut;
+transform = "{1, 0, 0, 1, 130, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+alignment = -1;
+name = o;
+},
+{
+alignment = -1;
+name = hungarumlaut;
+transform = "{1, 0, 0, 1, 138, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 0151;
+},
+{
+glyphname = oinvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 114, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 118, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 020F;
+},
+{
+glyphname = omacron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 115, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 121, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 014D;
+},
+{
+glyphname = oogonek;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = o;
+},
+{
+alignment = -1;
+name = ogonek;
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+alignment = -1;
+name = o;
+},
+{
+alignment = -1;
+name = ogonek;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 01EB;
+},
+{
+glyphname = oslash;
+lastChange = "2016-08-19 16:44:19 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"117 -53 LINE",
+"504 483 LINE",
+"466 483 LINE",
+"79 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"117 -53 LINE",
+"504 483 LINE",
+"466 483 LINE",
+"79 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH"
+);
+}
+);
+width = 562;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"432 -13 OFFCURVE",
+"544 84 OFFCURVE",
+"544 224 CURVE SMOOTH",
+"544 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -13 OFFCURVE",
+"294 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"106 -53 LINE",
+"533 483 LINE",
+"475 483 LINE",
+"48 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 22 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 22 OFFCURVE",
+"294 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"106 -53 LINE",
+"533 483 LINE",
+"475 483 LINE",
+"48 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"432 -13 OFFCURVE",
+"544 84 OFFCURVE",
+"544 224 CURVE SMOOTH",
+"544 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -13 OFFCURVE",
+"294 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 22 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 22 OFFCURVE",
+"294 22 CURVE SMOOTH"
+);
+}
+);
+width = 589;
+}
+);
+unicode = 00F8;
+},
+{
+glyphname = oslashacute;
+lastChange = "2016-08-22 12:26:25 +0000";
+layers = (
+{
+components = (
+{
+name = oslash;
+},
+{
+name = acutecomb;
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = oslash;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -93, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+unicode = 01FF;
+},
+{
+glyphname = otilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -10, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -18, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F5;
+},
+{
+glyphname = oe;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH",
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH",
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"693 287 LINE",
+"482 287 LINE",
+"482 262 LINE",
+"809 262 LINE",
+"809 268 LINE SMOOTH",
+"809 382 OFFCURVE",
+"726 462 OFFCURVE",
+"618 462 CURVE SMOOTH",
+"480 462 OFFCURVE",
+"390 347 OFFCURVE",
+"390 225 CURVE SMOOTH",
+"390 103 OFFCURVE",
+"494 -12 OFFCURVE",
+"623 -12 CURVE SMOOTH",
+"714 -12 OFFCURVE",
+"785 45 OFFCURVE",
+"812 139 CURVE",
+"784 139 LINE",
+"748 50 OFFCURVE",
+"696 18 OFFCURVE",
+"626 18 CURVE SMOOTH",
+"547 18 OFFCURVE",
+"520 63 OFFCURVE",
+"520 225 CURVE SMOOTH",
+"520 383 OFFCURVE",
+"546 435 OFFCURVE",
+"613 435 CURVE SMOOTH",
+"666 435 OFFCURVE",
+"693 404 OFFCURVE",
+"693 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"714 -12 OFFCURVE",
+"785 45 OFFCURVE",
+"812 139 CURVE",
+"784 139 LINE",
+"748 50 OFFCURVE",
+"696 18 OFFCURVE",
+"626 18 CURVE SMOOTH",
+"547 18 OFFCURVE",
+"520 63 OFFCURVE",
+"520 225 CURVE SMOOTH",
+"520 383 OFFCURVE",
+"546 435 OFFCURVE",
+"613 435 CURVE SMOOTH",
+"666 435 OFFCURVE",
+"693 404 OFFCURVE",
+"693 344 CURVE SMOOTH",
+"693 287 LINE",
+"482 287 LINE",
+"482 262 LINE",
+"809 262 LINE",
+"809 268 LINE SMOOTH",
+"809 382 OFFCURVE",
+"726 462 OFFCURVE",
+"618 462 CURVE SMOOTH",
+"480 462 OFFCURVE",
+"390 347 OFFCURVE",
+"390 225 CURVE SMOOTH",
+"390 103 OFFCURVE",
+"494 -12 OFFCURVE",
+"623 -12 CURVE SMOOTH"
+);
+}
+);
+width = 854;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"45 84 OFFCURVE",
+"156 -12 OFFCURVE",
+"294 -12 CURVE SMOOTH",
+"432 -12 OFFCURVE",
+"540 84 OFFCURVE",
+"540 224 CURVE SMOOTH",
+"540 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 23 OFFCURVE",
+"294 23 CURVE SMOOTH",
+"224 23 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"702 283 LINE",
+"496 283 LINE",
+"496 253 LINE",
+"843 253 LINE",
+"843 264 LINE SMOOTH",
+"843 386 OFFCURVE",
+"752 462 OFFCURVE",
+"633 462 CURVE SMOOTH",
+"484 462 OFFCURVE",
+"393 344 OFFCURVE",
+"393 228 CURVE SMOOTH",
+"393 103 OFFCURVE",
+"499 -12 OFFCURVE",
+"639 -12 CURVE SMOOTH",
+"739 -12 OFFCURVE",
+"818 46 OFFCURVE",
+"846 138 CURVE",
+"813 138 LINE",
+"774 53 OFFCURVE",
+"714 23 OFFCURVE",
+"644 23 CURVE SMOOTH",
+"568 23 OFFCURVE",
+"544 60 OFFCURVE",
+"544 222 CURVE SMOOTH",
+"544 380 OFFCURVE",
+"567 430 OFFCURVE",
+"630 430 CURVE SMOOTH",
+"678 430 OFFCURVE",
+"702 401 OFFCURVE",
+"702 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"432 -12 OFFCURVE",
+"540 84 OFFCURVE",
+"540 224 CURVE SMOOTH",
+"540 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -12 OFFCURVE",
+"294 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 23 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 23 OFFCURVE",
+"294 23 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"739 -12 OFFCURVE",
+"818 46 OFFCURVE",
+"846 138 CURVE",
+"813 138 LINE",
+"774 53 OFFCURVE",
+"714 23 OFFCURVE",
+"644 23 CURVE SMOOTH",
+"568 23 OFFCURVE",
+"544 60 OFFCURVE",
+"544 222 CURVE SMOOTH",
+"544 380 OFFCURVE",
+"567 430 OFFCURVE",
+"630 430 CURVE SMOOTH",
+"678 430 OFFCURVE",
+"702 401 OFFCURVE",
+"702 344 CURVE SMOOTH",
+"702 283 LINE",
+"496 283 LINE",
+"496 253 LINE",
+"843 253 LINE",
+"843 264 LINE SMOOTH",
+"843 386 OFFCURVE",
+"752 462 OFFCURVE",
+"633 462 CURVE SMOOTH",
+"484 462 OFFCURVE",
+"393 344 OFFCURVE",
+"393 228 CURVE SMOOTH",
+"393 103 OFFCURVE",
+"499 -12 OFFCURVE",
+"639 -12 CURVE SMOOTH"
+);
+}
+);
+width = 881;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = e;
+unicode = 0153;
+},
+{
+glyphname = p;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{289, 0}";
+},
+{
+name = top;
+position = "{289, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 416 LINE",
+"189 416 LINE",
+"189 441 LINE",
+"0 441 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 -299 LINE",
+"189 -299 LINE",
+"189 425 LINE",
+"79 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"10 -314 LINE",
+"289 -314 LINE",
+"289 -289 LINE",
+"10 -289 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"243 22 OFFCURVE",
+"189 80 OFFCURVE",
+"189 210 CURVE",
+"169 58 LINE",
+"193 58 LINE",
+"215 18 OFFCURVE",
+"264 -12 OFFCURVE",
+"326 -12 CURVE SMOOTH",
+"426 -12 OFFCURVE",
+"520 78 OFFCURVE",
+"520 220 CURVE SMOOTH",
+"520 362 OFFCURVE",
+"427 452 OFFCURVE",
+"327 452 CURVE SMOOTH",
+"265 452 OFFCURVE",
+"215 422 OFFCURVE",
+"193 382 CURVE",
+"169 382 LINE",
+"189 230 LINE",
+"189 360 OFFCURVE",
+"242 418 OFFCURVE",
+"314 418 CURVE SMOOTH",
+"370 418 OFFCURVE",
+"392 384 OFFCURVE",
+"392 219 CURVE SMOOTH",
+"392 54 OFFCURVE",
+"371 22 OFFCURVE",
+"315 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"435 -12 OFFCURVE",
+"529 83 OFFCURVE",
+"529 225 CURVE SMOOTH",
+"529 367 OFFCURVE",
+"436 462 OFFCURVE",
+"336 462 CURVE SMOOTH",
+"274 462 OFFCURVE",
+"224 432 OFFCURVE",
+"202 392 CURVE",
+"178 392 LINE",
+"198 240 LINE",
+"198 370 OFFCURVE",
+"251 428 OFFCURVE",
+"323 428 CURVE SMOOTH",
+"379 428 OFFCURVE",
+"401 389 OFFCURVE",
+"401 224 CURVE SMOOTH",
+"401 59 OFFCURVE",
+"380 22 OFFCURVE",
+"324 22 CURVE SMOOTH",
+"252 22 OFFCURVE",
+"198 80 OFFCURVE",
+"198 210 CURVE",
+"178 58 LINE",
+"202 58 LINE",
+"224 18 OFFCURVE",
+"273 -12 OFFCURVE",
+"335 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 -314 LINE",
+"298 -289 LINE",
+"19 -289 LINE",
+"19 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 -299 LINE",
+"198 434 LINE",
+"88 434 LINE",
+"88 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 425 LINE",
+"198 450 LINE",
+"9 450 LINE",
+"9 425 LINE"
+);
+}
+);
+width = 578;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{318, 0}";
+},
+{
+name = top;
+position = "{318, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"26 -314 LINE",
+"330 -314 LINE",
+"330 -284 LINE",
+"26 -284 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 -298 LINE",
+"239 -298 LINE",
+"239 425 LINE",
+"101 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"239 410 LINE",
+"239 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"412 413 OFFCURVE",
+"430 371 OFFCURVE",
+"430 222 CURVE SMOOTH",
+"430 62 OFFCURVE",
+"409 26 OFFCURVE",
+"357 26 CURVE SMOOTH",
+"288 26 OFFCURVE",
+"239 91 OFFCURVE",
+"239 216 CURVE",
+"219 54 LINE",
+"243 54 LINE",
+"264 16 OFFCURVE",
+"301 -14 OFFCURVE",
+"365 -14 CURVE SMOOTH",
+"480 -14 OFFCURVE",
+"585 83 OFFCURVE",
+"585 223 CURVE SMOOTH",
+"585 361 OFFCURVE",
+"484 453 OFFCURVE",
+"376 453 CURVE SMOOTH",
+"312 453 OFFCURVE",
+"267 421 OFFCURVE",
+"243 378 CURVE",
+"219 378 LINE",
+"239 217 LINE",
+"239 345 OFFCURVE",
+"287 413 OFFCURVE",
+"357 413 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"486 -12 OFFCURVE",
+"585 83 OFFCURVE",
+"585 225 CURVE SMOOTH",
+"585 367 OFFCURVE",
+"487 462 OFFCURVE",
+"377 462 CURVE SMOOTH",
+"315 462 OFFCURVE",
+"265 432 OFFCURVE",
+"243 392 CURVE",
+"219 392 LINE",
+"239 240 LINE",
+"239 367 OFFCURVE",
+"288 423 OFFCURVE",
+"354 423 CURVE SMOOTH",
+"408 423 OFFCURVE",
+"430 385 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"430 64 OFFCURVE",
+"409 27 OFFCURVE",
+"355 27 CURVE SMOOTH",
+"289 27 OFFCURVE",
+"239 83 OFFCURVE",
+"239 210 CURVE",
+"219 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 -314 LINE",
+"339 -284 LINE",
+"27 -284 LINE",
+"27 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 -299 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 635;
+}
+);
+unicode = 0070;
+},
+{
+glyphname = thorn;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"430 -12 OFFCURVE",
+"524 83 OFFCURVE",
+"524 225 CURVE SMOOTH",
+"524 367 OFFCURVE",
+"431 462 OFFCURVE",
+"331 462 CURVE SMOOTH",
+"269 462 OFFCURVE",
+"219 432 OFFCURVE",
+"197 392 CURVE",
+"193 392 LINE",
+"193 754 LINE",
+"4 754 LINE",
+"4 729 LINE",
+"83 729 LINE",
+"83 -289 LINE",
+"15 -289 LINE",
+"15 -314 LINE",
+"294 -314 LINE",
+"294 -289 LINE",
+"193 -289 LINE",
+"193 58 LINE",
+"197 58 LINE",
+"219 18 OFFCURVE",
+"268 -12 OFFCURVE",
+"330 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"250 22 OFFCURVE",
+"193 77 OFFCURVE",
+"193 200 CURVE SMOOTH",
+"193 249 LINE SMOOTH",
+"193 372 OFFCURVE",
+"249 428 OFFCURVE",
+"318 428 CURVE SMOOTH",
+"374 428 OFFCURVE",
+"396 389 OFFCURVE",
+"396 224 CURVE SMOOTH",
+"396 59 OFFCURVE",
+"375 22 OFFCURVE",
+"319 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"294 -314 LINE",
+"294 -289 LINE",
+"193 -289 LINE",
+"193 58 LINE",
+"197 58 LINE",
+"219 18 OFFCURVE",
+"268 -12 OFFCURVE",
+"330 -12 CURVE SMOOTH",
+"430 -12 OFFCURVE",
+"524 83 OFFCURVE",
+"524 225 CURVE SMOOTH",
+"524 367 OFFCURVE",
+"431 462 OFFCURVE",
+"331 462 CURVE SMOOTH",
+"269 462 OFFCURVE",
+"219 432 OFFCURVE",
+"197 392 CURVE",
+"193 392 LINE",
+"193 754 LINE",
+"4 754 LINE",
+"4 729 LINE",
+"83 729 LINE",
+"83 -289 LINE",
+"15 -289 LINE",
+"15 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"250 22 OFFCURVE",
+"193 77 OFFCURVE",
+"193 200 CURVE SMOOTH",
+"193 249 LINE SMOOTH",
+"193 372 OFFCURVE",
+"249 428 OFFCURVE",
+"318 428 CURVE SMOOTH",
+"374 428 OFFCURVE",
+"396 389 OFFCURVE",
+"396 224 CURVE SMOOTH",
+"396 59 OFFCURVE",
+"375 22 OFFCURVE",
+"319 22 CURVE SMOOTH"
+);
+}
+);
+width = 570;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"486 -12 OFFCURVE",
+"585 83 OFFCURVE",
+"585 225 CURVE SMOOTH",
+"585 367 OFFCURVE",
+"487 462 OFFCURVE",
+"377 462 CURVE SMOOTH",
+"315 462 OFFCURVE",
+"265 432 OFFCURVE",
+"243 392 CURVE",
+"239 392 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"101 724 LINE",
+"101 -284 LINE",
+"26 -284 LINE",
+"26 -314 LINE",
+"330 -314 LINE",
+"330 -284 LINE",
+"239 -284 LINE",
+"239 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"288 27 OFFCURVE",
+"239 85 OFFCURVE",
+"239 210 CURVE SMOOTH",
+"239 249 LINE SMOOTH",
+"241 366 OFFCURVE",
+"288 423 OFFCURVE",
+"353 423 CURVE SMOOTH",
+"405 423 OFFCURVE",
+"430 386 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"430 63 OFFCURVE",
+"406 27 OFFCURVE",
+"354 27 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"330 -314 LINE",
+"330 -284 LINE",
+"239 -284 LINE",
+"239 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH",
+"486 -12 OFFCURVE",
+"585 83 OFFCURVE",
+"585 225 CURVE SMOOTH",
+"585 367 OFFCURVE",
+"487 462 OFFCURVE",
+"377 462 CURVE SMOOTH",
+"315 462 OFFCURVE",
+"265 432 OFFCURVE",
+"243 392 CURVE",
+"239 392 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"101 724 LINE",
+"101 -284 LINE",
+"26 -284 LINE",
+"26 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"288 27 OFFCURVE",
+"239 85 OFFCURVE",
+"239 210 CURVE SMOOTH",
+"239 249 LINE SMOOTH",
+"241 366 OFFCURVE",
+"288 423 OFFCURVE",
+"353 423 CURVE SMOOTH",
+"405 423 OFFCURVE",
+"430 386 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"430 63 OFFCURVE",
+"406 27 OFFCURVE",
+"354 27 CURVE SMOOTH"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 00FE;
+},
+{
+glyphname = q;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{289, 0}";
+},
+{
+name = top;
+position = "{289, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"554 441 LINE",
+"365 441 LINE",
+"365 416 LINE",
+"554 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"475 433 LINE",
+"365 433 LINE",
+"365 -299 LINE",
+"475 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"554 -289 LINE",
+"275 -289 LINE",
+"275 -314 LINE",
+"554 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 22 OFFCURVE",
+"162 62 OFFCURVE",
+"162 219 CURVE SMOOTH",
+"162 384 OFFCURVE",
+"183 419 OFFCURVE",
+"240 419 CURVE SMOOTH",
+"310 419 OFFCURVE",
+"365 366 OFFCURVE",
+"365 234 CURVE",
+"385 381 LINE",
+"361 381 LINE",
+"339 420 OFFCURVE",
+"296 454 OFFCURVE",
+"233 454 CURVE SMOOTH",
+"128 454 OFFCURVE",
+"34 355 OFFCURVE",
+"34 219 CURVE SMOOTH",
+"34 83 OFFCURVE",
+"129 -13 OFFCURVE",
+"232 -13 CURVE SMOOTH",
+"291 -13 OFFCURVE",
+"338 20 OFFCURVE",
+"361 62 CURVE",
+"385 62 LINE",
+"365 213 LINE",
+"365 88 OFFCURVE",
+"312 22 OFFCURVE",
+"238 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"306 -12 OFFCURVE",
+"355 18 OFFCURVE",
+"377 58 CURVE",
+"401 58 LINE",
+"381 210 LINE",
+"381 80 OFFCURVE",
+"327 22 OFFCURVE",
+"255 22 CURVE SMOOTH",
+"199 22 OFFCURVE",
+"178 59 OFFCURVE",
+"178 224 CURVE SMOOTH",
+"178 389 OFFCURVE",
+"200 428 OFFCURVE",
+"256 428 CURVE SMOOTH",
+"328 428 OFFCURVE",
+"381 370 OFFCURVE",
+"381 240 CURVE",
+"401 392 LINE",
+"377 392 LINE",
+"355 432 OFFCURVE",
+"305 462 OFFCURVE",
+"243 462 CURVE SMOOTH",
+"143 462 OFFCURVE",
+"50 367 OFFCURVE",
+"50 225 CURVE SMOOTH",
+"50 83 OFFCURVE",
+"144 -12 OFFCURVE",
+"244 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 -314 LINE",
+"570 -289 LINE",
+"291 -289 LINE",
+"291 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 -299 LINE",
+"491 442 LINE",
+"381 442 LINE",
+"381 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 425 LINE",
+"570 450 LINE",
+"381 450 LINE",
+"381 425 LINE"
+);
+}
+);
+width = 578;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{311, 0}";
+},
+{
+name = top;
+position = "{311, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"611 -284 LINE",
+"298 -284 LINE",
+"298 -314 LINE",
+"611 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 425 LINE",
+"392 425 LINE",
+"392 -298 LINE",
+"530 -298 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 440 LINE",
+"392 440 LINE",
+"392 410 LINE",
+"611 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 27 OFFCURVE",
+"200 69 OFFCURVE",
+"200 213 CURVE SMOOTH",
+"200 379 OFFCURVE",
+"224 414 OFFCURVE",
+"275 414 CURVE SMOOTH",
+"344 414 OFFCURVE",
+"392 349 OFFCURVE",
+"392 224 CURVE",
+"412 386 LINE",
+"388 386 LINE",
+"368 420 OFFCURVE",
+"321 454 OFFCURVE",
+"258 454 CURVE SMOOTH",
+"150 454 OFFCURVE",
+"45 354 OFFCURVE",
+"45 216 CURVE SMOOTH",
+"45 79 OFFCURVE",
+"145 -13 OFFCURVE",
+"253 -13 CURVE SMOOTH",
+"317 -13 OFFCURVE",
+"362 19 OFFCURVE",
+"387 62 CURVE",
+"411 62 LINE",
+"392 223 LINE",
+"391 95 OFFCURVE",
+"342 27 OFFCURVE",
+"272 27 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"317 -12 OFFCURVE",
+"366 18 OFFCURVE",
+"388 58 CURVE",
+"412 58 LINE",
+"392 210 LINE",
+"392 83 OFFCURVE",
+"342 27 OFFCURVE",
+"275 27 CURVE SMOOTH",
+"221 27 OFFCURVE",
+"200 64 OFFCURVE",
+"200 223 CURVE SMOOTH",
+"200 385 OFFCURVE",
+"222 423 OFFCURVE",
+"277 423 CURVE SMOOTH",
+"343 423 OFFCURVE",
+"392 367 OFFCURVE",
+"392 240 CURVE",
+"412 392 LINE",
+"388 392 LINE",
+"366 432 OFFCURVE",
+"316 462 OFFCURVE",
+"254 462 CURVE SMOOTH",
+"143 462 OFFCURVE",
+"45 367 OFFCURVE",
+"45 225 CURVE SMOOTH",
+"45 83 OFFCURVE",
+"144 -12 OFFCURVE",
+"255 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 -314 LINE",
+"611 -284 LINE",
+"297 -284 LINE",
+"297 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 -299 LINE",
+"530 442 LINE",
+"392 442 LINE",
+"392 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 420 LINE",
+"611 450 LINE",
+"392 450 LINE",
+"392 420 LINE"
+);
+}
+);
+width = 621;
+}
+);
+unicode = 0071;
+},
+{
+glyphname = r;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{216, 0}";
+},
+{
+name = top;
+position = "{216, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"28 425 LINE",
+"217 425 LINE",
+"217 450 LINE",
+"28 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"107 15 LINE",
+"217 15 LINE",
+"217 434 LINE",
+"107 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"28 0 LINE",
+"307 0 LINE",
+"307 25 LINE",
+"28 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 246 LINE",
+"217 331 OFFCURVE",
+"258 404 OFFCURVE",
+"285 404 CURVE SMOOTH",
+"295 404 OFFCURVE",
+"297 395 OFFCURVE",
+"297 385 CURVE SMOOTH",
+"299 348 OFFCURVE",
+"326 332 OFFCURVE",
+"355 332 CURVE SMOOTH",
+"384 332 OFFCURVE",
+"408 349 OFFCURVE",
+"408 391 CURVE SMOOTH",
+"408 436 OFFCURVE",
+"381 462 OFFCURVE",
+"339 462 CURVE SMOOTH",
+"302 462 OFFCURVE",
+"254 443 OFFCURVE",
+"221 371 CURVE",
+"206 371 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"307 0 LINE",
+"307 25 LINE",
+"217 25 LINE",
+"217 252 LINE SMOOTH",
+"217 335 OFFCURVE",
+"258 404 OFFCURVE",
+"285 404 CURVE SMOOTH",
+"298 404 OFFCURVE",
+"301 398 OFFCURVE",
+"301 391 CURVE SMOOTH",
+"301 384 OFFCURVE",
+"298 379 OFFCURVE",
+"298 371 CURVE SMOOTH",
+"298 346 OFFCURVE",
+"323 331 OFFCURVE",
+"348 331 CURVE SMOOTH",
+"378 331 OFFCURVE",
+"408 350 OFFCURVE",
+"408 391 CURVE SMOOTH",
+"408 436 OFFCURVE",
+"381 462 OFFCURVE",
+"339 462 CURVE SMOOTH",
+"302 462 OFFCURVE",
+"254 443 OFFCURVE",
+"221 371 CURVE",
+"217 371 LINE",
+"217 450 LINE",
+"28 450 LINE",
+"28 425 LINE",
+"107 425 LINE",
+"107 25 LINE",
+"28 25 LINE",
+"28 0 LINE"
+);
+}
+);
+width = 432;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"239 248 LINE",
+"239 330 OFFCURVE",
+"295 404 OFFCURVE",
+"329 404 CURVE SMOOTH",
+"335 404 OFFCURVE",
+"337 402 OFFCURVE",
+"337 399 CURVE SMOOTH",
+"337 392 OFFCURVE",
+"324 383 OFFCURVE",
+"324 356 CURVE SMOOTH",
+"324 311 OFFCURVE",
+"361 288 OFFCURVE",
+"400 288 CURVE SMOOTH",
+"442 288 OFFCURVE",
+"475 314 OFFCURVE",
+"475 371 CURVE SMOOTH",
+"475 429 OFFCURVE",
+"440 462 OFFCURVE",
+"379 462 CURVE SMOOTH",
+"340 462 OFFCURVE",
+"287 448 OFFCURVE",
+"243 373 CURVE",
+"228 373 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"239 30 LINE",
+"239 254 LINE SMOOTH",
+"239 333 OFFCURVE",
+"296 404 OFFCURVE",
+"329 404 CURVE SMOOTH",
+"335 404 OFFCURVE",
+"337 402 OFFCURVE",
+"337 399 CURVE SMOOTH",
+"337 392 OFFCURVE",
+"324 383 OFFCURVE",
+"324 356 CURVE SMOOTH",
+"324 311 OFFCURVE",
+"361 288 OFFCURVE",
+"400 288 CURVE SMOOTH",
+"442 288 OFFCURVE",
+"475 314 OFFCURVE",
+"475 371 CURVE SMOOTH",
+"475 429 OFFCURVE",
+"440 462 OFFCURVE",
+"379 462 CURVE SMOOTH",
+"340 462 OFFCURVE",
+"287 448 OFFCURVE",
+"243 373 CURVE",
+"239 373 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE",
+"101 420 LINE",
+"101 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+}
+);
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0072;
+},
+{
+glyphname = racute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -109, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -137, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0155;
+},
+{
+glyphname = rcaron;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 51, -9}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 63, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0159;
+},
+{
+glyphname = rcommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 130, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 160, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0157;
+},
+{
+glyphname = rdblgrave;
+lastChange = "2022-03-23 16:30:18 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, -41, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0211;
+},
+{
+glyphname = rdotbelow;
+lastChange = "2016-08-22 11:52:49 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -68, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -40, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 1E5B;
+},
+{
+glyphname = rinvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 49, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 76, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0213;
+},
+{
+glyphname = s;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{219, 0}";
+},
+{
+name = top;
+position = "{219, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"332 -12 OFFCURVE",
+"393 47 OFFCURVE",
+"393 139 CURVE SMOOTH",
+"393 229 OFFCURVE",
+"336 262 OFFCURVE",
+"235 285 CURVE SMOOTH",
+"135 307 OFFCURVE",
+"114 323 OFFCURVE",
+"114 356 CURVE SMOOTH",
+"114 400 OFFCURVE",
+"155 426 OFFCURVE",
+"219 426 CURVE SMOOTH",
+"291 426 OFFCURVE",
+"324 394 OFFCURVE",
+"339 320 CURVE SMOOTH",
+"342 305 LINE",
+"373 305 LINE",
+"373 450 LINE",
+"347 450 LINE",
+"336 417 LINE",
+"319 445 OFFCURVE",
+"274 462 OFFCURVE",
+"217 462 CURVE SMOOTH",
+"116 462 OFFCURVE",
+"59 410 OFFCURVE",
+"59 316 CURVE SMOOTH",
+"59 216 OFFCURVE",
+"122 188 OFFCURVE",
+"218 168 CURVE SMOOTH",
+"293 152 OFFCURVE",
+"338 143 OFFCURVE",
+"338 92 CURVE SMOOTH",
+"338 48 OFFCURVE",
+"304 24 OFFCURVE",
+"238 24 CURVE SMOOTH",
+"156 24 OFFCURVE",
+"109 62 OFFCURVE",
+"90 134 CURVE SMOOTH",
+"85 153 LINE",
+"53 153 LINE",
+"53 0 LINE",
+"82 0 LINE",
+"97 39 LINE",
+"129 8 OFFCURVE",
+"184 -12 OFFCURVE",
+"239 -12 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"332 -12 OFFCURVE",
+"393 47 OFFCURVE",
+"393 139 CURVE SMOOTH",
+"393 229 OFFCURVE",
+"336 262 OFFCURVE",
+"235 285 CURVE SMOOTH",
+"146 305 OFFCURVE",
+"124 323 OFFCURVE",
+"124 356 CURVE SMOOTH",
+"124 400 OFFCURVE",
+"155 426 OFFCURVE",
+"219 426 CURVE SMOOTH",
+"291 426 OFFCURVE",
+"324 394 OFFCURVE",
+"339 320 CURVE SMOOTH",
+"342 305 LINE",
+"373 305 LINE",
+"373 450 LINE",
+"347 450 LINE",
+"336 417 LINE",
+"319 445 OFFCURVE",
+"274 462 OFFCURVE",
+"217 462 CURVE SMOOTH",
+"116 462 OFFCURVE",
+"59 410 OFFCURVE",
+"59 316 CURVE SMOOTH",
+"59 216 OFFCURVE",
+"122 188 OFFCURVE",
+"218 168 CURVE SMOOTH",
+"293 152 OFFCURVE",
+"328 136 OFFCURVE",
+"328 92 CURVE SMOOTH",
+"328 48 OFFCURVE",
+"304 24 OFFCURVE",
+"238 24 CURVE SMOOTH",
+"156 24 OFFCURVE",
+"109 62 OFFCURVE",
+"90 134 CURVE SMOOTH",
+"85 153 LINE",
+"53 153 LINE",
+"53 0 LINE",
+"82 0 LINE",
+"97 39 LINE",
+"129 8 OFFCURVE",
+"184 -12 OFFCURVE",
+"239 -12 CURVE SMOOTH"
+);
+}
+);
+width = 438;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{215, 0}";
+},
+{
+name = top;
+position = "{215, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"328 -12 OFFCURVE",
+"393 43 OFFCURVE",
+"393 147 CURVE SMOOTH",
+"393 256 OFFCURVE",
+"322 280 OFFCURVE",
+"230 300 CURVE SMOOTH",
+"132 321 OFFCURVE",
+"104 328 OFFCURVE",
+"104 362 CURVE SMOOTH",
+"104 404 OFFCURVE",
+"147 426 OFFCURVE",
+"212 426 CURVE SMOOTH",
+"290 426 OFFCURVE",
+"324 394 OFFCURVE",
+"339 320 CURVE SMOOTH",
+"342 305 LINE",
+"373 305 LINE",
+"373 450 LINE",
+"347 450 LINE",
+"336 417 LINE",
+"319 445 OFFCURVE",
+"272 462 OFFCURVE",
+"212 462 CURVE SMOOTH",
+"108 462 OFFCURVE",
+"49 412 OFFCURVE",
+"49 309 CURVE SMOOTH",
+"49 198 OFFCURVE",
+"118 170 OFFCURVE",
+"213 151 CURVE SMOOTH",
+"308 132 OFFCURVE",
+"338 124 OFFCURVE",
+"338 88 CURVE SMOOTH",
+"338 48 OFFCURVE",
+"301 24 OFFCURVE",
+"231 24 CURVE SMOOTH",
+"134 24 OFFCURVE",
+"86 71 OFFCURVE",
+"73 134 CURVE SMOOTH",
+"67 163 LINE",
+"35 163 LINE",
+"35 0 LINE",
+"64 0 LINE",
+"79 39 LINE",
+"113 8 OFFCURVE",
+"170 -12 OFFCURVE",
+"229 -12 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"328 -12 OFFCURVE",
+"393 40 OFFCURVE",
+"393 144 CURVE SMOOTH",
+"393 243 OFFCURVE",
+"322 277 OFFCURVE",
+"230 297 CURVE SMOOTH",
+"136 317 OFFCURVE",
+"119 337 OFFCURVE",
+"119 367 CURVE SMOOTH",
+"119 402 OFFCURVE",
+"150 426 OFFCURVE",
+"212 426 CURVE SMOOTH",
+"290 426 OFFCURVE",
+"320 394 OFFCURVE",
+"335 320 CURVE SMOOTH",
+"338 305 LINE",
+"373 305 LINE",
+"373 450 LINE",
+"347 450 LINE",
+"336 417 LINE",
+"319 445 OFFCURVE",
+"272 462 OFFCURVE",
+"212 462 CURVE SMOOTH",
+"108 462 OFFCURVE",
+"49 409 OFFCURVE",
+"49 306 CURVE SMOOTH",
+"49 205 OFFCURVE",
+"118 170 OFFCURVE",
+"213 152 CURVE SMOOTH",
+"304 135 OFFCURVE",
+"324 114 OFFCURVE",
+"324 82 CURVE SMOOTH",
+"324 43 OFFCURVE",
+"294 24 OFFCURVE",
+"231 24 CURVE SMOOTH",
+"134 24 OFFCURVE",
+"87 71 OFFCURVE",
+"74 134 CURVE SMOOTH",
+"68 163 LINE",
+"35 163 LINE",
+"35 0 LINE",
+"64 0 LINE",
+"79 39 LINE",
+"113 8 OFFCURVE",
+"170 -12 OFFCURVE",
+"229 -12 CURVE SMOOTH"
+);
+}
+);
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 0073;
+},
+{
+glyphname = sacute;
+lastChange = "2016-08-22 11:52:49 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -106, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -175, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 015B;
+},
+{
+glyphname = scaron;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 54, -9}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 25, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 0161;
+},
+{
+glyphname = scedilla;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 114, 6}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 98, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 015F;
+},
+{
+glyphname = scircumflex;
+lastChange = "2016-08-22 11:52:49 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -71, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -81, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 015D;
+},
+{
+glyphname = scommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 133, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 122, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 0219;
+},
+{
+glyphname = sdotbelow;
+lastChange = "2016-08-22 11:52:49 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -65, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -78, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 1E63;
+},
+{
+glyphname = germandbls;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"435 -6 OFFCURVE",
+"526 80 OFFCURVE",
+"526 218 CURVE SMOOTH",
+"526 350 OFFCURVE",
+"443 427 OFFCURVE",
+"345 435 CURVE",
+"345 439 LINE",
+"418 457 OFFCURVE",
+"481 499 OFFCURVE",
+"481 596 CURVE SMOOTH",
+"481 704 OFFCURVE",
+"404 763 OFFCURVE",
+"288 763 CURVE SMOOTH",
+"157 763 OFFCURVE",
+"92 687 OFFCURVE",
+"92 550 CURVE SMOOTH",
+"92 25 LINE",
+"7 25 LINE",
+"7 0 LINE",
+"202 0 LINE",
+"202 615 LINE SMOOTH",
+"202 694 OFFCURVE",
+"220 736 OFFCURVE",
+"290 736 CURVE SMOOTH",
+"342 736 OFFCURVE",
+"371 714 OFFCURVE",
+"371 599 CURVE SMOOTH",
+"371 482 OFFCURVE",
+"341 448 OFFCURVE",
+"287 448 CURVE SMOOTH",
+"249 448 LINE",
+"249 422 LINE",
+"286 422 LINE SMOOTH",
+"360 422 OFFCURVE",
+"397 379 OFFCURVE",
+"397 216 CURVE SMOOTH",
+"397 59 OFFCURVE",
+"363 19 OFFCURVE",
+"336 19 CURVE SMOOTH",
+"325 19 OFFCURVE",
+"311 25 OFFCURVE",
+"311 35 CURVE SMOOTH",
+"311 49 OFFCURVE",
+"339 46 OFFCURVE",
+"339 80 CURVE SMOOTH",
+"339 111 OFFCURVE",
+"317 125 OFFCURVE",
+"291 125 CURVE SMOOTH",
+"259 125 OFFCURVE",
+"238 104 OFFCURVE",
+"238 72 CURVE SMOOTH",
+"238 29 OFFCURVE",
+"278 -6 OFFCURVE",
+"339 -6 CURVE SMOOTH"
+);
+}
+);
+width = 561;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"521 -6 OFFCURVE",
+"623 80 OFFCURVE",
+"623 221 CURVE SMOOTH",
+"623 345 OFFCURVE",
+"543 427 OFFCURVE",
+"442 435 CURVE",
+"442 439 LINE",
+"515 457 OFFCURVE",
+"578 500 OFFCURVE",
+"578 595 CURVE SMOOTH",
+"578 704 OFFCURVE",
+"495 763 OFFCURVE",
+"355 763 CURVE SMOOTH",
+"197 763 OFFCURVE",
+"115 687 OFFCURVE",
+"115 550 CURVE SMOOTH",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"273 0 LINE",
+"273 615 LINE SMOOTH",
+"273 693 OFFCURVE",
+"291 731 OFFCURVE",
+"362 731 CURVE SMOOTH",
+"413 731 OFFCURVE",
+"442 711 OFFCURVE",
+"442 599 CURVE SMOOTH",
+"442 484 OFFCURVE",
+"412 450 OFFCURVE",
+"358 450 CURVE SMOOTH",
+"320 450 LINE",
+"320 418 LINE",
+"357 418 LINE SMOOTH",
+"431 418 OFFCURVE",
+"468 375 OFFCURVE",
+"468 216 CURVE SMOOTH",
+"468 61 OFFCURVE",
+"434 24 OFFCURVE",
+"406 24 CURVE SMOOTH",
+"396 24 OFFCURVE",
+"382 29 OFFCURVE",
+"382 40 CURVE SMOOTH",
+"382 55 OFFCURVE",
+"410 60 OFFCURVE",
+"410 92 CURVE SMOOTH",
+"410 121 OFFCURVE",
+"388 135 OFFCURVE",
+"363 135 CURVE SMOOTH",
+"330 135 OFFCURVE",
+"309 112 OFFCURVE",
+"309 78 CURVE SMOOTH",
+"309 33 OFFCURVE",
+"345 -6 OFFCURVE",
+"416 -6 CURVE SMOOTH"
+);
+}
+);
+width = 669;
+}
+);
+unicode = 00DF;
+},
+{
+glyphname = t;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{177, 0}";
+},
+{
+name = center;
+position = "{177, 225}";
+},
+{
+name = top;
+position = "{177, 450}";
+},
+{
+name = topright;
+position = "{334, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"312 95 LINE",
+"287 48 OFFCURVE",
+"259 34 OFFCURVE",
+"232 34 CURVE SMOOTH",
+"206 34 OFFCURVE",
+"188 47 OFFCURVE",
+"188 79 CURVE SMOOTH",
+"188 603 LINE",
+"78 563 LINE",
+"78 62 LINE SMOOTH",
+"78 19 OFFCURVE",
+"119 -12 OFFCURVE",
+"187 -12 CURVE SMOOTH",
+"256 -12 OFFCURVE",
+"302 20 OFFCURVE",
+"332 84 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-3 425 LINE",
+"297 425 LINE",
+"297 450 LINE",
+"-3 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"263 -13 OFFCURVE",
+"301 12 OFFCURVE",
+"335 85 CURVE",
+"315 96 LINE",
+"289 51 OFFCURVE",
+"268 33 OFFCURVE",
+"240 33 CURVE SMOOTH",
+"215 33 OFFCURVE",
+"203 47 OFFCURVE",
+"203 78 CURVE SMOOTH",
+"203 424 LINE",
+"318 424 LINE",
+"318 449 LINE",
+"203 449 LINE",
+"203 622 LINE",
+"175 622 LINE",
+"142 532 OFFCURVE",
+"81 455 OFFCURVE",
+"12 449 CURVE",
+"12 424 LINE",
+"93 424 LINE",
+"93 71 LINE SMOOTH",
+"93 15 OFFCURVE",
+"126 -13 OFFCURVE",
+"196 -13 CURVE SMOOTH"
+);
+}
+);
+width = 354;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{177, 0}";
+},
+{
+name = center;
+position = "{177, 225}";
+},
+{
+name = top;
+position = "{177, 450}";
+},
+{
+name = topright;
+position = "{334, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"325 99 LINE",
+"305 64 OFFCURVE",
+"282 53 OFFCURVE",
+"260 53 CURVE SMOOTH",
+"244 53 OFFCURVE",
+"229 63 OFFCURVE",
+"229 88 CURVE SMOOTH",
+"229 563 LINE",
+"91 563 LINE",
+"91 61 LINE SMOOTH",
+"91 18 OFFCURVE",
+"132 -13 OFFCURVE",
+"200 -13 CURVE SMOOTH",
+"269 -13 OFFCURVE",
+"315 19 OFFCURVE",
+"345 83 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 416 LINE",
+"323 416 LINE",
+"323 441 LINE",
+"20 441 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"281 -13 OFFCURVE",
+"325 12 OFFCURVE",
+"361 85 CURVE",
+"337 99 LINE",
+"312 58 OFFCURVE",
+"294 43 OFFCURVE",
+"267 43 CURVE SMOOTH",
+"241 43 OFFCURVE",
+"229 57 OFFCURVE",
+"229 88 CURVE SMOOTH",
+"229 419 LINE",
+"344 419 LINE",
+"344 450 LINE",
+"229 450 LINE",
+"229 622 LINE",
+"188 622 LINE",
+"152 532 OFFCURVE",
+"85 456 OFFCURVE",
+"10 450 CURVE",
+"10 419 LINE",
+"91 419 LINE",
+"91 71 LINE SMOOTH",
+"91 16 OFFCURVE",
+"126 -13 OFFCURVE",
+"206 -13 CURVE SMOOTH"
+);
+}
+);
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 0074;
+},
+{
+glyphname = tbar;
+lastChange = "2016-08-22 12:27:05 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 367, 269}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, -77, 262}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+unicode = 0167;
+},
+{
+glyphname = tcaron;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = t;
+},
+{
+alignment = -1;
+name = caron.alt;
+transform = "{1, 0, 0, 1, 236, -10}";
+}
+);
+layerId = UUID0;
+width = 366;
+},
+{
+components = (
+{
+alignment = -1;
+name = t;
+},
+{
+alignment = -1;
+name = caron.alt;
+transform = "{1, 0, 0, 1, 265, 8}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 379;
+}
+);
+leftKerningGroup = t;
+unicode = 0165;
+},
+{
+glyphname = tcedilla;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 72, 6}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 60, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 0163;
+},
+{
+glyphname = tcommaaccent;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 91, 0}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 84, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 021B;
+},
+{
+glyphname = tdotbelow;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -107, 0}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -116, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 1E6D;
+},
+{
+glyphname = u;
+lastChange = "2016-08-22 09:33:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{285, 0}";
+},
+{
+name = ogonek;
+position = "{513, 10}";
+},
+{
+name = top;
+position = "{285, 450}";
+},
+{
+name = topright;
+position = "{517, 396}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 -12 OFFCURVE",
+"335 26 OFFCURVE",
+"364 78 CURVE",
+"388 78 LINE",
+"368 228 LINE",
+"368 114 OFFCURVE",
+"312 25 OFFCURVE",
+"251 25 CURVE SMOOTH",
+"216 25 OFFCURVE",
+"195 50 OFFCURVE",
+"195 100 CURVE SMOOTH",
+"195 435 LINE",
+"85 435 LINE",
+"85 97 LINE SMOOTH",
+"85 36 OFFCURVE",
+"139 -12 OFFCURVE",
+"216 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"368 25 LINE",
+"368 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 425 LINE",
+"195 450 LINE",
+"7 450 LINE",
+"7 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 16 LINE",
+"478 435 LINE",
+"368 435 LINE",
+"368 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 425 LINE",
+"478 450 LINE",
+"286 450 LINE",
+"286 425 LINE"
+);
+}
+);
+width = 570;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{307, 0}";
+},
+{
+name = ogonek;
+position = "{552, 10}";
+},
+{
+name = top;
+position = "{307, 450}";
+},
+{
+name = topright;
+position = "{453, 391}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE",
+"603 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 425 LINE",
+"386 425 LINE",
+"386 15 LINE",
+"524 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 440 LINE",
+"304 440 LINE",
+"304 410 LINE",
+"524 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 440 LINE",
+"10 440 LINE",
+"10 410 LINE",
+"226 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH",
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 425 LINE",
+"88 425 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 435 LINE",
+"88 435 LINE",
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 0 LINE",
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 420 LINE",
+"226 450 LINE",
+"10 450 LINE",
+"10 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 15 LINE",
+"524 435 LINE",
+"386 435 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 420 LINE",
+"524 450 LINE",
+"304 450 LINE",
+"304 420 LINE"
+);
+}
+);
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0075;
+},
+{
+glyphname = uacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -40, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -83, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 00FA;
+},
+{
+glyphname = ubreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -10, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 9, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 016D;
+},
+{
+glyphname = ucircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -5, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 00FB;
+},
+{
+glyphname = udblgrave;
+lastChange = "2022-03-23 16:30:18 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 32, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 13, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0215;
+},
+{
+glyphname = udieresis;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 131, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 145, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 00FC;
+},
+{
+glyphname = udotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 1, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 14, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE5;
+},
+{
+glyphname = ugrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -2, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 58, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 00F9;
+},
+{
+glyphname = uhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = hookabovecomb;
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE7;
+},
+{
+glyphname = uhorn;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 205, -54}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 254, -59}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 01B0;
+},
+{
+glyphname = uhornacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -40, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -83, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE9;
+},
+{
+glyphname = uhorndotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 1, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 14, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EF1;
+},
+{
+glyphname = uhorngrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -2, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 58, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EEB;
+},
+{
+glyphname = uhornhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = hookabovecomb;
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EED;
+},
+{
+glyphname = uhorntilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EEF;
+},
+{
+glyphname = uhungarumlaut;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = u;
+},
+{
+alignment = -1;
+name = hungarumlaut;
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+alignment = -1;
+name = u;
+},
+{
+alignment = -1;
+name = hungarumlaut;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0171;
+},
+{
+glyphname = uinvertedbreve;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 118, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 130, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0217;
+},
+{
+glyphname = umacron;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 133, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 016B;
+},
+{
+glyphname = uogonek;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = u;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 290, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+alignment = -1;
+name = u;
+},
+{
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 322, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0173;
+},
+{
+glyphname = uring;
+lastChange = "2021-12-17 13:37:21 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = u;
+},
+{
+alignment = -1;
+name = ring;
+transform = "{1, 0, 0, 1, 164, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+alignment = -1;
+name = u;
+},
+{
+alignment = -1;
+name = ring;
+transform = "{1, 0, 0, 1, 184, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 016F;
+},
+{
+glyphname = utilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0169;
+},
+{
+glyphname = v;
+lastChange = "2016-10-31 10:00:08 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{249, 0}";
+},
+{
+name = top;
+position = "{249, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"231 425 LINE",
+"231 450 LINE",
+"-13 450 LINE",
+"-13 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"506 425 LINE",
+"506 450 LINE",
+"327 450 LINE",
+"327 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"294 135 LINE",
+"289 135 LINE",
+"162 447 LINE",
+"41 441 LINE",
+"241 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"270 -12 LINE",
+"435 433 LINE",
+"399 433 LINE",
+"241 -12 LINE"
+);
+}
+);
+width = 498;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{246, 0}";
+},
+{
+name = top;
+position = "{246, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-15 411 LINE",
+"253 411 LINE",
+"253 441 LINE",
+"-15 441 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 -13 LINE",
+"309 167 LINE",
+"304 167 LINE",
+"187 431 LINE",
+"31 431 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 411 LINE",
+"511 411 LINE",
+"511 441 LINE",
+"323 441 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 -13 LINE",
+"263 -13 LINE",
+"450 423 LINE",
+"414 423 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"253 420 LINE",
+"253 450 LINE",
+"-15 450 LINE",
+"-15 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 420 LINE",
+"511 450 LINE",
+"323 450 LINE",
+"323 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"309 167 LINE",
+"304 167 LINE",
+"187 440 LINE",
+"31 440 LINE",
+"234 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 -13 LINE",
+"450 432 LINE",
+"414 432 LINE",
+"234 -13 LINE"
+);
+}
+);
+width = 491;
+}
+);
+unicode = 0076;
+},
+{
+glyphname = w;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{343, 0}";
+},
+{
+name = top;
+position = "{343, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-12 425 LINE",
+"230 425 LINE",
+"230 450 LINE",
+"-12 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 -12 LINE",
+"233 -12 LINE",
+"407 450 LINE",
+"369 450 LINE",
+"265 156 LINE",
+"261 156 LINE",
+"166 446 LINE",
+"45 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 293 LINE",
+"353 293 LINE",
+"461 -12 LINE",
+"490 -12 LINE",
+"650 450 LINE",
+"614 450 LINE",
+"517 156 LINE",
+"513 156 LINE",
+"407 450 LINE",
+"338 334 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 425 LINE",
+"713 425 LINE",
+"713 450 LINE",
+"532 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"233 -12 LINE",
+"348 295 LINE",
+"352 295 LINE",
+"461 -12 LINE",
+"490 -12 LINE",
+"641 425 LINE",
+"713 425 LINE",
+"713 450 LINE",
+"532 450 LINE",
+"532 425 LINE",
+"606 425 LINE",
+"517 156 LINE",
+"513 156 LINE",
+"407 450 LINE",
+"369 450 LINE",
+"265 156 LINE",
+"261 156 LINE",
+"173 425 LINE",
+"230 425 LINE",
+"230 450 LINE",
+"-12 450 LINE",
+"-12 425 LINE",
+"50 425 LINE",
+"204 -12 LINE"
+);
+}
+);
+width = 686;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{345, 0}";
+},
+{
+name = top;
+position = "{345, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-15 420 LINE",
+"253 420 LINE",
+"253 450 LINE",
+"-15 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 -13 LINE",
+"280 187 LINE",
+"275 187 LINE",
+"187 441 LINE",
+"31 441 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 -13 LINE",
+"234 -13 LINE",
+"411 450 LINE",
+"375 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"522 420 LINE",
+"710 420 LINE",
+"710 450 LINE",
+"522 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"458 -13 LINE",
+"487 -13 LINE",
+"642 433 LINE",
+"606 433 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"458 -13 LINE",
+"526 187 LINE",
+"521 187 LINE",
+"411 450 LINE",
+"340 266 LINE",
+"344 266 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"234 -13 LINE",
+"340 266 LINE",
+"344 266 LINE",
+"458 -13 LINE",
+"487 -13 LINE",
+"637 420 LINE",
+"710 420 LINE",
+"710 450 LINE",
+"522 450 LINE",
+"522 420 LINE",
+"601 420 LINE",
+"524 187 LINE",
+"520 187 LINE",
+"411 450 LINE",
+"375 450 LINE",
+"278 187 LINE",
+"274 187 LINE",
+"194 420 LINE",
+"253 420 LINE",
+"253 450 LINE",
+"-15 450 LINE",
+"-15 420 LINE",
+"39 420 LINE",
+"205 -13 LINE"
+);
+}
+);
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 0077;
+},
+{
+glyphname = wacute;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = w;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 18, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = w;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -45, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 1E83;
+},
+{
+glyphname = wcircumflex;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = w;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 53, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = w;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 49, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 0175;
+},
+{
+glyphname = wdieresis;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = w;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 189, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = w;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 183, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 1E85;
+},
+{
+glyphname = wgrave;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = w;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 56, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = w;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 96, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 1E81;
+},
+{
+glyphname = x;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"477 15 LINE",
+"166 440 LINE",
+"33 440 LINE",
+"340 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 0 LINE",
+"189 25 LINE",
+"-9 25 LINE",
+"-9 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"103 18 LINE",
+"235 202 LINE",
+"217 226 LINE",
+"67 18 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"522 0 LINE",
+"522 25 LINE",
+"274 25 LINE",
+"274 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"237 425 LINE",
+"237 450 LINE",
+"-11 450 LINE",
+"-11 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 432 LINE",
+"380 432 LINE",
+"248 249 LINE",
+"269 228 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 425 LINE",
+"497 450 LINE",
+"309 450 LINE",
+"309 425 LINE"
+);
+}
+);
+width = 506;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{289, 0}";
+},
+{
+name = top;
+position = "{289, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"350 410 LINE",
+"538 410 LINE",
+"538 440 LINE",
+"350 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"277 243 LINE",
+"298 222 LINE",
+"479 421 LINE",
+"443 421 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 30 LINE",
+"7 30 LINE",
+"7 0 LINE",
+"205 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 177 LINE",
+"238 201 LINE",
+"68 18 LINE",
+"104 18 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"5 410 LINE",
+"283 410 LINE",
+"283 440 LINE",
+"5 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 0 LINE",
+"573 0 LINE",
+"573 30 LINE",
+"285 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 15 LINE",
+"531 15 LINE",
+"212 430 LINE",
+"39 430 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"531 15 LINE",
+"222 440 LINE",
+"49 440 LINE",
+"361 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 0 LINE",
+"205 30 LINE",
+"7 30 LINE",
+"7 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"104 18 LINE",
+"266 182 LINE",
+"248 206 LINE",
+"68 18 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"573 0 LINE",
+"573 30 LINE",
+"285 30 LINE",
+"285 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 420 LINE",
+"293 450 LINE",
+"15 450 LINE",
+"15 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 431 LINE",
+"463 431 LINE",
+"287 248 LINE",
+"308 227 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 420 LINE",
+"558 450 LINE",
+"370 450 LINE",
+"370 420 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 0078;
+},
+{
+glyphname = y;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{243, 0}";
+},
+{
+name = top;
+position = "{243, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-11 425 LINE",
+"237 425 LINE",
+"237 450 LINE",
+"-11 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 15 LINE",
+"303 124 LINE",
+"162 446 LINE",
+"41 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"309 425 LINE",
+"497 425 LINE",
+"497 450 LINE",
+"309 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 -228 LINE SMOOTH",
+"145 -240 OFFCURVE",
+"139 -251 OFFCURVE",
+"129 -251 CURVE SMOOTH",
+"110 -251 OFFCURVE",
+"103 -213 OFFCURVE",
+"63 -213 CURVE SMOOTH",
+"34 -213 OFFCURVE",
+"12 -234 OFFCURVE",
+"12 -266 CURVE SMOOTH",
+"12 -291 OFFCURVE",
+"26 -326 OFFCURVE",
+"76 -326 CURVE SMOOTH",
+"112 -326 OFFCURVE",
+"148 -306 OFFCURVE",
+"182 -216 CURVE SMOOTH",
+"422 432 LINE",
+"386 432 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"112 -326 OFFCURVE",
+"148 -306 OFFCURVE",
+"182 -216 CURVE SMOOTH",
+"422 432 LINE",
+"386 432 LINE",
+"149 -228 LINE SMOOTH",
+"145 -240 OFFCURVE",
+"139 -251 OFFCURVE",
+"129 -251 CURVE SMOOTH",
+"110 -251 OFFCURVE",
+"103 -213 OFFCURVE",
+"63 -213 CURVE SMOOTH",
+"34 -213 OFFCURVE",
+"12 -234 OFFCURVE",
+"12 -266 CURVE SMOOTH",
+"12 -291 OFFCURVE",
+"26 -326 OFFCURVE",
+"76 -326 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"291 159 LINE",
+"285 159 LINE",
+"162 446 LINE",
+"41 440 LINE",
+"238 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"237 425 LINE",
+"237 450 LINE",
+"-11 450 LINE",
+"-11 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 425 LINE",
+"497 450 LINE",
+"309 450 LINE",
+"309 425 LINE"
+);
+}
+);
+width = 486;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{251, 0}";
+},
+{
+name = top;
+position = "{251, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-15 410 LINE",
+"253 410 LINE",
+"253 440 LINE",
+"-15 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"244 -3 LINE",
+"314 176 LINE",
+"309 176 LINE",
+"187 430 LINE",
+"28 430 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 410 LINE",
+"511 410 LINE",
+"511 440 LINE",
+"323 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 -205 LINE SMOOTH",
+"148 -223 OFFCURVE",
+"142 -230 OFFCURVE",
+"131 -230 CURVE SMOOTH",
+"104 -230 OFFCURVE",
+"99 -190 OFFCURVE",
+"54 -190 CURVE SMOOTH",
+"19 -190 OFFCURVE",
+"-7 -215 OFFCURVE",
+"-7 -252 CURVE SMOOTH",
+"-7 -283 OFFCURVE",
+"11 -323 OFFCURVE",
+"70 -323 CURVE SMOOTH",
+"109 -323 OFFCURVE",
+"146 -306 OFFCURVE",
+"181 -223 CURVE SMOOTH",
+"456 423 LINE",
+"415 423 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"109 -323 OFFCURVE",
+"147 -305 OFFCURVE",
+"181 -223 CURVE SMOOTH",
+"456 433 LINE",
+"415 433 LINE",
+"156 -205 LINE SMOOTH",
+"148 -223 OFFCURVE",
+"142 -230 OFFCURVE",
+"131 -230 CURVE SMOOTH",
+"104 -230 OFFCURVE",
+"99 -190 OFFCURVE",
+"54 -190 CURVE SMOOTH",
+"19 -190 OFFCURVE",
+"-7 -215 OFFCURVE",
+"-7 -252 CURVE SMOOTH",
+"-7 -283 OFFCURVE",
+"11 -323 OFFCURVE",
+"70 -323 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"313 176 LINE",
+"308 176 LINE",
+"187 440 LINE",
+"28 440 LINE",
+"244 -3 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 420 LINE",
+"276 450 LINE",
+"-15 450 LINE",
+"-15 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 420 LINE",
+"511 450 LINE",
+"336 450 LINE",
+"336 420 LINE"
+);
+}
+);
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 0079;
+},
+{
+glyphname = yacute;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -82, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -139, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 00FD;
+},
+{
+glyphname = ycircumflex;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -47, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -45, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 0177;
+},
+{
+glyphname = ydieresis;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 89, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 89, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 00FF;
+},
+{
+glyphname = ydotbelow;
+lastChange = "2016-08-22 12:28:30 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+alignment = -1;
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 41, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+alignment = -1;
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 81, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF5;
+},
+{
+glyphname = ygrave;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF3;
+},
+{
+glyphname = yhookabove;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -33, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF7;
+},
+{
+glyphname = ytilde;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -48, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -62, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF9;
+},
+{
+glyphname = z;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{240, 0}";
+},
+{
+name = top;
+position = "{240, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"161 15 LINE",
+"422 415 LINE",
+"408 440 LINE",
+"314 440 LINE",
+"46 35 LINE",
+"49 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"431 0 LINE",
+"431 185 LINE",
+"406 185 LINE",
+"405 169 LINE SMOOTH",
+"401 73 OFFCURVE",
+"342 25 OFFCURVE",
+"268 25 CURVE SMOOTH",
+"54 25 LINE",
+"46 35 LINE",
+"46 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"93 275 LINE",
+"95 357 OFFCURVE",
+"144 425 OFFCURVE",
+"231 425 CURVE SMOOTH",
+"414 425 LINE",
+"422 415 LINE",
+"422 450 LINE",
+"68 450 LINE",
+"68 275 LINE"
+);
+}
+);
+width = 480;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{238, 0}";
+},
+{
+name = top;
+position = "{238, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"446 406 LINE",
+"432 431 LINE",
+"303 431 LINE",
+"25 35 LINE",
+"28 15 LINE",
+"175 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"57 265 LINE",
+"87 265 LINE",
+"89 344 OFFCURVE",
+"138 410 OFFCURVE",
+"225 410 CURVE SMOOTH",
+"438 410 LINE",
+"446 406 LINE",
+"446 440 LINE",
+"57 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 185 LINE",
+"410 185 LINE",
+"409 169 LINE SMOOTH",
+"405 76 OFFCURVE",
+"346 30 OFFCURVE",
+"272 30 CURVE SMOOTH",
+"33 30 LINE",
+"25 35 LINE",
+"25 0 LINE",
+"440 0 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"175 15 LINE",
+"446 416 LINE",
+"432 441 LINE",
+"303 441 LINE",
+"25 35 LINE",
+"28 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 0 LINE",
+"440 185 LINE",
+"410 185 LINE",
+"409 169 LINE SMOOTH",
+"405 76 OFFCURVE",
+"346 30 OFFCURVE",
+"272 30 CURVE SMOOTH",
+"33 30 LINE",
+"25 35 LINE",
+"25 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 275 LINE",
+"89 354 OFFCURVE",
+"138 420 OFFCURVE",
+"225 420 CURVE SMOOTH",
+"438 420 LINE",
+"446 416 LINE",
+"446 450 LINE",
+"57 450 LINE",
+"57 275 LINE"
+);
+}
+);
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 007A;
+},
+{
+glyphname = zacute;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = z;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -85, 0}";
+}
+);
+layerId = UUID0;
+width = 480;
+},
+{
+components = (
+{
+name = z;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -152, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 017A;
+},
+{
+glyphname = zcaron;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = z;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 75, -9}";
+}
+);
+layerId = UUID0;
+width = 480;
+},
+{
+components = (
+{
+name = z;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 48, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 017E;
+},
+{
+glyphname = zdotaccent;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = z;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 166, -3}";
+}
+);
+layerId = UUID0;
+width = 480;
+},
+{
+components = (
+{
+name = z;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 150, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 017C;
+},
+{
+glyphname = zdotbelow;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = z;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = UUID0;
+width = 480;
+},
+{
+components = (
+{
+name = z;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -55, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 1E93;
+},
+{
+glyphname = odotbelow.001;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+},
+{
+glyphname = f_f;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 585 LINE SMOOTH",
+"226 671 OFFCURVE",
+"242 705 OFFCURVE",
+"282 705 CURVE SMOOTH",
+"298 705 OFFCURVE",
+"305 700 OFFCURVE",
+"305 688 CURVE SMOOTH",
+"305 671 OFFCURVE",
+"291 665 OFFCURVE",
+"291 641 CURVE SMOOTH",
+"291 613 OFFCURVE",
+"311 594 OFFCURVE",
+"341 594 CURVE SMOOTH",
+"374 594 OFFCURVE",
+"397 617 OFFCURVE",
+"397 652 CURVE SMOOTH",
+"397 700 OFFCURVE",
+"355 732 OFFCURVE",
+"287 732 CURVE SMOOTH",
+"171 732 OFFCURVE",
+"116 639 OFFCURVE",
+"116 445 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 0 LINE",
+"510 0 LINE",
+"510 618 LINE SMOOTH",
+"510 704 OFFCURVE",
+"526 738 OFFCURVE",
+"566 738 CURVE SMOOTH",
+"582 738 OFFCURVE",
+"589 733 OFFCURVE",
+"589 721 CURVE SMOOTH",
+"589 704 OFFCURVE",
+"575 698 OFFCURVE",
+"575 674 CURVE SMOOTH",
+"575 646 OFFCURVE",
+"595 627 OFFCURVE",
+"625 627 CURVE SMOOTH",
+"658 627 OFFCURVE",
+"681 650 OFFCURVE",
+"681 685 CURVE SMOOTH",
+"681 733 OFFCURVE",
+"639 765 OFFCURVE",
+"571 765 CURVE SMOOTH",
+"455 765 OFFCURVE",
+"400 672 OFFCURVE",
+"400 478 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"289 0 LINE",
+"289 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 0 LINE",
+"623 0 LINE",
+"623 25 LINE",
+"343 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"633 425 LINE",
+"633 450 LINE",
+"19 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"510 0 LINE",
+"510 618 LINE SMOOTH",
+"510 704 OFFCURVE",
+"526 738 OFFCURVE",
+"566 738 CURVE SMOOTH",
+"582 738 OFFCURVE",
+"589 733 OFFCURVE",
+"589 721 CURVE SMOOTH",
+"589 704 OFFCURVE",
+"575 698 OFFCURVE",
+"575 674 CURVE SMOOTH",
+"575 646 OFFCURVE",
+"595 627 OFFCURVE",
+"625 627 CURVE SMOOTH",
+"658 627 OFFCURVE",
+"681 650 OFFCURVE",
+"681 685 CURVE SMOOTH",
+"681 733 OFFCURVE",
+"639 765 OFFCURVE",
+"571 765 CURVE SMOOTH",
+"455 765 OFFCURVE",
+"400 672 OFFCURVE",
+"400 478 CURVE SMOOTH",
+"400 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"289 0 LINE",
+"289 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"623 0 LINE",
+"623 25 LINE",
+"343 25 LINE",
+"343 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 585 LINE SMOOTH",
+"226 671 OFFCURVE",
+"242 705 OFFCURVE",
+"282 705 CURVE SMOOTH",
+"298 705 OFFCURVE",
+"305 700 OFFCURVE",
+"305 688 CURVE SMOOTH",
+"305 671 OFFCURVE",
+"291 665 OFFCURVE",
+"291 641 CURVE SMOOTH",
+"291 613 OFFCURVE",
+"311 594 OFFCURVE",
+"341 594 CURVE SMOOTH",
+"374 594 OFFCURVE",
+"397 617 OFFCURVE",
+"397 652 CURVE SMOOTH",
+"397 700 OFFCURVE",
+"355 732 OFFCURVE",
+"287 732 CURVE SMOOTH",
+"171 732 OFFCURVE",
+"116 639 OFFCURVE",
+"116 445 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 425 LINE",
+"633 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+}
+);
+width = 646;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"553 0 LINE",
+"553 629 LINE SMOOTH",
+"553 712 OFFCURVE",
+"588 734 OFFCURVE",
+"629 734 CURVE SMOOTH",
+"652 734 OFFCURVE",
+"662 727 OFFCURVE",
+"662 715 CURVE SMOOTH",
+"662 697 OFFCURVE",
+"638 693 OFFCURVE",
+"638 659 CURVE SMOOTH",
+"638 621 OFFCURVE",
+"667 603 OFFCURVE",
+"699 603 CURVE SMOOTH",
+"739 603 OFFCURVE",
+"768 630 OFFCURVE",
+"768 670 CURVE SMOOTH",
+"768 722 OFFCURVE",
+"717 766 OFFCURVE",
+"635 766 CURVE SMOOTH",
+"500 766 OFFCURVE",
+"415 649 OFFCURVE",
+"415 479 CURVE SMOOTH",
+"415 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"314 0 LINE",
+"314 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"338 0 LINE",
+"654 0 LINE",
+"654 30 LINE",
+"338 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"661 420 LINE",
+"661 450 LINE",
+"20 450 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"553 0 LINE",
+"553 629 LINE SMOOTH",
+"553 712 OFFCURVE",
+"588 734 OFFCURVE",
+"629 734 CURVE SMOOTH",
+"652 734 OFFCURVE",
+"662 727 OFFCURVE",
+"662 715 CURVE SMOOTH",
+"662 697 OFFCURVE",
+"638 693 OFFCURVE",
+"638 659 CURVE SMOOTH",
+"638 621 OFFCURVE",
+"667 603 OFFCURVE",
+"699 603 CURVE SMOOTH",
+"739 603 OFFCURVE",
+"768 630 OFFCURVE",
+"768 670 CURVE SMOOTH",
+"768 722 OFFCURVE",
+"717 766 OFFCURVE",
+"635 766 CURVE SMOOTH",
+"500 766 OFFCURVE",
+"415 649 OFFCURVE",
+"415 479 CURVE SMOOTH",
+"415 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"314 0 LINE",
+"314 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"654 0 LINE",
+"654 30 LINE",
+"338 30 LINE",
+"338 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"661 420 LINE",
+"661 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 658;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = f;
+},
+{
+glyphname = f_f_i;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 10 LINE",
+"226 10 LINE",
+"226 565 LINE SMOOTH",
+"226 666 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"314 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 680 CURVE SMOOTH",
+"325 660 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 606 OFFCURVE",
+"417 643 CURVE SMOOTH",
+"417 695 OFFCURVE",
+"372 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"299 0 LINE",
+"299 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"791 425 LINE",
+"791 450 LINE",
+"19 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 10 LINE",
+"510 10 LINE",
+"510 588 LINE SMOOTH",
+"510 696 OFFCURVE",
+"541 738 OFFCURVE",
+"618 738 CURVE SMOOTH",
+"658 738 OFFCURVE",
+"679 727 OFFCURVE",
+"679 703 CURVE SMOOTH",
+"679 683 OFFCURVE",
+"665 678 OFFCURVE",
+"665 654 CURVE SMOOTH",
+"665 626 OFFCURVE",
+"685 607 OFFCURVE",
+"715 607 CURVE SMOOTH",
+"748 607 OFFCURVE",
+"771 630 OFFCURVE",
+"771 666 CURVE SMOOTH",
+"771 724 OFFCURVE",
+"713 765 OFFCURVE",
+"622 765 CURVE SMOOTH",
+"479 765 OFFCURVE",
+"400 663 OFFCURVE",
+"400 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"333 0 LINE",
+"574 0 LINE",
+"574 25 LINE",
+"333 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"681 15 LINE",
+"791 15 LINE",
+"791 435 LINE",
+"681 435 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"612 0 LINE",
+"871 0 LINE",
+"871 25 LINE",
+"612 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"510 10 LINE",
+"510 588 LINE SMOOTH",
+"510 696 OFFCURVE",
+"541 738 OFFCURVE",
+"618 738 CURVE SMOOTH",
+"658 738 OFFCURVE",
+"679 727 OFFCURVE",
+"679 703 CURVE SMOOTH",
+"679 683 OFFCURVE",
+"665 678 OFFCURVE",
+"665 654 CURVE SMOOTH",
+"665 626 OFFCURVE",
+"685 607 OFFCURVE",
+"715 607 CURVE SMOOTH",
+"748 607 OFFCURVE",
+"771 630 OFFCURVE",
+"771 666 CURVE SMOOTH",
+"771 724 OFFCURVE",
+"713 765 OFFCURVE",
+"622 765 CURVE SMOOTH",
+"479 765 OFFCURVE",
+"400 663 OFFCURVE",
+"400 448 CURVE SMOOTH",
+"400 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"299 0 LINE",
+"299 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 0 LINE",
+"574 25 LINE",
+"333 25 LINE",
+"333 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 10 LINE",
+"226 565 LINE SMOOTH",
+"226 666 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"314 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 680 CURVE SMOOTH",
+"325 660 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 606 OFFCURVE",
+"417 643 CURVE SMOOTH",
+"417 695 OFFCURVE",
+"372 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH",
+"116 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"871 0 LINE",
+"871 25 LINE",
+"612 25 LINE",
+"612 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 425 LINE",
+"791 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 15 LINE",
+"791 435 LINE",
+"681 435 LINE",
+"681 15 LINE"
+);
+}
+);
+width = 897;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"103 10 LINE",
+"241 10 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"312 0 LINE",
+"312 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 10 LINE",
+"553 10 LINE",
+"553 609 LINE SMOOTH",
+"553 709 OFFCURVE",
+"603 734 OFFCURVE",
+"660 734 CURVE SMOOTH",
+"700 734 OFFCURVE",
+"719 722 OFFCURVE",
+"719 703 CURVE SMOOTH",
+"719 683 OFFCURVE",
+"698 680 OFFCURVE",
+"698 647 CURVE SMOOTH",
+"698 608 OFFCURVE",
+"727 590 OFFCURVE",
+"759 590 CURVE SMOOTH",
+"799 590 OFFCURVE",
+"828 617 OFFCURVE",
+"828 657 CURVE SMOOTH",
+"828 717 OFFCURVE",
+"765 766 OFFCURVE",
+"665 766 CURVE SMOOTH",
+"512 766 OFFCURVE",
+"415 649 OFFCURVE",
+"415 479 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 0 LINE",
+"618 0 LINE",
+"618 30 LINE",
+"341 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"845 420 LINE",
+"845 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"707 15 LINE",
+"845 15 LINE",
+"845 434 LINE",
+"707 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"650 0 LINE",
+"910 0 LINE",
+"910 30 LINE",
+"650 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"553 10 LINE",
+"553 609 LINE SMOOTH",
+"553 709 OFFCURVE",
+"603 734 OFFCURVE",
+"660 734 CURVE SMOOTH",
+"700 734 OFFCURVE",
+"719 722 OFFCURVE",
+"719 703 CURVE SMOOTH",
+"719 683 OFFCURVE",
+"698 680 OFFCURVE",
+"698 647 CURVE SMOOTH",
+"698 608 OFFCURVE",
+"727 590 OFFCURVE",
+"759 590 CURVE SMOOTH",
+"799 590 OFFCURVE",
+"828 617 OFFCURVE",
+"828 657 CURVE SMOOTH",
+"828 717 OFFCURVE",
+"765 766 OFFCURVE",
+"665 766 CURVE SMOOTH",
+"512 766 OFFCURVE",
+"415 649 OFFCURVE",
+"415 479 CURVE SMOOTH",
+"415 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 0 LINE",
+"312 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"618 0 LINE",
+"618 30 LINE",
+"341 30 LINE",
+"341 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 10 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"910 0 LINE",
+"910 30 LINE",
+"650 30 LINE",
+"650 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"845 420 LINE",
+"845 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"845 15 LINE",
+"845 434 LINE",
+"707 434 LINE",
+"707 15 LINE"
+);
+}
+);
+width = 925;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = i;
+},
+{
+glyphname = f_f_l;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 565 LINE SMOOTH",
+"226 665 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"315 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 678 CURVE SMOOTH",
+"325 661 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 607 OFFCURVE",
+"417 642 CURVE SMOOTH",
+"417 696 OFFCURVE",
+"371 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 0 LINE",
+"510 0 LINE",
+"510 588 LINE SMOOTH",
+"510 695 OFFCURVE",
+"538 738 OFFCURVE",
+"606 738 CURVE SMOOTH",
+"641 738 OFFCURVE",
+"659 727 OFFCURVE",
+"659 703 CURVE SMOOTH",
+"659 682 OFFCURVE",
+"645 679 OFFCURVE",
+"645 655 CURVE SMOOTH",
+"645 626 OFFCURVE",
+"665 607 OFFCURVE",
+"695 607 CURVE SMOOTH",
+"728 607 OFFCURVE",
+"751 629 OFFCURVE",
+"751 667 CURVE SMOOTH",
+"751 724 OFFCURVE",
+"697 765 OFFCURVE",
+"612 765 CURVE SMOOTH",
+"477 765 OFFCURVE",
+"400 663 OFFCURVE",
+"400 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"681 15 LINE",
+"791 15 LINE",
+"791 766 LINE",
+"681 718 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"633 425 LINE",
+"633 450 LINE",
+"19 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"304 0 LINE",
+"304 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"581 0 LINE",
+"581 25 LINE",
+"318 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 0 LINE",
+"871 0 LINE",
+"871 25 LINE",
+"600 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"510 0 LINE",
+"510 588 LINE SMOOTH",
+"510 695 OFFCURVE",
+"538 738 OFFCURVE",
+"606 738 CURVE SMOOTH",
+"641 738 OFFCURVE",
+"659 727 OFFCURVE",
+"659 703 CURVE SMOOTH",
+"659 682 OFFCURVE",
+"645 679 OFFCURVE",
+"645 655 CURVE SMOOTH",
+"645 626 OFFCURVE",
+"665 607 OFFCURVE",
+"695 607 CURVE SMOOTH",
+"728 607 OFFCURVE",
+"751 629 OFFCURVE",
+"751 667 CURVE SMOOTH",
+"751 724 OFFCURVE",
+"697 765 OFFCURVE",
+"612 765 CURVE SMOOTH",
+"477 765 OFFCURVE",
+"400 663 OFFCURVE",
+"400 448 CURVE SMOOTH",
+"400 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"581 0 LINE",
+"581 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 565 LINE SMOOTH",
+"226 665 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"315 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 678 CURVE SMOOTH",
+"325 661 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 607 OFFCURVE",
+"417 642 CURVE SMOOTH",
+"417 696 OFFCURVE",
+"371 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"871 0 LINE",
+"871 25 LINE",
+"600 25 LINE",
+"600 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 425 LINE",
+"633 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 15 LINE",
+"791 766 LINE",
+"681 718 LINE",
+"681 15 LINE"
+);
+}
+);
+width = 885;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"103 0 LINE",
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"312 0 LINE",
+"312 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 0 LINE",
+"551 0 LINE",
+"551 628 LINE SMOOTH",
+"551 711 OFFCURVE",
+"591 733 OFFCURVE",
+"637 733 CURVE SMOOTH",
+"667 733 OFFCURVE",
+"680 726 OFFCURVE",
+"680 714 CURVE SMOOTH",
+"680 696 OFFCURVE",
+"656 692 OFFCURVE",
+"656 658 CURVE SMOOTH",
+"656 620 OFFCURVE",
+"685 602 OFFCURVE",
+"717 602 CURVE SMOOTH",
+"757 602 OFFCURVE",
+"786 629 OFFCURVE",
+"786 669 CURVE SMOOTH",
+"786 721 OFFCURVE",
+"731 765 OFFCURVE",
+"643 765 CURVE SMOOTH",
+"502 765 OFFCURVE",
+"413 648 OFFCURVE",
+"413 478 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"333 0 LINE",
+"624 0 LINE",
+"624 30 LINE",
+"333 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"791 420 LINE",
+"791 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"716 15 LINE",
+"854 15 LINE",
+"854 754 LINE",
+"716 730 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"645 0 LINE",
+"929 0 LINE",
+"929 30 LINE",
+"645 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"551 0 LINE",
+"551 628 LINE SMOOTH",
+"551 711 OFFCURVE",
+"591 733 OFFCURVE",
+"637 733 CURVE SMOOTH",
+"667 733 OFFCURVE",
+"680 726 OFFCURVE",
+"680 714 CURVE SMOOTH",
+"680 696 OFFCURVE",
+"656 692 OFFCURVE",
+"656 658 CURVE SMOOTH",
+"656 620 OFFCURVE",
+"685 602 OFFCURVE",
+"717 602 CURVE SMOOTH",
+"757 602 OFFCURVE",
+"786 629 OFFCURVE",
+"786 669 CURVE SMOOTH",
+"786 721 OFFCURVE",
+"731 765 OFFCURVE",
+"643 765 CURVE SMOOTH",
+"502 765 OFFCURVE",
+"413 648 OFFCURVE",
+"413 478 CURVE SMOOTH",
+"413 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 0 LINE",
+"312 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"624 0 LINE",
+"624 30 LINE",
+"333 30 LINE",
+"333 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"929 0 LINE",
+"929 30 LINE",
+"645 30 LINE",
+"645 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 420 LINE",
+"791 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"854 15 LINE",
+"854 754 LINE",
+"716 730 LINE",
+"716 15 LINE"
+);
+}
+);
+width = 944;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = l;
+},
+{
+glyphname = f_i;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 588 LINE SMOOTH",
+"226 696 OFFCURVE",
+"257 738 OFFCURVE",
+"334 738 CURVE SMOOTH",
+"374 738 OFFCURVE",
+"395 727 OFFCURVE",
+"395 703 CURVE SMOOTH",
+"395 683 OFFCURVE",
+"381 678 OFFCURVE",
+"381 654 CURVE SMOOTH",
+"381 626 OFFCURVE",
+"401 607 OFFCURVE",
+"431 607 CURVE SMOOTH",
+"464 607 OFFCURVE",
+"487 630 OFFCURVE",
+"487 666 CURVE SMOOTH",
+"487 724 OFFCURVE",
+"429 765 OFFCURVE",
+"338 765 CURVE SMOOTH",
+"195 765 OFFCURVE",
+"116 663 OFFCURVE",
+"116 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"280 0 LINE",
+"280 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"507 425 LINE",
+"507 450 LINE",
+"19 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"397 15 LINE",
+"507 15 LINE",
+"507 435 LINE",
+"397 435 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"587 0 LINE",
+"587 25 LINE",
+"318 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 588 LINE SMOOTH",
+"226 696 OFFCURVE",
+"257 738 OFFCURVE",
+"334 738 CURVE SMOOTH",
+"374 738 OFFCURVE",
+"395 727 OFFCURVE",
+"395 703 CURVE SMOOTH",
+"395 683 OFFCURVE",
+"381 678 OFFCURVE",
+"381 654 CURVE SMOOTH",
+"381 626 OFFCURVE",
+"401 607 OFFCURVE",
+"431 607 CURVE SMOOTH",
+"464 607 OFFCURVE",
+"487 630 OFFCURVE",
+"487 666 CURVE SMOOTH",
+"487 724 OFFCURVE",
+"429 765 OFFCURVE",
+"338 765 CURVE SMOOTH",
+"195 765 OFFCURVE",
+"116 663 OFFCURVE",
+"116 448 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 0 LINE",
+"280 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 0 LINE",
+"587 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 15 LINE",
+"507 435 LINE",
+"397 435 LINE",
+"397 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 425 LINE",
+"507 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+}
+);
+width = 613;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 609 LINE SMOOTH",
+"241 709 OFFCURVE",
+"291 734 OFFCURVE",
+"348 734 CURVE SMOOTH",
+"388 734 OFFCURVE",
+"407 722 OFFCURVE",
+"407 703 CURVE SMOOTH",
+"407 683 OFFCURVE",
+"386 680 OFFCURVE",
+"386 647 CURVE SMOOTH",
+"386 608 OFFCURVE",
+"415 590 OFFCURVE",
+"447 590 CURVE SMOOTH",
+"487 590 OFFCURVE",
+"516 617 OFFCURVE",
+"516 657 CURVE SMOOTH",
+"516 717 OFFCURVE",
+"453 766 OFFCURVE",
+"353 766 CURVE SMOOTH",
+"200 766 OFFCURVE",
+"103 649 OFFCURVE",
+"103 479 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"302 0 LINE",
+"302 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"533 420 LINE",
+"533 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"395 15 LINE",
+"533 15 LINE",
+"533 434 LINE",
+"395 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"334 0 LINE",
+"598 0 LINE",
+"598 30 LINE",
+"334 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"241 10 LINE",
+"241 609 LINE SMOOTH",
+"241 709 OFFCURVE",
+"291 734 OFFCURVE",
+"348 734 CURVE SMOOTH",
+"388 734 OFFCURVE",
+"407 722 OFFCURVE",
+"407 703 CURVE SMOOTH",
+"407 683 OFFCURVE",
+"386 680 OFFCURVE",
+"386 647 CURVE SMOOTH",
+"386 608 OFFCURVE",
+"415 590 OFFCURVE",
+"447 590 CURVE SMOOTH",
+"487 590 OFFCURVE",
+"516 617 OFFCURVE",
+"516 657 CURVE SMOOTH",
+"516 717 OFFCURVE",
+"453 766 OFFCURVE",
+"353 766 CURVE SMOOTH",
+"200 766 OFFCURVE",
+"103 649 OFFCURVE",
+"103 479 CURVE SMOOTH",
+"103 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"302 0 LINE",
+"302 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"598 0 LINE",
+"598 30 LINE",
+"334 30 LINE",
+"334 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 15 LINE",
+"533 434 LINE",
+"395 434 LINE",
+"395 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 420 LINE",
+"533 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 613;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = i;
+},
+{
+glyphname = f_l;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 588 LINE SMOOTH",
+"226 695 OFFCURVE",
+"254 738 OFFCURVE",
+"322 738 CURVE SMOOTH",
+"357 738 OFFCURVE",
+"375 727 OFFCURVE",
+"375 703 CURVE SMOOTH",
+"375 682 OFFCURVE",
+"361 679 OFFCURVE",
+"361 655 CURVE SMOOTH",
+"361 626 OFFCURVE",
+"381 607 OFFCURVE",
+"411 607 CURVE SMOOTH",
+"444 607 OFFCURVE",
+"467 629 OFFCURVE",
+"467 667 CURVE SMOOTH",
+"467 724 OFFCURVE",
+"413 765 OFFCURVE",
+"328 765 CURVE SMOOTH",
+"193 765 OFFCURVE",
+"116 663 OFFCURVE",
+"116 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"280 0 LINE",
+"280 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"349 425 LINE",
+"349 450 LINE",
+"19 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"397 15 LINE",
+"507 15 LINE",
+"507 766 LINE",
+"397 718 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"587 0 LINE",
+"587 25 LINE",
+"318 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 588 LINE SMOOTH",
+"226 695 OFFCURVE",
+"254 738 OFFCURVE",
+"322 738 CURVE SMOOTH",
+"357 738 OFFCURVE",
+"375 727 OFFCURVE",
+"375 703 CURVE SMOOTH",
+"375 682 OFFCURVE",
+"361 679 OFFCURVE",
+"361 655 CURVE SMOOTH",
+"361 626 OFFCURVE",
+"381 607 OFFCURVE",
+"411 607 CURVE SMOOTH",
+"444 607 OFFCURVE",
+"467 629 OFFCURVE",
+"467 667 CURVE SMOOTH",
+"467 724 OFFCURVE",
+"413 765 OFFCURVE",
+"328 765 CURVE SMOOTH",
+"193 765 OFFCURVE",
+"116 663 OFFCURVE",
+"116 448 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 0 LINE",
+"280 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 0 LINE",
+"587 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 425 LINE",
+"349 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 15 LINE",
+"507 766 LINE",
+"397 718 LINE",
+"397 15 LINE"
+);
+}
+);
+width = 601;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 576 LINE SMOOTH",
+"241 700 OFFCURVE",
+"286 731 OFFCURVE",
+"340 731 CURVE SMOOTH",
+"371 731 OFFCURVE",
+"385 724 OFFCURVE",
+"385 711 CURVE SMOOTH",
+"385 695 OFFCURVE",
+"361 689 OFFCURVE",
+"361 656 CURVE SMOOTH",
+"361 618 OFFCURVE",
+"392 600 OFFCURVE",
+"426 600 CURVE SMOOTH",
+"467 600 OFFCURVE",
+"496 627 OFFCURVE",
+"496 665 CURVE SMOOTH",
+"496 719 OFFCURVE",
+"437 763 OFFCURVE",
+"345 763 CURVE SMOOTH",
+"195 763 OFFCURVE",
+"103 646 OFFCURVE",
+"103 476 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"29 0 LINE",
+"312 0 LINE",
+"312 30 LINE",
+"29 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"429 410 LINE",
+"429 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"406 15 LINE",
+"544 15 LINE",
+"544 754 LINE",
+"406 730 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"335 0 LINE",
+"619 0 LINE",
+"619 30 LINE",
+"335 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 628 LINE SMOOTH",
+"241 711 OFFCURVE",
+"281 733 OFFCURVE",
+"327 733 CURVE SMOOTH",
+"357 733 OFFCURVE",
+"370 726 OFFCURVE",
+"370 714 CURVE SMOOTH",
+"370 696 OFFCURVE",
+"346 692 OFFCURVE",
+"346 658 CURVE SMOOTH",
+"346 620 OFFCURVE",
+"375 602 OFFCURVE",
+"407 602 CURVE SMOOTH",
+"447 602 OFFCURVE",
+"476 629 OFFCURVE",
+"476 669 CURVE SMOOTH",
+"476 721 OFFCURVE",
+"421 765 OFFCURVE",
+"333 765 CURVE SMOOTH",
+"192 765 OFFCURVE",
+"103 648 OFFCURVE",
+"103 478 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"314 0 LINE",
+"314 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"619 0 LINE",
+"619 30 LINE",
+"335 30 LINE",
+"335 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"481 420 LINE",
+"481 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"544 15 LINE",
+"544 754 LINE",
+"406 730 LINE",
+"406 15 LINE"
+);
+}
+);
+width = 634;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = l;
+},
+{
+glyphname = ordfeminine;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"133 458 OFFCURVE",
+"174 478 OFFCURVE",
+"191 507 CURVE",
+"195 507 LINE",
+"201 478 OFFCURVE",
+"220 458 OFFCURVE",
+"251 458 CURVE SMOOTH",
+"278 458 OFFCURVE",
+"300 469 OFFCURVE",
+"321 492 CURVE",
+"308 509 LINE",
+"300 499 OFFCURVE",
+"295 497 OFFCURVE",
+"289 497 CURVE SMOOTH",
+"282 497 OFFCURVE",
+"274 501 OFFCURVE",
+"274 510 CURVE SMOOTH",
+"274 691 LINE SMOOTH",
+"274 735 OFFCURVE",
+"228 764 OFFCURVE",
+"157 764 CURVE SMOOTH",
+"81 764 OFFCURVE",
+"36 725 OFFCURVE",
+"36 685 CURVE SMOOTH",
+"36 667 OFFCURVE",
+"49 651 OFFCURVE",
+"71 651 CURVE SMOOTH",
+"90 651 OFFCURVE",
+"107 663 OFFCURVE",
+"107 683 CURVE SMOOTH",
+"107 697 OFFCURVE",
+"98 702 OFFCURVE",
+"98 711 CURVE SMOOTH",
+"98 723 OFFCURVE",
+"113 735 OFFCURVE",
+"143 735 CURVE SMOOTH",
+"174 735 OFFCURVE",
+"191 727 OFFCURVE",
+"191 712 CURVE SMOOTH",
+"191 634 LINE",
+"74 634 OFFCURVE",
+"15 590 OFFCURVE",
+"15 532 CURVE SMOOTH",
+"15 486 OFFCURVE",
+"50 458 OFFCURVE",
+"95 458 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"116 505 OFFCURVE",
+"101 521 OFFCURVE",
+"101 550 CURVE SMOOTH",
+"101 584 OFFCURVE",
+"126 607 OFFCURVE",
+"191 607 CURVE",
+"191 563 LINE SMOOTH",
+"191 524 OFFCURVE",
+"166 505 OFFCURVE",
+"140 505 CURVE SMOOTH"
+);
+}
+);
+width = 336;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"131 458 OFFCURVE",
+"170 478 OFFCURVE",
+"186 507 CURVE",
+"190 507 LINE",
+"197 478 OFFCURVE",
+"217 458 OFFCURVE",
+"251 458 CURVE SMOOTH",
+"280 458 OFFCURVE",
+"303 469 OFFCURVE",
+"326 492 CURVE",
+"313 514 LINE",
+"305 504 OFFCURVE",
+"300 502 OFFCURVE",
+"294 502 CURVE SMOOTH",
+"287 502 OFFCURVE",
+"279 505 OFFCURVE",
+"279 515 CURVE SMOOTH",
+"279 691 LINE SMOOTH",
+"279 735 OFFCURVE",
+"231 764 OFFCURVE",
+"157 764 CURVE SMOOTH",
+"78 764 OFFCURVE",
+"31 725 OFFCURVE",
+"31 685 CURVE SMOOTH",
+"31 664 OFFCURVE",
+"46 646 OFFCURVE",
+"71 646 CURVE SMOOTH",
+"93 646 OFFCURVE",
+"112 660 OFFCURVE",
+"112 683 CURVE SMOOTH",
+"112 697 OFFCURVE",
+"103 702 OFFCURVE",
+"103 711 CURVE SMOOTH",
+"103 723 OFFCURVE",
+"116 735 OFFCURVE",
+"143 735 CURVE SMOOTH",
+"171 735 OFFCURVE",
+"186 727 OFFCURVE",
+"186 712 CURVE SMOOTH",
+"186 634 LINE",
+"69 634 OFFCURVE",
+"10 590 OFFCURVE",
+"10 532 CURVE SMOOTH",
+"10 486 OFFCURVE",
+"47 458 OFFCURVE",
+"95 458 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"121 505 OFFCURVE",
+"106 521 OFFCURVE",
+"106 550 CURVE SMOOTH",
+"106 584 OFFCURVE",
+"129 607 OFFCURVE",
+"186 607 CURVE",
+"186 563 LINE SMOOTH",
+"186 524 OFFCURVE",
+"165 505 OFFCURVE",
+"145 505 CURVE SMOOTH"
+);
+}
+);
+width = 336;
+}
+);
+unicode = 00AA;
+},
+{
+glyphname = ordmasculine;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"254 457 OFFCURVE",
+"323 533 OFFCURVE",
+"323 611 CURVE SMOOTH",
+"323 688 OFFCURVE",
+"254 764 OFFCURVE",
+"168 764 CURVE SMOOTH",
+"83 764 OFFCURVE",
+"15 688 OFFCURVE",
+"15 611 CURVE SMOOTH",
+"15 533 OFFCURVE",
+"83 457 OFFCURVE",
+"168 457 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"125 487 OFFCURVE",
+"110 509 OFFCURVE",
+"110 611 CURVE SMOOTH",
+"110 712 OFFCURVE",
+"125 735 OFFCURVE",
+"168 735 CURVE SMOOTH",
+"212 735 OFFCURVE",
+"227 712 OFFCURVE",
+"227 611 CURVE SMOOTH",
+"227 509 OFFCURVE",
+"212 487 OFFCURVE",
+"168 487 CURVE SMOOTH"
+);
+}
+);
+width = 338;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"257 457 OFFCURVE",
+"328 533 OFFCURVE",
+"328 611 CURVE SMOOTH",
+"328 688 OFFCURVE",
+"257 764 OFFCURVE",
+"168 764 CURVE SMOOTH",
+"80 764 OFFCURVE",
+"10 688 OFFCURVE",
+"10 611 CURVE SMOOTH",
+"10 533 OFFCURVE",
+"80 457 OFFCURVE",
+"168 457 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"129 487 OFFCURVE",
+"115 509 OFFCURVE",
+"115 611 CURVE SMOOTH",
+"115 712 OFFCURVE",
+"129 735 OFFCURVE",
+"168 735 CURVE SMOOTH",
+"208 735 OFFCURVE",
+"222 712 OFFCURVE",
+"222 611 CURVE SMOOTH",
+"222 509 OFFCURVE",
+"208 487 OFFCURVE",
+"168 487 CURVE SMOOTH"
+);
+}
+);
+width = 338;
+}
+);
+unicode = 00BA;
+},
+{
+glyphname = Delta;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"645 0 LINE",
+"645 37 LINE",
+"363 729 LINE",
+"306 715 LINE",
+"35 37 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 570 LINE",
+"482 37 LINE",
+"71 37 LINE"
+);
+}
+);
+width = 680;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"689 0 LINE",
+"689 43 LINE",
+"392 733 LINE",
+"322 716 LINE",
+"37 43 LINE",
+"37 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 527 LINE",
+"495 73 LINE",
+"119 73 LINE"
+);
+}
+);
+width = 727;
+}
+);
+unicode = 0394;
+},
+{
+glyphname = Omega;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"332 0 LINE",
+"342 23 LINE",
+"254 156 OFFCURVE",
+"219 257 OFFCURVE",
+"219 412 CURVE SMOOTH",
+"219 636 OFFCURVE",
+"292 702 OFFCURVE",
+"377 702 CURVE SMOOTH",
+"468 702 OFFCURVE",
+"542 625 OFFCURVE",
+"542 408 CURVE SMOOTH",
+"542 267 OFFCURVE",
+"511 160 OFFCURVE",
+"418 23 CURVE",
+"427 0 LINE",
+"698 0 LINE",
+"727 174 LINE",
+"704 174 LINE",
+"683 109 OFFCURVE",
+"669 95 OFFCURVE",
+"627 95 CURVE SMOOTH",
+"505 95 LINE",
+"604 187 OFFCURVE",
+"691 269 OFFCURVE",
+"691 421 CURVE SMOOTH",
+"691 607 OFFCURVE",
+"562 733 OFFCURVE",
+"384 733 CURVE SMOOTH",
+"205 733 OFFCURVE",
+"69 606 OFFCURVE",
+"69 412 CURVE SMOOTH",
+"69 249 OFFCURVE",
+"165 165 OFFCURVE",
+"248 96 CURVE",
+"141 96 LINE SMOOTH",
+"97 96 OFFCURVE",
+"81 112 OFFCURVE",
+"59 174 CURVE",
+"35 174 LINE",
+"60 0 LINE"
+);
+}
+);
+width = 762;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"353 0 LINE",
+"363 26 LINE",
+"314 132 OFFCURVE",
+"251 268 OFFCURVE",
+"251 399 CURVE SMOOTH",
+"251 626 OFFCURVE",
+"311 694 OFFCURVE",
+"403 694 CURVE SMOOTH",
+"494 694 OFFCURVE",
+"560 615 OFFCURVE",
+"560 402 CURVE SMOOTH",
+"560 267 OFFCURVE",
+"488 123 OFFCURVE",
+"446 26 CURVE",
+"456 0 LINE",
+"744 0 LINE",
+"776 189 LINE",
+"735 189 LINE",
+"712 127 OFFCURVE",
+"697 116 OFFCURVE",
+"653 116 CURVE SMOOTH",
+"540 116 LINE",
+"632 188 OFFCURVE",
+"739 274 OFFCURVE",
+"739 414 CURVE SMOOTH",
+"739 612 OFFCURVE",
+"603 733 OFFCURVE",
+"407 733 CURVE SMOOTH",
+"214 733 OFFCURVE",
+"71 609 OFFCURVE",
+"71 408 CURVE SMOOTH",
+"71 253 OFFCURVE",
+"183 171 OFFCURVE",
+"262 116 CURVE",
+"164 116 LINE SMOOTH",
+"115 116 OFFCURVE",
+"99 128 OFFCURVE",
+"75 189 CURVE",
+"36 189 LINE",
+"63 0 LINE"
+);
+}
+);
+width = 812;
+}
+);
+unicode = 03A9;
+},
+{
+glyphname = mu;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"541 25 LINE",
+"352 25 LINE",
+"352 0 LINE",
+"541 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 426 LINE",
+"352 426 LINE",
+"352 16 LINE",
+"462 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 441 LINE",
+"270 441 LINE",
+"270 416 LINE",
+"462 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"179 441 LINE",
+"-9 441 LINE",
+"-9 416 LINE",
+"179 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"69 99 LINE SMOOTH",
+"69 38 OFFCURVE",
+"123 -10 OFFCURVE",
+"200 -10 CURVE SMOOTH",
+"274 -10 OFFCURVE",
+"319 28 OFFCURVE",
+"348 80 CURVE",
+"372 80 LINE",
+"352 230 LINE",
+"352 116 OFFCURVE",
+"296 27 OFFCURVE",
+"235 27 CURVE SMOOTH",
+"200 27 OFFCURVE",
+"179 52 OFFCURVE",
+"179 102 CURVE SMOOTH",
+"179 426 LINE",
+"69 426 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"69 101 LINE",
+"64 -72 OFFCURVE",
+"35 -124 OFFCURVE",
+"35 -190 CURVE SMOOTH",
+"35 -230 OFFCURVE",
+"51 -254 OFFCURVE",
+"86 -254 CURVE SMOOTH",
+"122 -254 OFFCURVE",
+"139 -227 OFFCURVE",
+"139 -188 CURVE SMOOTH",
+"139 -140 OFFCURVE",
+"103 -103 OFFCURVE",
+"95 28 CURVE",
+"99 28 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 -12 OFFCURVE",
+"335 26 OFFCURVE",
+"364 78 CURVE",
+"388 78 LINE",
+"368 228 LINE",
+"368 114 OFFCURVE",
+"312 25 OFFCURVE",
+"251 25 CURVE SMOOTH",
+"216 25 OFFCURVE",
+"195 50 OFFCURVE",
+"195 100 CURVE SMOOTH",
+"195 435 LINE",
+"85 435 LINE",
+"85 97 LINE SMOOTH",
+"85 36 OFFCURVE",
+"139 -12 OFFCURVE",
+"216 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 -254 OFFCURVE",
+"153 -227 OFFCURVE",
+"153 -188 CURVE SMOOTH",
+"153 -140 OFFCURVE",
+"117 -103 OFFCURVE",
+"109 28 CURVE",
+"113 28 LINE",
+"85 101 LINE",
+"80 -72 OFFCURVE",
+"49 -124 OFFCURVE",
+"49 -190 CURVE SMOOTH",
+"49 -230 OFFCURVE",
+"65 -254 OFFCURVE",
+"100 -254 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"368 25 LINE",
+"368 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 425 LINE",
+"195 450 LINE",
+"7 450 LINE",
+"7 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 16 LINE",
+"478 435 LINE",
+"368 435 LINE",
+"368 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 425 LINE",
+"478 450 LINE",
+"286 450 LINE",
+"286 425 LINE"
+);
+}
+);
+width = 570;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE",
+"603 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 425 LINE",
+"386 425 LINE",
+"386 15 LINE",
+"524 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 440 LINE",
+"304 440 LINE",
+"304 410 LINE",
+"524 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 440 LINE",
+"10 440 LINE",
+"10 410 LINE",
+"226 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH",
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 425 LINE",
+"88 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH",
+"153 -277 OFFCURVE",
+"178 -246 OFFCURVE",
+"178 -203 CURVE SMOOTH",
+"178 -152 OFFCURVE",
+"152 -119 OFFCURVE",
+"134 10 CURVE",
+"138 10 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 435 LINE",
+"88 435 LINE",
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"153 -277 OFFCURVE",
+"178 -246 OFFCURVE",
+"178 -203 CURVE SMOOTH",
+"178 -152 OFFCURVE",
+"152 -119 OFFCURVE",
+"134 10 CURVE",
+"138 10 LINE",
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 0 LINE",
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 420 LINE",
+"226 450 LINE",
+"10 450 LINE",
+"10 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 15 LINE",
+"524 435 LINE",
+"386 435 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 420 LINE",
+"524 450 LINE",
+"304 450 LINE",
+"304 420 LINE"
+);
+}
+);
+width = 613;
+}
+);
+unicode = 03BC;
+},
+{
+glyphname = pi;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 -12 OFFCURVE",
+"126 -5 OFFCURVE",
+"151 6 CURVE",
+"168 29 OFFCURVE",
+"220 117 OFFCURVE",
+"220 365 CURVE SMOOTH",
+"220 377 LINE",
+"353 377 LINE",
+"350 331 OFFCURVE",
+"343 218 OFFCURVE",
+"343 155 CURVE SMOOTH",
+"343 40 OFFCURVE",
+"366 -13 OFFCURVE",
+"447 -13 CURVE SMOOTH",
+"507 -13 OFFCURVE",
+"544 16 OFFCURVE",
+"572 62 CURVE",
+"563 80 LINE",
+"546 64 OFFCURVE",
+"530 57 OFFCURVE",
+"515 57 CURVE SMOOTH",
+"483 57 OFFCURVE",
+"471 89 OFFCURVE",
+"471 214 CURVE SMOOTH",
+"471 270 OFFCURVE",
+"471 324 OFFCURVE",
+"476 377 CURVE",
+"531 377 LINE",
+"582 490 LINE",
+"567 496 LINE",
+"550 472 OFFCURVE",
+"534 465 OFFCURVE",
+"489 465 CURVE SMOOTH",
+"395 465 OFFCURVE",
+"302 465 OFFCURVE",
+"208 465 CURVE SMOOTH",
+"124 465 OFFCURVE",
+"79 438 OFFCURVE",
+"19 362 CURVE",
+"36 340 LINE",
+"80 369 OFFCURVE",
+"105 377 OFFCURVE",
+"168 377 CURVE",
+"168 272 OFFCURVE",
+"145 116 OFFCURVE",
+"70 9 CURVE",
+"78 -13 LINE"
+);
+}
+);
+width = 602;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"109 -12 OFFCURVE",
+"137 -6 OFFCURVE",
+"167 6 CURVE",
+"185 28 OFFCURVE",
+"238 111 OFFCURVE",
+"238 353 CURVE SMOOTH",
+"238 363 LINE",
+"365 363 LINE",
+"359 295 OFFCURVE",
+"355 206 OFFCURVE",
+"355 163 CURVE SMOOTH",
+"355 17 OFFCURVE",
+"401 -14 OFFCURVE",
+"465 -14 CURVE SMOOTH",
+"535 -14 OFFCURVE",
+"584 24 OFFCURVE",
+"612 64 CURVE",
+"598 96 LINE",
+"581 83 OFFCURVE",
+"569 77 OFFCURVE",
+"554 77 CURVE SMOOTH",
+"528 77 OFFCURVE",
+"509 96 OFFCURVE",
+"509 166 CURVE SMOOTH",
+"509 239 OFFCURVE",
+"509 295 OFFCURVE",
+"515 363 CURVE",
+"583 363 LINE",
+"626 500 LINE",
+"592 509 LINE",
+"572 476 OFFCURVE",
+"559 474 OFFCURVE",
+"511 474 CURVE SMOOTH",
+"452 474 OFFCURVE",
+"285 477 OFFCURVE",
+"242 477 CURVE SMOOTH",
+"126 477 OFFCURVE",
+"94 455 OFFCURVE",
+"22 361 CURVE",
+"41 325 LINE",
+"90 354 OFFCURVE",
+"118 363 OFFCURVE",
+"180 363 CURVE",
+"180 266 OFFCURVE",
+"153 118 OFFCURVE",
+"77 12 CURVE",
+"86 -14 LINE"
+);
+}
+);
+width = 652;
+}
+);
+unicode = 03C0;
+},
+{
+glyphname = zero;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"47 152 OFFCURVE",
+"169 -12 OFFCURVE",
+"331 -12 CURVE SMOOTH",
+"494 -12 OFFCURVE",
+"616 152 OFFCURVE",
+"616 360 CURVE SMOOTH",
+"616 567 OFFCURVE",
+"494 732 OFFCURVE",
+"331 732 CURVE SMOOTH",
+"169 732 OFFCURVE",
+"47 567 OFFCURVE",
+"47 360 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 638 OFFCURVE",
+"228 702 OFFCURVE",
+"331 702 CURVE SMOOTH",
+"433 702 OFFCURVE",
+"466 638 OFFCURVE",
+"466 360 CURVE SMOOTH",
+"466 81 OFFCURVE",
+"433 18 OFFCURVE",
+"331 18 CURVE SMOOTH",
+"228 18 OFFCURVE",
+"197 81 OFFCURVE",
+"197 360 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"494 -12 OFFCURVE",
+"616 152 OFFCURVE",
+"616 360 CURVE SMOOTH",
+"616 567 OFFCURVE",
+"494 732 OFFCURVE",
+"331 732 CURVE SMOOTH",
+"169 732 OFFCURVE",
+"47 567 OFFCURVE",
+"47 360 CURVE SMOOTH",
+"47 152 OFFCURVE",
+"169 -12 OFFCURVE",
+"331 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"228 18 OFFCURVE",
+"197 81 OFFCURVE",
+"197 360 CURVE SMOOTH",
+"197 638 OFFCURVE",
+"228 702 OFFCURVE",
+"331 702 CURVE SMOOTH",
+"433 702 OFFCURVE",
+"466 638 OFFCURVE",
+"466 360 CURVE SMOOTH",
+"466 81 OFFCURVE",
+"433 18 OFFCURVE",
+"331 18 CURVE SMOOTH"
+);
+}
+);
+width = 663;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"44 142 OFFCURVE",
+"182 -13 OFFCURVE",
+"363 -13 CURVE SMOOTH",
+"544 -13 OFFCURVE",
+"683 142 OFFCURVE",
+"683 360 CURVE SMOOTH",
+"683 577 OFFCURVE",
+"544 733 OFFCURVE",
+"363 733 CURVE SMOOTH",
+"182 733 OFFCURVE",
+"44 577 OFFCURVE",
+"44 360 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 634 OFFCURVE",
+"256 698 OFFCURVE",
+"363 698 CURVE SMOOTH",
+"465 698 OFFCURVE",
+"503 634 OFFCURVE",
+"503 360 CURVE SMOOTH",
+"503 85 OFFCURVE",
+"465 22 OFFCURVE",
+"363 22 CURVE SMOOTH",
+"256 22 OFFCURVE",
+"224 85 OFFCURVE",
+"224 360 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"544 -12 OFFCURVE",
+"683 142 OFFCURVE",
+"683 360 CURVE SMOOTH",
+"683 577 OFFCURVE",
+"544 733 OFFCURVE",
+"363 733 CURVE SMOOTH",
+"182 733 OFFCURVE",
+"44 577 OFFCURVE",
+"44 360 CURVE SMOOTH",
+"44 142 OFFCURVE",
+"182 -12 OFFCURVE",
+"363 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 23 OFFCURVE",
+"224 85 OFFCURVE",
+"224 360 CURVE SMOOTH",
+"224 634 OFFCURVE",
+"256 698 OFFCURVE",
+"363 698 CURVE SMOOTH",
+"465 698 OFFCURVE",
+"503 634 OFFCURVE",
+"503 360 CURVE SMOOTH",
+"503 85 OFFCURVE",
+"465 23 OFFCURVE",
+"363 23 CURVE SMOOTH"
+);
+}
+);
+width = 727;
+}
+);
+unicode = 0030;
+},
+{
+glyphname = one;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"11 691 LINE",
+"161 691 LINE",
+"161 25 LINE",
+"11 25 LINE",
+"11 0 LINE",
+"420 0 LINE",
+"420 25 LINE",
+"280 25 LINE",
+"280 716 LINE",
+"11 716 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"420 0 LINE",
+"420 25 LINE",
+"280 25 LINE",
+"280 716 LINE",
+"11 716 LINE",
+"11 691 LINE",
+"161 691 LINE",
+"161 25 LINE",
+"11 25 LINE",
+"11 0 LINE"
+);
+}
+);
+width = 431;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"8 694 LINE",
+"166 694 LINE",
+"166 30 LINE",
+"8 30 LINE",
+"8 0 LINE",
+"472 0 LINE",
+"472 30 LINE",
+"324 30 LINE",
+"324 724 LINE",
+"8 724 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"472 0 LINE",
+"472 30 LINE",
+"324 30 LINE",
+"324 716 LINE",
+"8 716 LINE",
+"8 686 LINE",
+"166 686 LINE",
+"166 30 LINE",
+"8 30 LINE",
+"8 0 LINE"
+);
+}
+);
+width = 480;
+}
+);
+unicode = 0031;
+},
+{
+glyphname = two;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"490 200 LINE",
+"490 105 OFFCURVE",
+"476 96 OFFCURVE",
+"429 96 CURVE SMOOTH",
+"124 96 LINE",
+"124 100 LINE",
+"409 355 LINE SMOOTH",
+"498 435 OFFCURVE",
+"515 495 OFFCURVE",
+"515 543 CURVE SMOOTH",
+"515 673 OFFCURVE",
+"395 732 OFFCURVE",
+"283 732 CURVE SMOOTH",
+"166 732 OFFCURVE",
+"54 668 OFFCURVE",
+"54 555 CURVE SMOOTH",
+"54 499 OFFCURVE",
+"81 449 OFFCURVE",
+"142 449 CURVE SMOOTH",
+"179 449 OFFCURVE",
+"210 467 OFFCURVE",
+"210 512 CURVE SMOOTH",
+"210 551 OFFCURVE",
+"187 569 OFFCURVE",
+"154 569 CURVE SMOOTH",
+"128 569 OFFCURVE",
+"116 557 OFFCURVE",
+"103 557 CURVE SMOOTH",
+"95 557 OFFCURVE",
+"90 561 OFFCURVE",
+"90 576 CURVE SMOOTH",
+"90 631 OFFCURVE",
+"160 687 OFFCURVE",
+"242 687 CURVE SMOOTH",
+"332 687 OFFCURVE",
+"381 619 OFFCURVE",
+"381 509 CURVE SMOOTH",
+"381 425 OFFCURVE",
+"352 372 OFFCURVE",
+"250 277 CURVE SMOOTH",
+"35 77 LINE",
+"35 0 LINE",
+"515 0 LINE",
+"515 200 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"515 0 LINE",
+"515 200 LINE",
+"490 200 LINE",
+"490 105 OFFCURVE",
+"476 96 OFFCURVE",
+"429 96 CURVE SMOOTH",
+"124 96 LINE",
+"124 100 LINE",
+"409 355 LINE SMOOTH",
+"498 435 OFFCURVE",
+"515 495 OFFCURVE",
+"515 543 CURVE SMOOTH",
+"515 673 OFFCURVE",
+"395 732 OFFCURVE",
+"283 732 CURVE SMOOTH",
+"166 732 OFFCURVE",
+"54 668 OFFCURVE",
+"54 555 CURVE SMOOTH",
+"54 499 OFFCURVE",
+"81 449 OFFCURVE",
+"142 449 CURVE SMOOTH",
+"179 449 OFFCURVE",
+"210 467 OFFCURVE",
+"210 512 CURVE SMOOTH",
+"210 551 OFFCURVE",
+"187 569 OFFCURVE",
+"154 569 CURVE SMOOTH",
+"128 569 OFFCURVE",
+"116 557 OFFCURVE",
+"103 557 CURVE SMOOTH",
+"95 557 OFFCURVE",
+"90 561 OFFCURVE",
+"90 576 CURVE SMOOTH",
+"90 631 OFFCURVE",
+"160 687 OFFCURVE",
+"242 687 CURVE SMOOTH",
+"332 687 OFFCURVE",
+"381 619 OFFCURVE",
+"381 509 CURVE SMOOTH",
+"381 425 OFFCURVE",
+"352 372 OFFCURVE",
+"250 277 CURVE SMOOTH",
+"35 77 LINE",
+"35 0 LINE"
+);
+}
+);
+width = 570;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"542 245 LINE",
+"542 148 OFFCURVE",
+"528 139 OFFCURVE",
+"481 139 CURVE SMOOTH",
+"155 139 LINE",
+"155 143 LINE",
+"442 339 LINE SMOOTH",
+"541 406 OFFCURVE",
+"572 472 OFFCURVE",
+"572 539 CURVE SMOOTH",
+"572 676 OFFCURVE",
+"442 733 OFFCURVE",
+"319 733 CURVE SMOOTH",
+"189 733 OFFCURVE",
+"61 670 OFFCURVE",
+"61 551 CURVE SMOOTH",
+"61 494 OFFCURVE",
+"91 434 OFFCURVE",
+"162 434 CURVE SMOOTH",
+"207 434 OFFCURVE",
+"247 458 OFFCURVE",
+"247 515 CURVE SMOOTH",
+"247 556 OFFCURVE",
+"226 584 OFFCURVE",
+"182 584 CURVE SMOOTH",
+"154 584 OFFCURVE",
+"142 572 OFFCURVE",
+"131 572 CURVE SMOOTH",
+"123 572 OFFCURVE",
+"117 578 OFFCURVE",
+"117 592 CURVE SMOOTH",
+"117 636 OFFCURVE",
+"181 688 OFFCURVE",
+"256 688 CURVE SMOOTH",
+"344 688 OFFCURVE",
+"398 618 OFFCURVE",
+"398 503 CURVE SMOOTH",
+"398 422 OFFCURVE",
+"371 365 OFFCURVE",
+"264 280 CURVE SMOOTH",
+"32 97 LINE",
+"32 0 LINE",
+"572 0 LINE",
+"572 245 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"572 0 LINE",
+"572 245 LINE",
+"542 245 LINE",
+"542 148 OFFCURVE",
+"528 139 OFFCURVE",
+"481 139 CURVE SMOOTH",
+"155 139 LINE",
+"155 143 LINE",
+"442 339 LINE SMOOTH",
+"541 406 OFFCURVE",
+"572 472 OFFCURVE",
+"572 539 CURVE SMOOTH",
+"572 676 OFFCURVE",
+"442 732 OFFCURVE",
+"319 732 CURVE SMOOTH",
+"189 732 OFFCURVE",
+"61 670 OFFCURVE",
+"61 551 CURVE SMOOTH",
+"61 494 OFFCURVE",
+"91 434 OFFCURVE",
+"162 434 CURVE SMOOTH",
+"207 434 OFFCURVE",
+"247 458 OFFCURVE",
+"247 515 CURVE SMOOTH",
+"247 556 OFFCURVE",
+"226 584 OFFCURVE",
+"182 584 CURVE SMOOTH",
+"154 584 OFFCURVE",
+"142 572 OFFCURVE",
+"131 572 CURVE SMOOTH",
+"123 572 OFFCURVE",
+"117 578 OFFCURVE",
+"117 592 CURVE SMOOTH",
+"117 636 OFFCURVE",
+"181 687 OFFCURVE",
+"256 687 CURVE SMOOTH",
+"344 687 OFFCURVE",
+"398 618 OFFCURVE",
+"398 503 CURVE SMOOTH",
+"398 422 OFFCURVE",
+"371 365 OFFCURVE",
+"264 280 CURVE SMOOTH",
+"32 97 LINE",
+"32 0 LINE"
+);
+}
+);
+width = 625;
+}
+);
+unicode = 0032;
+},
+{
+glyphname = three;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"209 371 LINE",
+"328 371 OFFCURVE",
+"374 311 OFFCURVE",
+"374 200 CURVE SMOOTH",
+"374 83 OFFCURVE",
+"322 18 OFFCURVE",
+"229 18 CURVE SMOOTH",
+"187 18 OFFCURVE",
+"116 31 OFFCURVE",
+"116 67 CURVE SMOOTH",
+"116 95 OFFCURVE",
+"158 91 OFFCURVE",
+"158 135 CURVE SMOOTH",
+"158 170 OFFCURVE",
+"130 195 OFFCURVE",
+"94 195 CURVE SMOOTH",
+"56 195 OFFCURVE",
+"29 167 OFFCURVE",
+"29 123 CURVE SMOOTH",
+"29 44 OFFCURVE",
+"115 -12 OFFCURVE",
+"241 -12 CURVE SMOOTH",
+"413 -12 OFFCURVE",
+"514 91 OFFCURVE",
+"514 200 CURVE SMOOTH",
+"514 299 OFFCURVE",
+"431 379 OFFCURVE",
+"307 394 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"131 371 LINE",
+"307 371 LINE",
+"307 401 LINE",
+"131 401 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"248 390 LINE",
+"384 404 OFFCURVE",
+"471 480 OFFCURVE",
+"471 570 CURVE SMOOTH",
+"471 654 OFFCURVE",
+"393 732 OFFCURVE",
+"259 732 CURVE SMOOTH",
+"137 732 OFFCURVE",
+"67 666 OFFCURVE",
+"67 609 CURVE SMOOTH",
+"67 574 OFFCURVE",
+"94 547 OFFCURVE",
+"127 547 CURVE SMOOTH",
+"153 547 OFFCURVE",
+"181 563 OFFCURVE",
+"181 598 CURVE SMOOTH",
+"181 636 OFFCURVE",
+"149 639 OFFCURVE",
+"149 661 CURVE SMOOTH",
+"149 686 OFFCURVE",
+"187 702 OFFCURVE",
+"236 702 CURVE SMOOTH",
+"302 702 OFFCURVE",
+"341 674 OFFCURVE",
+"341 572 CURVE SMOOTH",
+"341 465 OFFCURVE",
+"298 401 OFFCURVE",
+"190 401 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"410 -12 OFFCURVE",
+"511 91 OFFCURVE",
+"511 200 CURVE SMOOTH",
+"511 299 OFFCURVE",
+"428 379 OFFCURVE",
+"304 394 CURVE",
+"206 371 LINE",
+"325 371 OFFCURVE",
+"371 311 OFFCURVE",
+"371 200 CURVE SMOOTH",
+"371 83 OFFCURVE",
+"319 18 OFFCURVE",
+"226 18 CURVE SMOOTH",
+"184 18 OFFCURVE",
+"113 31 OFFCURVE",
+"113 67 CURVE SMOOTH",
+"113 95 OFFCURVE",
+"155 91 OFFCURVE",
+"155 135 CURVE SMOOTH",
+"155 170 OFFCURVE",
+"127 195 OFFCURVE",
+"91 195 CURVE SMOOTH",
+"53 195 OFFCURVE",
+"26 167 OFFCURVE",
+"26 123 CURVE SMOOTH",
+"26 44 OFFCURVE",
+"112 -12 OFFCURVE",
+"238 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 371 LINE",
+"304 401 LINE",
+"128 401 LINE",
+"128 371 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"381 404 OFFCURVE",
+"468 480 OFFCURVE",
+"468 570 CURVE SMOOTH",
+"468 654 OFFCURVE",
+"390 732 OFFCURVE",
+"256 732 CURVE SMOOTH",
+"134 732 OFFCURVE",
+"64 666 OFFCURVE",
+"64 609 CURVE SMOOTH",
+"64 574 OFFCURVE",
+"91 547 OFFCURVE",
+"124 547 CURVE SMOOTH",
+"150 547 OFFCURVE",
+"178 563 OFFCURVE",
+"178 598 CURVE SMOOTH",
+"178 636 OFFCURVE",
+"146 639 OFFCURVE",
+"146 661 CURVE SMOOTH",
+"146 686 OFFCURVE",
+"184 702 OFFCURVE",
+"233 702 CURVE SMOOTH",
+"299 702 OFFCURVE",
+"338 674 OFFCURVE",
+"338 572 CURVE SMOOTH",
+"338 465 OFFCURVE",
+"295 401 OFFCURVE",
+"187 401 CURVE",
+"245 390 LINE"
+);
+}
+);
+width = 552;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"206 371 LINE",
+"333 371 OFFCURVE",
+"381 311 OFFCURVE",
+"381 198 CURVE SMOOTH",
+"381 86 OFFCURVE",
+"334 22 OFFCURVE",
+"242 22 CURVE SMOOTH",
+"206 22 OFFCURVE",
+"133 32 OFFCURVE",
+"133 61 CURVE SMOOTH",
+"133 88 OFFCURVE",
+"195 88 OFFCURVE",
+"195 154 CURVE SMOOTH",
+"195 211 OFFCURVE",
+"148 229 OFFCURVE",
+"113 229 CURVE SMOOTH",
+"57 229 OFFCURVE",
+"26 183 OFFCURVE",
+"26 131 CURVE SMOOTH",
+"26 43 OFFCURVE",
+"113 -13 OFFCURVE",
+"255 -13 CURVE SMOOTH",
+"448 -13 OFFCURVE",
+"567 91 OFFCURVE",
+"567 204 CURVE SMOOTH",
+"567 323 OFFCURVE",
+"458 388 OFFCURVE",
+"314 396 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"139 371 LINE",
+"314 371 LINE",
+"314 403 LINE",
+"139 406 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"254 395 LINE",
+"447 409 OFFCURVE",
+"532 476 OFFCURVE",
+"532 568 CURVE SMOOTH",
+"532 664 OFFCURVE",
+"440 733 OFFCURVE",
+"288 733 CURVE SMOOTH",
+"133 733 OFFCURVE",
+"68 662 OFFCURVE",
+"68 594 CURVE SMOOTH",
+"68 547 OFFCURVE",
+"100 518 OFFCURVE",
+"145 518 CURVE SMOOTH",
+"183 518 OFFCURVE",
+"227 538 OFFCURVE",
+"227 584 CURVE SMOOTH",
+"227 633 OFFCURVE",
+"175 640 OFFCURVE",
+"175 665 CURVE SMOOTH",
+"175 688 OFFCURVE",
+"218 698 OFFCURVE",
+"258 698 CURVE SMOOTH",
+"319 698 OFFCURVE",
+"357 674 OFFCURVE",
+"357 576 CURVE SMOOTH",
+"357 468 OFFCURVE",
+"310 405 OFFCURVE",
+"186 405 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"446 -12 OFFCURVE",
+"565 91 OFFCURVE",
+"565 204 CURVE SMOOTH",
+"565 323 OFFCURVE",
+"456 388 OFFCURVE",
+"312 396 CURVE",
+"204 371 LINE",
+"331 371 OFFCURVE",
+"379 311 OFFCURVE",
+"379 198 CURVE SMOOTH",
+"379 86 OFFCURVE",
+"332 23 OFFCURVE",
+"240 23 CURVE SMOOTH",
+"204 23 OFFCURVE",
+"131 32 OFFCURVE",
+"131 61 CURVE SMOOTH",
+"131 88 OFFCURVE",
+"193 89 OFFCURVE",
+"193 155 CURVE SMOOTH",
+"193 212 OFFCURVE",
+"146 230 OFFCURVE",
+"111 230 CURVE SMOOTH",
+"55 230 OFFCURVE",
+"24 184 OFFCURVE",
+"24 132 CURVE SMOOTH",
+"24 44 OFFCURVE",
+"111 -12 OFFCURVE",
+"253 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 371 LINE",
+"312 406 LINE",
+"137 406 LINE",
+"137 371 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"445 409 OFFCURVE",
+"530 476 OFFCURVE",
+"530 568 CURVE SMOOTH",
+"530 664 OFFCURVE",
+"438 732 OFFCURVE",
+"286 732 CURVE SMOOTH",
+"131 732 OFFCURVE",
+"66 662 OFFCURVE",
+"66 594 CURVE SMOOTH",
+"66 547 OFFCURVE",
+"98 518 OFFCURVE",
+"143 518 CURVE SMOOTH",
+"181 518 OFFCURVE",
+"225 538 OFFCURVE",
+"225 584 CURVE SMOOTH",
+"225 633 OFFCURVE",
+"173 640 OFFCURVE",
+"173 665 CURVE SMOOTH",
+"173 688 OFFCURVE",
+"216 697 OFFCURVE",
+"256 697 CURVE SMOOTH",
+"317 697 OFFCURVE",
+"355 674 OFFCURVE",
+"355 576 CURVE SMOOTH",
+"355 468 OFFCURVE",
+"308 406 OFFCURVE",
+"184 406 CURVE",
+"252 395 LINE"
+);
+}
+);
+width = 602;
+}
+);
+unicode = 0033;
+},
+{
+glyphname = four;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"56 227 LINE",
+"56 231 LINE",
+"308 599 LINE",
+"312 599 LINE",
+"312 227 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"539 200 LINE",
+"539 118 LINE",
+"565 118 LINE",
+"565 306 LINE",
+"539 306 LINE",
+"539 227 LINE",
+"431 227 LINE",
+"431 732 LINE",
+"358 732 LINE",
+"18 228 LINE",
+"18 200 LINE",
+"313 200 LINE",
+"313 25 LINE",
+"214 25 LINE",
+"214 0 LINE",
+"517 0 LINE",
+"517 25 LINE",
+"432 25 LINE",
+"432 200 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"517 0 LINE",
+"517 25 LINE",
+"432 25 LINE",
+"432 200 LINE",
+"539 200 LINE",
+"539 118 LINE",
+"565 118 LINE",
+"565 306 LINE",
+"539 306 LINE",
+"539 227 LINE",
+"431 227 LINE",
+"431 732 LINE",
+"358 732 LINE",
+"18 228 LINE",
+"18 200 LINE",
+"313 200 LINE",
+"313 25 LINE",
+"214 25 LINE",
+"214 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"56 231 LINE",
+"308 599 LINE",
+"312 599 LINE",
+"312 227 LINE",
+"56 227 LINE"
+);
+}
+);
+width = 595;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"61 232 LINE",
+"61 236 LINE",
+"315 580 LINE",
+"319 580 LINE",
+"319 232 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"602 200 LINE",
+"602 118 LINE",
+"633 118 LINE",
+"633 311 LINE",
+"602 311 LINE",
+"602 232 LINE",
+"477 232 LINE",
+"477 723 LINE",
+"375 723 LINE",
+"15 233 LINE",
+"15 200 LINE",
+"319 200 LINE",
+"319 30 LINE",
+"211 30 LINE",
+"211 0 LINE",
+"573 0 LINE",
+"573 30 LINE",
+"477 30 LINE",
+"477 200 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"573 0 LINE",
+"573 30 LINE",
+"477 30 LINE",
+"477 200 LINE",
+"602 200 LINE",
+"602 118 LINE",
+"633 118 LINE",
+"633 311 LINE",
+"602 311 LINE",
+"602 232 LINE",
+"477 232 LINE",
+"477 732 LINE",
+"375 732 LINE",
+"15 233 LINE",
+"15 200 LINE",
+"319 200 LINE",
+"319 30 LINE",
+"211 30 LINE",
+"211 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"61 236 LINE",
+"315 588 LINE",
+"319 588 LINE",
+"319 232 LINE",
+"61 232 LINE"
+);
+}
+);
+width = 670;
+}
+);
+unicode = 0034;
+},
+{
+glyphname = five;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 620 LINE",
+"429 620 LINE",
+"465 748 LINE",
+"440 748 LINE",
+"426 722 OFFCURVE",
+"412 716 OFFCURVE",
+"368 716 CURVE SMOOTH",
+"102 716 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"83 387 LINE",
+"99 377 LINE",
+"118 396 LINE",
+"137 716 LINE",
+"102 716 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"169 437 OFFCURVE",
+"120 423 OFFCURVE",
+"106 415 CURVE",
+"99 377 LINE",
+"124 394 OFFCURVE",
+"172 406 OFFCURVE",
+"214 406 CURVE SMOOTH",
+"310 406 OFFCURVE",
+"379 345 OFFCURVE",
+"379 208 CURVE SMOOTH",
+"379 81 OFFCURVE",
+"319 18 OFFCURVE",
+"218 18 CURVE SMOOTH",
+"164 18 OFFCURVE",
+"114 35 OFFCURVE",
+"114 66 CURVE SMOOTH",
+"114 97 OFFCURVE",
+"161 96 OFFCURVE",
+"161 141 CURVE SMOOTH",
+"161 176 OFFCURVE",
+"133 197 OFFCURVE",
+"97 197 CURVE SMOOTH",
+"59 197 OFFCURVE",
+"32 167 OFFCURVE",
+"32 123 CURVE SMOOTH",
+"32 42 OFFCURVE",
+"123 -12 OFFCURVE",
+"239 -12 CURVE SMOOTH",
+"393 -12 OFFCURVE",
+"517 87 OFFCURVE",
+"517 222 CURVE SMOOTH",
+"517 346 OFFCURVE",
+"412 437 OFFCURVE",
+"237 437 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"393 -12 OFFCURVE",
+"517 87 OFFCURVE",
+"517 222 CURVE SMOOTH",
+"517 346 OFFCURVE",
+"412 437 OFFCURVE",
+"237 437 CURVE SMOOTH",
+"169 437 OFFCURVE",
+"120 423 OFFCURVE",
+"106 415 CURVE",
+"99 377 LINE",
+"124 394 OFFCURVE",
+"172 406 OFFCURVE",
+"214 406 CURVE SMOOTH",
+"310 406 OFFCURVE",
+"379 345 OFFCURVE",
+"379 208 CURVE SMOOTH",
+"379 81 OFFCURVE",
+"319 18 OFFCURVE",
+"218 18 CURVE SMOOTH",
+"164 18 OFFCURVE",
+"114 35 OFFCURVE",
+"114 66 CURVE SMOOTH",
+"114 97 OFFCURVE",
+"161 96 OFFCURVE",
+"161 141 CURVE SMOOTH",
+"161 176 OFFCURVE",
+"133 197 OFFCURVE",
+"97 197 CURVE SMOOTH",
+"59 197 OFFCURVE",
+"32 167 OFFCURVE",
+"32 123 CURVE SMOOTH",
+"32 42 OFFCURVE",
+"123 -12 OFFCURVE",
+"239 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"118 396 LINE",
+"155 716 LINE",
+"120 716 LINE",
+"83 387 LINE",
+"99 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 620 LINE",
+"483 748 LINE",
+"458 748 LINE",
+"444 722 OFFCURVE",
+"430 716 OFFCURVE",
+"386 716 CURVE SMOOTH",
+"120 716 LINE",
+"145 620 LINE"
+);
+}
+);
+width = 551;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"135 594 LINE",
+"507 594 LINE",
+"543 773 LINE",
+"513 773 LINE",
+"500 741 OFFCURVE",
+"487 733 OFFCURVE",
+"446 733 CURVE SMOOTH",
+"110 733 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"85 382 LINE",
+"102 371 LINE",
+"126 410 LINE",
+"145 733 LINE",
+"105 733 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 447 OFFCURVE",
+"131 430 OFFCURVE",
+"113 420 CURVE",
+"102 371 LINE",
+"123 388 OFFCURVE",
+"182 401 OFFCURVE",
+"230 401 CURVE SMOOTH",
+"330 401 OFFCURVE",
+"401 343 OFFCURVE",
+"401 206 CURVE SMOOTH",
+"401 83 OFFCURVE",
+"344 27 OFFCURVE",
+"241 27 CURVE SMOOTH",
+"198 27 OFFCURVE",
+"141 37 OFFCURVE",
+"141 61 CURVE SMOOTH",
+"141 86 OFFCURVE",
+"203 86 OFFCURVE",
+"203 150 CURVE SMOOTH",
+"203 202 OFFCURVE",
+"161 224 OFFCURVE",
+"119 224 CURVE SMOOTH",
+"66 224 OFFCURVE",
+"29 187 OFFCURVE",
+"29 133 CURVE SMOOTH",
+"29 51 OFFCURVE",
+"116 -8 OFFCURVE",
+"266 -8 CURVE SMOOTH",
+"445 -8 OFFCURVE",
+"589 76 OFFCURVE",
+"589 224 CURVE SMOOTH",
+"589 345 OFFCURVE",
+"494 447 OFFCURVE",
+"295 447 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"445 -12 OFFCURVE",
+"589 76 OFFCURVE",
+"589 224 CURVE SMOOTH",
+"589 345 OFFCURVE",
+"494 447 OFFCURVE",
+"295 447 CURVE SMOOTH",
+"214 447 OFFCURVE",
+"131 430 OFFCURVE",
+"113 420 CURVE",
+"102 371 LINE",
+"123 388 OFFCURVE",
+"182 401 OFFCURVE",
+"230 401 CURVE SMOOTH",
+"330 401 OFFCURVE",
+"401 343 OFFCURVE",
+"401 206 CURVE SMOOTH",
+"401 83 OFFCURVE",
+"344 23 OFFCURVE",
+"241 23 CURVE SMOOTH",
+"198 23 OFFCURVE",
+"141 33 OFFCURVE",
+"141 57 CURVE SMOOTH",
+"141 82 OFFCURVE",
+"203 82 OFFCURVE",
+"203 146 CURVE SMOOTH",
+"203 198 OFFCURVE",
+"161 220 OFFCURVE",
+"119 220 CURVE SMOOTH",
+"66 220 OFFCURVE",
+"29 183 OFFCURVE",
+"29 129 CURVE SMOOTH",
+"29 47 OFFCURVE",
+"116 -12 OFFCURVE",
+"266 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 410 LINE",
+"154 716 LINE",
+"114 716 LINE",
+"85 382 LINE",
+"102 371 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 577 LINE",
+"552 754 LINE",
+"522 754 LINE",
+"509 722 OFFCURVE",
+"496 716 OFFCURVE",
+"455 716 CURVE SMOOTH",
+"119 716 LINE",
+"144 577 LINE"
+);
+}
+);
+width = 620;
+}
+);
+unicode = 0035;
+},
+{
+glyphname = six;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"508 752 LINE",
+"265 743 OFFCURVE",
+"43 544 OFFCURVE",
+"43 290 CURVE SMOOTH",
+"43 107 OFFCURVE",
+"158 -12 OFFCURVE",
+"304 -12 CURVE SMOOTH",
+"442 -12 OFFCURVE",
+"570 93 OFFCURVE",
+"570 238 CURVE SMOOTH",
+"570 371 OFFCURVE",
+"461 474 OFFCURVE",
+"328 474 CURVE SMOOTH",
+"274 474 OFFCURVE",
+"234 457 OFFCURVE",
+"198 425 CURVE",
+"195 426 LINE",
+"218 593 OFFCURVE",
+"336 710 OFFCURVE",
+"508 723 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 262 OFFCURVE",
+"183 320 OFFCURVE",
+"191 368 CURVE",
+"219 413 OFFCURVE",
+"265 444 OFFCURVE",
+"326 444 CURVE SMOOTH",
+"395 444 OFFCURVE",
+"425 404 OFFCURVE",
+"425 231 CURVE SMOOTH",
+"425 59 OFFCURVE",
+"395 18 OFFCURVE",
+"302 18 CURVE SMOOTH",
+"213 18 OFFCURVE",
+"181 55 OFFCURVE",
+"181 221 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"448 -12 OFFCURVE",
+"576 93 OFFCURVE",
+"576 238 CURVE SMOOTH",
+"576 371 OFFCURVE",
+"467 474 OFFCURVE",
+"334 474 CURVE SMOOTH",
+"280 474 OFFCURVE",
+"240 457 OFFCURVE",
+"204 425 CURVE",
+"201 426 LINE",
+"224 593 OFFCURVE",
+"342 710 OFFCURVE",
+"514 723 CURVE",
+"514 752 LINE",
+"271 743 OFFCURVE",
+"49 544 OFFCURVE",
+"49 290 CURVE SMOOTH",
+"49 107 OFFCURVE",
+"164 -12 OFFCURVE",
+"310 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"219 18 OFFCURVE",
+"187 55 OFFCURVE",
+"187 221 CURVE",
+"187 262 OFFCURVE",
+"189 320 OFFCURVE",
+"197 368 CURVE",
+"225 413 OFFCURVE",
+"271 444 OFFCURVE",
+"332 444 CURVE SMOOTH",
+"401 444 OFFCURVE",
+"431 404 OFFCURVE",
+"431 231 CURVE SMOOTH",
+"431 59 OFFCURVE",
+"401 18 OFFCURVE",
+"308 18 CURVE SMOOTH"
+);
+}
+);
+width = 606;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"525 733 LINE",
+"272 724 OFFCURVE",
+"40 530 OFFCURVE",
+"40 291 CURVE SMOOTH",
+"40 107 OFFCURVE",
+"164 -13 OFFCURVE",
+"319 -13 CURVE SMOOTH",
+"464 -13 OFFCURVE",
+"597 93 OFFCURVE",
+"597 236 CURVE SMOOTH",
+"597 365 OFFCURVE",
+"490 464 OFFCURVE",
+"357 464 CURVE SMOOTH",
+"303 464 OFFCURVE",
+"265 448 OFFCURVE",
+"230 420 CURVE",
+"227 421 LINE",
+"249 574 OFFCURVE",
+"361 682 OFFCURVE",
+"525 699 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"208 258 OFFCURVE",
+"208 310 OFFCURVE",
+"218 353 CURVE",
+"240 392 OFFCURVE",
+"278 424 OFFCURVE",
+"333 424 CURVE SMOOTH",
+"391 424 OFFCURVE",
+"422 388 OFFCURVE",
+"422 224 CURVE SMOOTH",
+"422 73 OFFCURVE",
+"396 22 OFFCURVE",
+"316 22 CURVE SMOOTH",
+"237 22 OFFCURVE",
+"208 71 OFFCURVE",
+"208 221 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"470 -12 OFFCURVE",
+"603 93 OFFCURVE",
+"603 236 CURVE SMOOTH",
+"603 365 OFFCURVE",
+"496 464 OFFCURVE",
+"363 464 CURVE SMOOTH",
+"309 464 OFFCURVE",
+"271 448 OFFCURVE",
+"236 420 CURVE",
+"233 421 LINE",
+"255 574 OFFCURVE",
+"359 703 OFFCURVE",
+"523 720 CURVE",
+"523 754 LINE",
+"270 745 OFFCURVE",
+"46 530 OFFCURVE",
+"46 291 CURVE SMOOTH",
+"46 107 OFFCURVE",
+"170 -12 OFFCURVE",
+"325 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"243 23 OFFCURVE",
+"214 71 OFFCURVE",
+"214 221 CURVE SMOOTH",
+"214 258 OFFCURVE",
+"214 310 OFFCURVE",
+"224 353 CURVE",
+"246 392 OFFCURVE",
+"284 424 OFFCURVE",
+"339 424 CURVE SMOOTH",
+"397 424 OFFCURVE",
+"428 388 OFFCURVE",
+"428 224 CURVE SMOOTH",
+"428 73 OFFCURVE",
+"402 23 OFFCURVE",
+"322 23 CURVE SMOOTH"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 0036;
+},
+{
+glyphname = seven;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"23 518 LINE",
+"48 518 LINE",
+"80 606 OFFCURVE",
+"98 620 OFFCURVE",
+"153 620 CURVE SMOOTH",
+"409 620 LINE",
+"244 276 LINE SMOOTH",
+"183 149 OFFCURVE",
+"175 112 OFFCURVE",
+"175 76 CURVE SMOOTH",
+"175 15 OFFCURVE",
+"205 -12 OFFCURVE",
+"252 -12 CURVE SMOOTH",
+"294 -12 OFFCURVE",
+"322 10 OFFCURVE",
+"322 56 CURVE SMOOTH",
+"322 106 OFFCURVE",
+"290 113 OFFCURVE",
+"290 197 CURVE SMOOTH",
+"290 250 OFFCURVE",
+"300 313 OFFCURVE",
+"345 408 CURVE SMOOTH",
+"486 704 LINE",
+"486 716 LINE",
+"69 716 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"311 -12 OFFCURVE",
+"339 10 OFFCURVE",
+"339 56 CURVE SMOOTH",
+"339 106 OFFCURVE",
+"307 113 OFFCURVE",
+"307 197 CURVE SMOOTH",
+"307 250 OFFCURVE",
+"318 312 OFFCURVE",
+"362 408 CURVE SMOOTH",
+"497 704 LINE",
+"497 716 LINE",
+"86 716 LINE",
+"40 518 LINE",
+"65 518 LINE",
+"97 606 OFFCURVE",
+"115 620 OFFCURVE",
+"170 620 CURVE SMOOTH",
+"420 620 LINE",
+"261 276 LINE SMOOTH",
+"202 147 OFFCURVE",
+"192 112 OFFCURVE",
+"192 76 CURVE SMOOTH",
+"192 15 OFFCURVE",
+"222 -12 OFFCURVE",
+"269 -12 CURVE SMOOTH"
+);
+}
+);
+width = 504;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"36 485 LINE",
+"71 485 LINE",
+"103 579 OFFCURVE",
+"114 594 OFFCURVE",
+"145 594 CURVE SMOOTH",
+"479 594 LINE",
+"295 286 LINE SMOOTH",
+"227 172 OFFCURVE",
+"201 126 OFFCURVE",
+"201 77 CURVE SMOOTH",
+"201 22 OFFCURVE",
+"233 -13 OFFCURVE",
+"296 -13 CURVE SMOOTH",
+"352 -13 OFFCURVE",
+"398 14 OFFCURVE",
+"398 72 CURVE SMOOTH",
+"398 121 OFFCURVE",
+"366 167 OFFCURVE",
+"366 238 CURVE SMOOTH",
+"366 284 OFFCURVE",
+"382 341 OFFCURVE",
+"429 418 CURVE SMOOTH",
+"591 683 LINE",
+"591 733 LINE",
+"112 733 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"352 -12 OFFCURVE",
+"398 14 OFFCURVE",
+"398 72 CURVE SMOOTH",
+"398 121 OFFCURVE",
+"366 167 OFFCURVE",
+"366 238 CURVE SMOOTH",
+"366 284 OFFCURVE",
+"384 340 OFFCURVE",
+"429 418 CURVE SMOOTH",
+"573 666 LINE",
+"573 716 LINE",
+"104 716 LINE",
+"38 468 LINE",
+"73 468 LINE",
+"105 562 OFFCURVE",
+"106 577 OFFCURVE",
+"137 577 CURVE SMOOTH",
+"465 577 LINE",
+"295 286 LINE SMOOTH",
+"228 172 OFFCURVE",
+"201 126 OFFCURVE",
+"201 77 CURVE SMOOTH",
+"201 22 OFFCURVE",
+"233 -12 OFFCURVE",
+"296 -12 CURVE SMOOTH"
+);
+}
+);
+width = 590;
+}
+);
+unicode = 0037;
+},
+{
+glyphname = eight;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"184 300 OFFCURVE",
+"217 361 OFFCURVE",
+"308 361 CURVE SMOOTH",
+"399 361 OFFCURVE",
+"433 300 OFFCURVE",
+"433 190 CURVE SMOOTH",
+"433 67 OFFCURVE",
+"399 18 OFFCURVE",
+"308 18 CURVE SMOOTH",
+"217 18 OFFCURVE",
+"184 67 OFFCURVE",
+"184 190 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"543 653 OFFCURVE",
+"465 732 OFFCURVE",
+"309 732 CURVE SMOOTH",
+"153 732 OFFCURVE",
+"74 653 OFFCURVE",
+"74 555 CURVE SMOOTH",
+"74 443 OFFCURVE",
+"179 371 OFFCURVE",
+"309 371 CURVE SMOOTH",
+"439 371 OFFCURVE",
+"543 443 OFFCURVE",
+"543 555 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 445 OFFCURVE",
+"385 386 OFFCURVE",
+"309 386 CURVE SMOOTH",
+"233 386 OFFCURVE",
+"204 445 OFFCURVE",
+"204 550 CURVE SMOOTH",
+"204 659 OFFCURVE",
+"233 702 OFFCURVE",
+"309 702 CURVE SMOOTH",
+"385 702 OFFCURVE",
+"413 659 OFFCURVE",
+"413 550 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"44 77 OFFCURVE",
+"130 -12 OFFCURVE",
+"308 -12 CURVE SMOOTH",
+"486 -12 OFFCURVE",
+"573 77 OFFCURVE",
+"573 190 CURVE SMOOTH",
+"573 270 OFFCURVE",
+"490 350 OFFCURVE",
+"376 374 CURVE",
+"376 378 LINE",
+"242 378 LINE",
+"242 374 LINE",
+"127 351 OFFCURVE",
+"44 270 OFFCURVE",
+"44 190 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"484 -12 OFFCURVE",
+"571 77 OFFCURVE",
+"571 190 CURVE SMOOTH",
+"571 270 OFFCURVE",
+"488 350 OFFCURVE",
+"374 374 CURVE",
+"374 378 LINE",
+"240 378 LINE",
+"240 374 LINE",
+"125 351 OFFCURVE",
+"42 270 OFFCURVE",
+"42 190 CURVE SMOOTH",
+"42 77 OFFCURVE",
+"128 -12 OFFCURVE",
+"306 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"215 18 OFFCURVE",
+"182 67 OFFCURVE",
+"182 190 CURVE SMOOTH",
+"182 300 OFFCURVE",
+"215 361 OFFCURVE",
+"306 361 CURVE SMOOTH",
+"397 361 OFFCURVE",
+"431 300 OFFCURVE",
+"431 190 CURVE SMOOTH",
+"431 67 OFFCURVE",
+"397 18 OFFCURVE",
+"306 18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"231 386 OFFCURVE",
+"202 445 OFFCURVE",
+"202 550 CURVE SMOOTH",
+"202 659 OFFCURVE",
+"231 702 OFFCURVE",
+"307 702 CURVE SMOOTH",
+"383 702 OFFCURVE",
+"411 659 OFFCURVE",
+"411 550 CURVE SMOOTH",
+"411 445 OFFCURVE",
+"383 386 OFFCURVE",
+"307 386 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"437 371 OFFCURVE",
+"541 443 OFFCURVE",
+"541 555 CURVE SMOOTH",
+"541 653 OFFCURVE",
+"463 732 OFFCURVE",
+"307 732 CURVE SMOOTH",
+"151 732 OFFCURVE",
+"72 653 OFFCURVE",
+"72 555 CURVE SMOOTH",
+"72 443 OFFCURVE",
+"177 371 OFFCURVE",
+"307 371 CURVE SMOOTH"
+);
+}
+);
+width = 613;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"211 298 OFFCURVE",
+"239 356 OFFCURVE",
+"320 356 CURVE SMOOTH",
+"402 356 OFFCURVE",
+"430 296 OFFCURVE",
+"430 185 CURVE SMOOTH",
+"430 66 OFFCURVE",
+"398 17 OFFCURVE",
+"320 17 CURVE SMOOTH",
+"242 17 OFFCURVE",
+"211 66 OFFCURVE",
+"211 185 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"575 649 OFFCURVE",
+"493 733 OFFCURVE",
+"320 733 CURVE SMOOTH",
+"151 733 OFFCURVE",
+"66 653 OFFCURVE",
+"66 555 CURVE SMOOTH",
+"66 443 OFFCURVE",
+"179 371 OFFCURVE",
+"321 371 CURVE SMOOTH",
+"463 371 OFFCURVE",
+"575 443 OFFCURVE",
+"575 554 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"410 448 OFFCURVE",
+"387 391 OFFCURVE",
+"321 391 CURVE SMOOTH",
+"255 391 OFFCURVE",
+"231 448 OFFCURVE",
+"231 551 CURVE SMOOTH",
+"231 654 OFFCURVE",
+"255 698 OFFCURVE",
+"321 698 CURVE SMOOTH",
+"387 698 OFFCURVE",
+"410 654 OFFCURVE",
+"410 551 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 73 OFFCURVE",
+"128 -13 OFFCURVE",
+"320 -13 CURVE SMOOTH",
+"512 -13 OFFCURVE",
+"605 73 OFFCURVE",
+"605 180 CURVE SMOOTH",
+"605 285 OFFCURVE",
+"514 349 OFFCURVE",
+"388 374 CURVE",
+"388 378 LINE",
+"254 378 LINE",
+"254 374 LINE",
+"127 350 OFFCURVE",
+"36 285 OFFCURVE",
+"36 180 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"510 -12 OFFCURVE",
+"603 73 OFFCURVE",
+"603 180 CURVE SMOOTH",
+"603 285 OFFCURVE",
+"512 349 OFFCURVE",
+"386 374 CURVE",
+"386 378 LINE",
+"252 378 LINE",
+"252 374 LINE",
+"125 350 OFFCURVE",
+"34 285 OFFCURVE",
+"34 180 CURVE SMOOTH",
+"34 73 OFFCURVE",
+"126 -12 OFFCURVE",
+"318 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 18 OFFCURVE",
+"209 66 OFFCURVE",
+"209 185 CURVE SMOOTH",
+"209 298 OFFCURVE",
+"237 356 OFFCURVE",
+"318 356 CURVE SMOOTH",
+"400 356 OFFCURVE",
+"428 296 OFFCURVE",
+"428 185 CURVE SMOOTH",
+"428 66 OFFCURVE",
+"396 18 OFFCURVE",
+"318 18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 391 OFFCURVE",
+"229 448 OFFCURVE",
+"229 551 CURVE SMOOTH",
+"229 654 OFFCURVE",
+"253 697 OFFCURVE",
+"319 697 CURVE SMOOTH",
+"385 697 OFFCURVE",
+"408 654 OFFCURVE",
+"408 551 CURVE SMOOTH",
+"408 448 OFFCURVE",
+"385 391 OFFCURVE",
+"319 391 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"461 371 OFFCURVE",
+"573 443 OFFCURVE",
+"573 554 CURVE SMOOTH",
+"573 649 OFFCURVE",
+"491 732 OFFCURVE",
+"318 732 CURVE SMOOTH",
+"149 732 OFFCURVE",
+"64 653 OFFCURVE",
+"64 555 CURVE SMOOTH",
+"64 443 OFFCURVE",
+"177 371 OFFCURVE",
+"319 371 CURVE SMOOTH"
+);
+}
+);
+width = 637;
+}
+);
+unicode = 0038;
+},
+{
+glyphname = nine;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"97 -32 LINE",
+"340 -23 OFFCURVE",
+"562 176 OFFCURVE",
+"562 430 CURVE SMOOTH",
+"562 613 OFFCURVE",
+"447 732 OFFCURVE",
+"301 732 CURVE SMOOTH",
+"163 732 OFFCURVE",
+"35 627 OFFCURVE",
+"35 482 CURVE SMOOTH",
+"35 349 OFFCURVE",
+"144 246 OFFCURVE",
+"277 246 CURVE SMOOTH",
+"331 246 OFFCURVE",
+"371 263 OFFCURVE",
+"407 295 CURVE",
+"410 294 LINE",
+"387 127 OFFCURVE",
+"269 11 OFFCURVE",
+"97 -3 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"424 458 OFFCURVE",
+"422 400 OFFCURVE",
+"414 352 CURVE",
+"386 307 OFFCURVE",
+"340 276 OFFCURVE",
+"279 276 CURVE SMOOTH",
+"210 276 OFFCURVE",
+"180 316 OFFCURVE",
+"180 489 CURVE SMOOTH",
+"180 661 OFFCURVE",
+"210 702 OFFCURVE",
+"303 702 CURVE SMOOTH",
+"392 702 OFFCURVE",
+"424 665 OFFCURVE",
+"424 499 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"349 -23 OFFCURVE",
+"571 176 OFFCURVE",
+"571 430 CURVE SMOOTH",
+"571 613 OFFCURVE",
+"456 732 OFFCURVE",
+"310 732 CURVE SMOOTH",
+"172 732 OFFCURVE",
+"44 627 OFFCURVE",
+"44 482 CURVE SMOOTH",
+"44 349 OFFCURVE",
+"153 246 OFFCURVE",
+"286 246 CURVE SMOOTH",
+"340 246 OFFCURVE",
+"380 263 OFFCURVE",
+"416 295 CURVE",
+"419 294 LINE",
+"396 127 OFFCURVE",
+"278 11 OFFCURVE",
+"106 -3 CURVE",
+"106 -32 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"219 276 OFFCURVE",
+"189 316 OFFCURVE",
+"189 489 CURVE SMOOTH",
+"189 661 OFFCURVE",
+"219 702 OFFCURVE",
+"312 702 CURVE SMOOTH",
+"401 702 OFFCURVE",
+"433 665 OFFCURVE",
+"433 499 CURVE SMOOTH",
+"433 458 OFFCURVE",
+"431 400 OFFCURVE",
+"423 352 CURVE",
+"395 307 OFFCURVE",
+"349 276 OFFCURVE",
+"288 276 CURVE SMOOTH"
+);
+}
+);
+width = 606;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"104 -11 LINE",
+"357 -2 OFFCURVE",
+"589 188 OFFCURVE",
+"589 430 CURVE SMOOTH",
+"589 614 OFFCURVE",
+"465 734 OFFCURVE",
+"310 734 CURVE SMOOTH",
+"165 734 OFFCURVE",
+"32 628 OFFCURVE",
+"32 485 CURVE SMOOTH",
+"32 356 OFFCURVE",
+"139 257 OFFCURVE",
+"272 257 CURVE SMOOTH",
+"326 257 OFFCURVE",
+"364 273 OFFCURVE",
+"399 301 CURVE",
+"402 300 LINE",
+"380 145 OFFCURVE",
+"268 39 OFFCURVE",
+"104 23 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"421 463 OFFCURVE",
+"421 411 OFFCURVE",
+"411 368 CURVE",
+"389 329 OFFCURVE",
+"351 297 OFFCURVE",
+"296 297 CURVE SMOOTH",
+"238 297 OFFCURVE",
+"207 333 OFFCURVE",
+"207 497 CURVE SMOOTH",
+"207 648 OFFCURVE",
+"233 699 OFFCURVE",
+"313 699 CURVE SMOOTH",
+"392 699 OFFCURVE",
+"421 650 OFFCURVE",
+"421 500 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"357 -2 OFFCURVE",
+"589 188 OFFCURVE",
+"589 430 CURVE SMOOTH",
+"589 614 OFFCURVE",
+"465 734 OFFCURVE",
+"310 734 CURVE SMOOTH",
+"165 734 OFFCURVE",
+"32 628 OFFCURVE",
+"32 485 CURVE SMOOTH",
+"32 356 OFFCURVE",
+"139 257 OFFCURVE",
+"272 257 CURVE SMOOTH",
+"326 257 OFFCURVE",
+"364 273 OFFCURVE",
+"399 301 CURVE",
+"402 300 LINE",
+"380 145 OFFCURVE",
+"268 39 OFFCURVE",
+"104 23 CURVE",
+"104 -11 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 297 OFFCURVE",
+"207 333 OFFCURVE",
+"207 497 CURVE SMOOTH",
+"207 648 OFFCURVE",
+"233 699 OFFCURVE",
+"313 699 CURVE SMOOTH",
+"392 699 OFFCURVE",
+"421 650 OFFCURVE",
+"421 500 CURVE",
+"421 463 OFFCURVE",
+"421 411 OFFCURVE",
+"411 368 CURVE",
+"389 329 OFFCURVE",
+"351 297 OFFCURVE",
+"296 297 CURVE SMOOTH"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 0039;
+},
+{
+glyphname = zero.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"305 -8 OFFCURVE",
+"383 75 OFFCURVE",
+"383 197 CURVE SMOOTH",
+"383 319 OFFCURVE",
+"305 403 OFFCURVE",
+"203 403 CURVE SMOOTH",
+"101 403 OFFCURVE",
+"24 319 OFFCURVE",
+"24 197 CURVE SMOOTH",
+"24 75 OFFCURVE",
+"101 -8 OFFCURVE",
+"203 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 13 OFFCURVE",
+"126 47 OFFCURVE",
+"126 197 CURVE SMOOTH",
+"126 348 OFFCURVE",
+"144 383 OFFCURVE",
+"203 383 CURVE SMOOTH",
+"259 383 OFFCURVE",
+"280 348 OFFCURVE",
+"280 197 CURVE SMOOTH",
+"280 47 OFFCURVE",
+"259 13 OFFCURVE",
+"203 13 CURVE SMOOTH"
+);
+}
+);
+width = 407;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH",
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH",
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 -8 OFFCURVE",
+"396 74 OFFCURVE",
+"396 197 CURVE SMOOTH",
+"396 319 OFFCURVE",
+"314 403 OFFCURVE",
+"209 403 CURVE SMOOTH",
+"104 403 OFFCURVE",
+"23 319 OFFCURVE",
+"23 197 CURVE SMOOTH",
+"23 74 OFFCURVE",
+"104 -8 OFFCURVE",
+"209 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 13 OFFCURVE",
+"131 46 OFFCURVE",
+"131 197 CURVE SMOOTH",
+"131 347 OFFCURVE",
+"149 382 OFFCURVE",
+"209 382 CURVE SMOOTH",
+"265 382 OFFCURVE",
+"287 347 OFFCURVE",
+"287 197 CURVE SMOOTH",
+"287 46 OFFCURVE",
+"265 13 OFFCURVE",
+"209 13 CURVE SMOOTH"
+);
+}
+);
+width = 419;
+}
+);
+},
+{
+glyphname = one.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 0 LINE",
+"266 17 LINE",
+"184 17 LINE",
+"184 395 LINE",
+"4 395 LINE",
+"4 377 LINE",
+"91 377 LINE",
+"91 17 LINE",
+"4 17 LINE",
+"4 0 LINE"
+);
+}
+);
+width = 270;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 0 LINE",
+"275 18 LINE",
+"192 18 LINE",
+"192 395 LINE",
+"3 395 LINE",
+"3 377 LINE",
+"92 377 LINE",
+"92 18 LINE",
+"3 18 LINE",
+"3 0 LINE"
+);
+}
+);
+width = 279;
+}
+);
+},
+{
+glyphname = two.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 0 LINE",
+"321 143 LINE",
+"304 143 LINE",
+"304 90 OFFCURVE",
+"296 85 OFFCURVE",
+"271 85 CURVE SMOOTH",
+"89 85 LINE",
+"89 89 LINE",
+"247 184 LINE SMOOTH",
+"303 217 OFFCURVE",
+"321 256 OFFCURVE",
+"321 296 CURVE SMOOTH",
+"321 373 OFFCURVE",
+"249 403 OFFCURVE",
+"180 403 CURVE SMOOTH",
+"107 403 OFFCURVE",
+"34 370 OFFCURVE",
+"34 303 CURVE SMOOTH",
+"34 271 OFFCURVE",
+"51 236 OFFCURVE",
+"92 236 CURVE SMOOTH",
+"117 236 OFFCURVE",
+"141 251 OFFCURVE",
+"141 284 CURVE SMOOTH",
+"141 307 OFFCURVE",
+"129 325 OFFCURVE",
+"104 325 CURVE SMOOTH",
+"88 325 OFFCURVE",
+"82 318 OFFCURVE",
+"76 318 CURVE SMOOTH",
+"71 318 OFFCURVE",
+"68 322 OFFCURVE",
+"68 329 CURVE SMOOTH",
+"68 351 OFFCURVE",
+"102 379 OFFCURVE",
+"142 379 CURVE SMOOTH",
+"190 379 OFFCURVE",
+"220 340 OFFCURVE",
+"220 276 CURVE SMOOTH",
+"220 232 OFFCURVE",
+"206 200 OFFCURVE",
+"146 155 CURVE SMOOTH",
+"17 57 LINE",
+"17 0 LINE"
+);
+}
+);
+width = 350;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 0 LINE",
+"332 147 LINE",
+"314 147 LINE",
+"314 93 OFFCURVE",
+"306 88 OFFCURVE",
+"280 88 CURVE SMOOTH",
+"95 88 LINE",
+"95 92 LINE",
+"252 183 LINE SMOOTH",
+"309 216 OFFCURVE",
+"332 254 OFFCURVE",
+"332 296 CURVE SMOOTH",
+"332 374 OFFCURVE",
+"257 403 OFFCURVE",
+"186 403 CURVE SMOOTH",
+"111 403 OFFCURVE",
+"36 369 OFFCURVE",
+"36 302 CURVE SMOOTH",
+"36 270 OFFCURVE",
+"53 235 OFFCURVE",
+"95 235 CURVE SMOOTH",
+"123 235 OFFCURVE",
+"147 249 OFFCURVE",
+"147 284 CURVE SMOOTH",
+"147 307 OFFCURVE",
+"137 325 OFFCURVE",
+"109 325 CURVE SMOOTH",
+"93 325 OFFCURVE",
+"86 318 OFFCURVE",
+"81 318 CURVE SMOOTH",
+"77 318 OFFCURVE",
+"73 322 OFFCURVE",
+"73 330 CURVE SMOOTH",
+"73 351 OFFCURVE",
+"106 378 OFFCURVE",
+"144 378 CURVE SMOOTH",
+"192 378 OFFCURVE",
+"223 341 OFFCURVE",
+"223 276 CURVE SMOOTH",
+"223 232 OFFCURVE",
+"210 199 OFFCURVE",
+"149 155 CURVE SMOOTH",
+"16 59 LINE",
+"16 0 LINE"
+);
+}
+);
+width = 360;
+}
+);
+},
+{
+glyphname = three.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"249 -8 OFFCURVE",
+"317 50 OFFCURVE",
+"317 113 CURVE SMOOTH",
+"317 183 OFFCURVE",
+"253 216 OFFCURVE",
+"172 219 CURVE",
+"111 204 LINE",
+"182 204 OFFCURVE",
+"208 171 OFFCURVE",
+"208 109 CURVE SMOOTH",
+"208 48 OFFCURVE",
+"183 13 OFFCURVE",
+"133 13 CURVE SMOOTH",
+"115 13 OFFCURVE",
+"74 17 OFFCURVE",
+"74 31 CURVE SMOOTH",
+"74 46 OFFCURVE",
+"111 48 OFFCURVE",
+"111 88 CURVE SMOOTH",
+"111 124 OFFCURVE",
+"83 132 OFFCURVE",
+"64 132 CURVE SMOOTH",
+"30 132 OFFCURVE",
+"13 104 OFFCURVE",
+"13 73 CURVE SMOOTH",
+"13 23 OFFCURVE",
+"61 -8 OFFCURVE",
+"141 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 204 LINE",
+"172 225 LINE",
+"76 225 LINE",
+"76 204 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 226 OFFCURVE",
+"299 262 OFFCURVE",
+"299 313 CURVE SMOOTH",
+"299 368 OFFCURVE",
+"247 403 OFFCURVE",
+"161 403 CURVE SMOOTH",
+"71 403 OFFCURVE",
+"36 364 OFFCURVE",
+"36 325 CURVE SMOOTH",
+"36 296 OFFCURVE",
+"55 280 OFFCURVE",
+"81 280 CURVE SMOOTH",
+"104 280 OFFCURVE",
+"130 292 OFFCURVE",
+"130 319 CURVE SMOOTH",
+"130 348 OFFCURVE",
+"99 353 OFFCURVE",
+"99 367 CURVE SMOOTH",
+"99 380 OFFCURVE",
+"123 383 OFFCURVE",
+"143 383 CURVE SMOOTH",
+"176 383 OFFCURVE",
+"197 371 OFFCURVE",
+"197 318 CURVE SMOOTH",
+"197 258 OFFCURVE",
+"170 225 OFFCURVE",
+"100 225 CURVE",
+"139 219 LINE"
+);
+}
+);
+width = 337;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 -8 OFFCURVE",
+"327 49 OFFCURVE",
+"327 113 CURVE SMOOTH",
+"327 183 OFFCURVE",
+"258 215 OFFCURVE",
+"173 218 CURVE",
+"111 204 LINE",
+"183 204 OFFCURVE",
+"210 171 OFFCURVE",
+"210 108 CURVE SMOOTH",
+"210 47 OFFCURVE",
+"186 13 OFFCURVE",
+"136 13 CURVE SMOOTH",
+"118 13 OFFCURVE",
+"78 17 OFFCURVE",
+"78 31 CURVE SMOOTH",
+"78 46 OFFCURVE",
+"118 48 OFFCURVE",
+"118 90 CURVE SMOOTH",
+"118 127 OFFCURVE",
+"86 135 OFFCURVE",
+"67 135 CURVE SMOOTH",
+"31 135 OFFCURVE",
+"12 105 OFFCURVE",
+"12 74 CURVE SMOOTH",
+"12 23 OFFCURVE",
+"60 -8 OFFCURVE",
+"143 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 204 LINE",
+"173 224 LINE",
+"78 224 LINE",
+"78 204 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 226 OFFCURVE",
+"310 261 OFFCURVE",
+"310 312 CURVE SMOOTH",
+"310 368 OFFCURVE",
+"255 403 OFFCURVE",
+"166 403 CURVE SMOOTH",
+"70 403 OFFCURVE",
+"37 363 OFFCURVE",
+"37 323 CURVE SMOOTH",
+"37 294 OFFCURVE",
+"56 277 OFFCURVE",
+"85 277 CURVE SMOOTH",
+"109 277 OFFCURVE",
+"139 289 OFFCURVE",
+"139 318 CURVE SMOOTH",
+"139 347 OFFCURVE",
+"104 352 OFFCURVE",
+"104 367 CURVE SMOOTH",
+"104 379 OFFCURVE",
+"129 382 OFFCURVE",
+"148 382 CURVE SMOOTH",
+"179 382 OFFCURVE",
+"200 371 OFFCURVE",
+"200 318 CURVE SMOOTH",
+"200 258 OFFCURVE",
+"173 224 OFFCURVE",
+"99 224 CURVE",
+"140 218 LINE"
+);
+}
+);
+width = 346;
+}
+);
+},
+{
+glyphname = four.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"322 0 LINE",
+"322 17 LINE",
+"267 17 LINE",
+"267 110 LINE",
+"338 110 LINE",
+"338 65 LINE",
+"356 65 LINE",
+"356 172 LINE",
+"338 172 LINE",
+"338 129 LINE",
+"268 129 LINE",
+"268 403 LINE",
+"208 403 LINE",
+"8 129 LINE",
+"8 110 LINE",
+"175 110 LINE",
+"175 17 LINE",
+"115 17 LINE",
+"115 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 133 LINE",
+"171 320 LINE",
+"175 320 LINE",
+"175 129 LINE",
+"36 129 LINE"
+);
+}
+);
+width = 377;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 0 LINE",
+"332 18 LINE",
+"276 18 LINE",
+"276 110 LINE",
+"350 110 LINE",
+"350 65 LINE",
+"369 65 LINE",
+"369 173 LINE",
+"350 173 LINE",
+"350 129 LINE",
+"276 129 LINE",
+"276 403 LINE",
+"210 403 LINE",
+"7 130 LINE",
+"7 110 LINE",
+"176 110 LINE",
+"176 18 LINE",
+"114 18 LINE",
+"114 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 133 LINE",
+"172 318 LINE",
+"176 318 LINE",
+"176 129 LINE",
+"34 129 LINE"
+);
+}
+);
+width = 391;
+}
+);
+},
+{
+glyphname = five.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"251 -8 OFFCURVE",
+"333 39 OFFCURVE",
+"333 123 CURVE SMOOTH",
+"333 189 OFFCURVE",
+"282 247 OFFCURVE",
+"170 247 CURVE SMOOTH",
+"124 247 OFFCURVE",
+"73 237 OFFCURVE",
+"63 231 CURVE",
+"56 202 LINE",
+"67 212 OFFCURVE",
+"101 219 OFFCURVE",
+"128 219 CURVE SMOOTH",
+"183 219 OFFCURVE",
+"222 188 OFFCURVE",
+"222 112 CURVE SMOOTH",
+"222 45 OFFCURVE",
+"192 13 OFFCURVE",
+"135 13 CURVE SMOOTH",
+"113 13 OFFCURVE",
+"81 17 OFFCURVE",
+"81 29 CURVE SMOOTH",
+"81 41 OFFCURVE",
+"117 42 OFFCURVE",
+"117 80 CURVE SMOOTH",
+"117 112 OFFCURVE",
+"92 125 OFFCURVE",
+"68 125 CURVE SMOOTH",
+"37 125 OFFCURVE",
+"15 103 OFFCURVE",
+"15 71 CURVE SMOOTH",
+"15 26 OFFCURVE",
+"62 -8 OFFCURVE",
+"149 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 228 LINE",
+"84 395 LINE",
+"61 395 LINE",
+"47 209 LINE",
+"56 202 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 310 LINE",
+"312 417 LINE",
+"295 417 LINE",
+"288 398 OFFCURVE",
+"281 395 OFFCURVE",
+"259 395 CURVE SMOOTH",
+"65 395 LINE",
+"79 310 LINE"
+);
+}
+);
+width = 349;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 -8 OFFCURVE",
+"346 38 OFFCURVE",
+"346 123 CURVE SMOOTH",
+"346 189 OFFCURVE",
+"298 248 OFFCURVE",
+"181 248 CURVE SMOOTH",
+"132 248 OFFCURVE",
+"75 238 OFFCURVE",
+"64 232 CURVE",
+"57 202 LINE",
+"67 211 OFFCURVE",
+"103 219 OFFCURVE",
+"131 219 CURVE SMOOTH",
+"187 219 OFFCURVE",
+"226 188 OFFCURVE",
+"226 112 CURVE SMOOTH",
+"226 45 OFFCURVE",
+"196 13 OFFCURVE",
+"139 13 CURVE SMOOTH",
+"120 13 OFFCURVE",
+"86 17 OFFCURVE",
+"86 28 CURVE SMOOTH",
+"86 40 OFFCURVE",
+"125 41 OFFCURVE",
+"125 81 CURVE SMOOTH",
+"125 114 OFFCURVE",
+"97 126 OFFCURVE",
+"72 126 CURVE SMOOTH",
+"38 126 OFFCURVE",
+"15 104 OFFCURVE",
+"15 72 CURVE SMOOTH",
+"15 26 OFFCURVE",
+"61 -8 OFFCURVE",
+"154 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 229 LINE",
+"84 395 LINE",
+"60 395 LINE",
+"47 208 LINE",
+"57 202 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 306 LINE",
+"325 418 LINE",
+"307 418 LINE",
+"300 398 OFFCURVE",
+"293 395 OFFCURVE",
+"272 395 CURVE SMOOTH",
+"65 395 LINE",
+"78 306 LINE"
+);
+}
+);
+width = 362;
+}
+);
+},
+{
+glyphname = six.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"260 -8 OFFCURVE",
+"334 50 OFFCURVE",
+"334 129 CURVE SMOOTH",
+"334 199 OFFCURVE",
+"275 253 OFFCURVE",
+"203 253 CURVE SMOOTH",
+"173 253 OFFCURVE",
+"153 244 OFFCURVE",
+"136 230 CURVE",
+"132 230 LINE",
+"144 312 OFFCURVE",
+"199 385 OFFCURVE",
+"287 395 CURVE",
+"287 415 LINE",
+"147 410 OFFCURVE",
+"25 288 OFFCURVE",
+"25 160 CURVE SMOOTH",
+"25 58 OFFCURVE",
+"94 -8 OFFCURVE",
+"180 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 13 OFFCURVE",
+"121 41 OFFCURVE",
+"121 121 CURVE SMOOTH",
+"121 140 OFFCURVE",
+"121 168 OFFCURVE",
+"126 191 CURVE",
+"138 211 OFFCURVE",
+"157 229 OFFCURVE",
+"186 229 CURVE SMOOTH",
+"216 229 OFFCURVE",
+"233 210 OFFCURVE",
+"233 121 CURVE SMOOTH",
+"233 42 OFFCURVE",
+"220 13 OFFCURVE",
+"178 13 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"264 -8 OFFCURVE",
+"338 50 OFFCURVE",
+"338 129 CURVE SMOOTH",
+"338 199 OFFCURVE",
+"281 252 OFFCURVE",
+"208 252 CURVE SMOOTH",
+"179 252 OFFCURVE",
+"159 243 OFFCURVE",
+"141 228 CURVE",
+"138 230 LINE",
+"150 311 OFFCURVE",
+"202 385 OFFCURVE",
+"288 395 CURVE",
+"288 416 LINE",
+"147 411 OFFCURVE",
+"24 288 OFFCURVE",
+"24 160 CURVE SMOOTH",
+"24 58 OFFCURVE",
+"95 -8 OFFCURVE",
+"182 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 13 OFFCURVE",
+"126 42 OFFCURVE",
+"126 121 CURVE SMOOTH",
+"126 140 OFFCURVE",
+"126 167 OFFCURVE",
+"131 190 CURVE",
+"141 210 OFFCURVE",
+"159 228 OFFCURVE",
+"187 228 CURVE SMOOTH",
+"215 228 OFFCURVE",
+"233 209 OFFCURVE",
+"233 121 CURVE SMOOTH",
+"233 43 OFFCURVE",
+"220 13 OFFCURVE",
+"181 13 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+},
+{
+glyphname = seven.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"199 -8 OFFCURVE",
+"226 7 OFFCURVE",
+"226 42 CURVE SMOOTH",
+"226 69 OFFCURVE",
+"209 101 OFFCURVE",
+"209 138 CURVE SMOOTH",
+"209 162 OFFCURVE",
+"220 192 OFFCURVE",
+"245 231 CURVE SMOOTH",
+"325 359 LINE",
+"325 395 LINE",
+"60 395 LINE",
+"20 248 LINE",
+"41 248 LINE",
+"59 300 OFFCURVE",
+"57 309 OFFCURVE",
+"70 309 CURVE SMOOTH",
+"261 309 LINE",
+"166 159 LINE SMOOTH",
+"127 98 OFFCURVE",
+"111 71 OFFCURVE",
+"111 42 CURVE SMOOTH",
+"111 12 OFFCURVE",
+"129 -8 OFFCURVE",
+"166 -8 CURVE SMOOTH"
+);
+}
+);
+width = 335;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 -8 OFFCURVE",
+"237 8 OFFCURVE",
+"237 43 CURVE SMOOTH",
+"237 70 OFFCURVE",
+"220 105 OFFCURVE",
+"220 141 CURVE SMOOTH",
+"220 165 OFFCURVE",
+"232 194 OFFCURVE",
+"257 232 CURVE SMOOTH",
+"339 357 LINE",
+"339 395 LINE",
+"63 395 LINE",
+"20 244 LINE",
+"43 244 LINE",
+"60 298 OFFCURVE",
+"66 306 OFFCURVE",
+"75 306 CURVE SMOOTH",
+"269 306 LINE",
+"173 159 LINE SMOOTH",
+"134 99 OFFCURVE",
+"113 72 OFFCURVE",
+"113 42 CURVE SMOOTH",
+"113 13 OFFCURVE",
+"131 -8 OFFCURVE",
+"171 -8 CURVE SMOOTH"
+);
+}
+);
+width = 351;
+}
+);
+},
+{
+glyphname = eight.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"283 -8 OFFCURVE",
+"334 38 OFFCURVE",
+"334 96 CURVE SMOOTH",
+"334 159 OFFCURVE",
+"283 191 OFFCURVE",
+"213 205 CURVE",
+"213 209 LINE",
+"140 209 LINE",
+"140 205 LINE",
+"68 192 OFFCURVE",
+"17 159 OFFCURVE",
+"17 96 CURVE SMOOTH",
+"17 38 OFFCURVE",
+"69 -8 OFFCURVE",
+"176 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 9 OFFCURVE",
+"118 35 OFFCURVE",
+"118 100 CURVE SMOOTH",
+"118 163 OFFCURVE",
+"133 195 OFFCURVE",
+"176 195 CURVE SMOOTH",
+"219 195 OFFCURVE",
+"233 161 OFFCURVE",
+"233 100 CURVE SMOOTH",
+"233 35 OFFCURVE",
+"216 9 OFFCURVE",
+"176 9 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 216 OFFCURVE",
+"129 246 OFFCURVE",
+"129 303 CURVE SMOOTH",
+"129 359 OFFCURVE",
+"142 383 OFFCURVE",
+"176 383 CURVE SMOOTH",
+"211 383 OFFCURVE",
+"223 359 OFFCURVE",
+"223 303 CURVE SMOOTH",
+"223 246 OFFCURVE",
+"211 216 OFFCURVE",
+"176 216 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 205 OFFCURVE",
+"318 243 OFFCURVE",
+"318 304 CURVE SMOOTH",
+"318 356 OFFCURVE",
+"273 403 OFFCURVE",
+"175 403 CURVE SMOOTH",
+"81 403 OFFCURVE",
+"34 359 OFFCURVE",
+"34 305 CURVE SMOOTH",
+"34 243 OFFCURVE",
+"97 205 OFFCURVE",
+"176 205 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 -8 OFFCURVE",
+"340 38 OFFCURVE",
+"340 96 CURVE SMOOTH",
+"340 160 OFFCURVE",
+"288 190 OFFCURVE",
+"215 204 CURVE",
+"215 210 LINE",
+"142 210 LINE",
+"142 204 LINE",
+"68 191 OFFCURVE",
+"16 160 OFFCURVE",
+"16 96 CURVE SMOOTH",
+"16 38 OFFCURVE",
+"68 -8 OFFCURVE",
+"178 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 9 OFFCURVE",
+"123 35 OFFCURVE",
+"123 100 CURVE SMOOTH",
+"123 163 OFFCURVE",
+"137 194 OFFCURVE",
+"178 194 CURVE SMOOTH",
+"219 194 OFFCURVE",
+"233 161 OFFCURVE",
+"233 100 CURVE SMOOTH",
+"233 35 OFFCURVE",
+"216 9 OFFCURVE",
+"178 9 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 216 OFFCURVE",
+"134 247 OFFCURVE",
+"134 303 CURVE SMOOTH",
+"134 359 OFFCURVE",
+"146 382 OFFCURVE",
+"178 382 CURVE SMOOTH",
+"211 382 OFFCURVE",
+"222 359 OFFCURVE",
+"222 303 CURVE SMOOTH",
+"222 247 OFFCURVE",
+"211 216 OFFCURVE",
+"178 216 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 205 OFFCURVE",
+"324 243 OFFCURVE",
+"324 304 CURVE SMOOTH",
+"324 356 OFFCURVE",
+"278 403 OFFCURVE",
+"177 403 CURVE SMOOTH",
+"81 403 OFFCURVE",
+"32 359 OFFCURVE",
+"32 305 CURVE SMOOTH",
+"32 243 OFFCURVE",
+"97 205 OFFCURVE",
+"178 205 CURVE SMOOTH"
+);
+}
+);
+width = 356;
+}
+);
+},
+{
+glyphname = nine.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"196 1 OFFCURVE",
+"325 104 OFFCURVE",
+"325 235 CURVE SMOOTH",
+"325 337 OFFCURVE",
+"256 403 OFFCURVE",
+"169 403 CURVE SMOOTH",
+"89 403 OFFCURVE",
+"16 344 OFFCURVE",
+"16 266 CURVE SMOOTH",
+"16 196 OFFCURVE",
+"74 142 OFFCURVE",
+"147 142 CURVE SMOOTH",
+"176 142 OFFCURVE",
+"195 149 OFFCURVE",
+"213 164 CURVE",
+"217 164 LINE",
+"205 81 OFFCURVE",
+"145 25 OFFCURVE",
+"57 16 CURVE",
+"57 -4 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 166 OFFCURVE",
+"116 185 OFFCURVE",
+"116 273 CURVE SMOOTH",
+"116 353 OFFCURVE",
+"129 383 OFFCURVE",
+"171 383 CURVE SMOOTH",
+"213 383 OFFCURVE",
+"228 353 OFFCURVE",
+"228 274 CURVE SMOOTH",
+"228 254 OFFCURVE",
+"228 227 OFFCURVE",
+"223 204 CURVE",
+"212 183 OFFCURVE",
+"192 166 OFFCURVE",
+"163 166 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"198 2 OFFCURVE",
+"328 105 OFFCURVE",
+"328 235 CURVE SMOOTH",
+"328 337 OFFCURVE",
+"257 403 OFFCURVE",
+"169 403 CURVE SMOOTH",
+"88 403 OFFCURVE",
+"13 345 OFFCURVE",
+"13 266 CURVE SMOOTH",
+"13 196 OFFCURVE",
+"71 143 OFFCURVE",
+"144 143 CURVE SMOOTH",
+"173 143 OFFCURVE",
+"192 152 OFFCURVE",
+"211 167 CURVE",
+"214 165 LINE",
+"202 83 OFFCURVE",
+"143 27 OFFCURVE",
+"56 17 CURVE",
+"56 -3 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 167 OFFCURVE",
+"119 186 OFFCURVE",
+"119 274 CURVE SMOOTH",
+"119 352 OFFCURVE",
+"132 383 OFFCURVE",
+"171 383 CURVE SMOOTH",
+"211 383 OFFCURVE",
+"226 353 OFFCURVE",
+"226 274 CURVE SMOOTH",
+"226 255 OFFCURVE",
+"225 228 OFFCURVE",
+"220 205 CURVE",
+"210 185 OFFCURVE",
+"192 167 OFFCURVE",
+"164 167 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+},
+{
+glyphname = zero.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH",
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH",
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH"
+);
+}
+);
+width = 407;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH",
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH",
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 351 OFFCURVE",
+"396 433 OFFCURVE",
+"396 556 CURVE SMOOTH",
+"396 678 OFFCURVE",
+"314 762 OFFCURVE",
+"209 762 CURVE SMOOTH",
+"104 762 OFFCURVE",
+"23 678 OFFCURVE",
+"23 556 CURVE SMOOTH",
+"23 433 OFFCURVE",
+"104 351 OFFCURVE",
+"209 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 372 OFFCURVE",
+"131 405 OFFCURVE",
+"131 556 CURVE SMOOTH",
+"131 706 OFFCURVE",
+"149 741 OFFCURVE",
+"209 741 CURVE SMOOTH",
+"265 741 OFFCURVE",
+"287 706 OFFCURVE",
+"287 556 CURVE SMOOTH",
+"287 405 OFFCURVE",
+"265 372 OFFCURVE",
+"209 372 CURVE SMOOTH"
+);
+}
+);
+width = 419;
+}
+);
+},
+{
+glyphname = one.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 359 LINE",
+"266 376 LINE",
+"184 376 LINE",
+"184 754 LINE",
+"4 754 LINE",
+"4 736 LINE",
+"91 736 LINE",
+"91 376 LINE",
+"4 376 LINE",
+"4 359 LINE"
+);
+}
+);
+width = 270;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 359 LINE",
+"275 377 LINE",
+"192 377 LINE",
+"192 754 LINE",
+"3 754 LINE",
+"3 736 LINE",
+"92 736 LINE",
+"92 377 LINE",
+"3 377 LINE",
+"3 359 LINE"
+);
+}
+);
+width = 279;
+}
+);
+},
+{
+glyphname = two.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 359 LINE",
+"321 502 LINE",
+"304 502 LINE",
+"304 449 OFFCURVE",
+"296 444 OFFCURVE",
+"271 444 CURVE SMOOTH",
+"89 444 LINE",
+"89 448 LINE",
+"247 543 LINE SMOOTH",
+"303 576 OFFCURVE",
+"321 615 OFFCURVE",
+"321 655 CURVE SMOOTH",
+"321 732 OFFCURVE",
+"249 762 OFFCURVE",
+"180 762 CURVE SMOOTH",
+"107 762 OFFCURVE",
+"34 729 OFFCURVE",
+"34 662 CURVE SMOOTH",
+"34 630 OFFCURVE",
+"51 595 OFFCURVE",
+"92 595 CURVE SMOOTH",
+"117 595 OFFCURVE",
+"141 610 OFFCURVE",
+"141 643 CURVE SMOOTH",
+"141 666 OFFCURVE",
+"129 684 OFFCURVE",
+"104 684 CURVE SMOOTH",
+"88 684 OFFCURVE",
+"82 677 OFFCURVE",
+"76 677 CURVE SMOOTH",
+"71 677 OFFCURVE",
+"68 681 OFFCURVE",
+"68 688 CURVE SMOOTH",
+"68 710 OFFCURVE",
+"102 738 OFFCURVE",
+"142 738 CURVE SMOOTH",
+"190 738 OFFCURVE",
+"220 699 OFFCURVE",
+"220 635 CURVE SMOOTH",
+"220 591 OFFCURVE",
+"206 559 OFFCURVE",
+"146 514 CURVE SMOOTH",
+"17 416 LINE",
+"17 359 LINE"
+);
+}
+);
+width = 350;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 359 LINE",
+"332 506 LINE",
+"314 506 LINE",
+"314 452 OFFCURVE",
+"306 447 OFFCURVE",
+"280 447 CURVE SMOOTH",
+"95 447 LINE",
+"95 451 LINE",
+"252 542 LINE SMOOTH",
+"309 575 OFFCURVE",
+"332 613 OFFCURVE",
+"332 655 CURVE SMOOTH",
+"332 733 OFFCURVE",
+"257 762 OFFCURVE",
+"186 762 CURVE SMOOTH",
+"111 762 OFFCURVE",
+"36 728 OFFCURVE",
+"36 661 CURVE SMOOTH",
+"36 629 OFFCURVE",
+"53 594 OFFCURVE",
+"95 594 CURVE SMOOTH",
+"123 594 OFFCURVE",
+"147 608 OFFCURVE",
+"147 643 CURVE SMOOTH",
+"147 666 OFFCURVE",
+"137 684 OFFCURVE",
+"109 684 CURVE SMOOTH",
+"93 684 OFFCURVE",
+"86 677 OFFCURVE",
+"81 677 CURVE SMOOTH",
+"77 677 OFFCURVE",
+"73 681 OFFCURVE",
+"73 689 CURVE SMOOTH",
+"73 710 OFFCURVE",
+"106 737 OFFCURVE",
+"144 737 CURVE SMOOTH",
+"192 737 OFFCURVE",
+"223 700 OFFCURVE",
+"223 635 CURVE SMOOTH",
+"223 591 OFFCURVE",
+"210 558 OFFCURVE",
+"149 514 CURVE SMOOTH",
+"16 418 LINE",
+"16 359 LINE"
+);
+}
+);
+width = 360;
+}
+);
+},
+{
+glyphname = three.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"249 351 OFFCURVE",
+"317 409 OFFCURVE",
+"317 472 CURVE SMOOTH",
+"317 542 OFFCURVE",
+"253 575 OFFCURVE",
+"172 578 CURVE",
+"111 563 LINE",
+"182 563 OFFCURVE",
+"208 530 OFFCURVE",
+"208 468 CURVE SMOOTH",
+"208 407 OFFCURVE",
+"183 372 OFFCURVE",
+"133 372 CURVE SMOOTH",
+"115 372 OFFCURVE",
+"74 376 OFFCURVE",
+"74 390 CURVE SMOOTH",
+"74 405 OFFCURVE",
+"111 407 OFFCURVE",
+"111 447 CURVE SMOOTH",
+"111 483 OFFCURVE",
+"83 491 OFFCURVE",
+"64 491 CURVE SMOOTH",
+"30 491 OFFCURVE",
+"13 463 OFFCURVE",
+"13 432 CURVE SMOOTH",
+"13 382 OFFCURVE",
+"61 351 OFFCURVE",
+"141 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 563 LINE",
+"172 584 LINE",
+"76 584 LINE",
+"76 563 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 585 OFFCURVE",
+"299 621 OFFCURVE",
+"299 672 CURVE SMOOTH",
+"299 727 OFFCURVE",
+"247 762 OFFCURVE",
+"161 762 CURVE SMOOTH",
+"71 762 OFFCURVE",
+"36 723 OFFCURVE",
+"36 684 CURVE SMOOTH",
+"36 655 OFFCURVE",
+"55 639 OFFCURVE",
+"81 639 CURVE SMOOTH",
+"104 639 OFFCURVE",
+"130 651 OFFCURVE",
+"130 678 CURVE SMOOTH",
+"130 707 OFFCURVE",
+"99 712 OFFCURVE",
+"99 726 CURVE SMOOTH",
+"99 739 OFFCURVE",
+"123 742 OFFCURVE",
+"143 742 CURVE SMOOTH",
+"176 742 OFFCURVE",
+"197 730 OFFCURVE",
+"197 677 CURVE SMOOTH",
+"197 617 OFFCURVE",
+"170 584 OFFCURVE",
+"100 584 CURVE",
+"139 578 LINE"
+);
+}
+);
+width = 337;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 351 OFFCURVE",
+"327 408 OFFCURVE",
+"327 472 CURVE SMOOTH",
+"327 542 OFFCURVE",
+"258 574 OFFCURVE",
+"173 577 CURVE",
+"111 563 LINE",
+"183 563 OFFCURVE",
+"210 530 OFFCURVE",
+"210 467 CURVE SMOOTH",
+"210 406 OFFCURVE",
+"186 372 OFFCURVE",
+"136 372 CURVE SMOOTH",
+"118 372 OFFCURVE",
+"78 376 OFFCURVE",
+"78 390 CURVE SMOOTH",
+"78 405 OFFCURVE",
+"118 407 OFFCURVE",
+"118 449 CURVE SMOOTH",
+"118 486 OFFCURVE",
+"86 494 OFFCURVE",
+"67 494 CURVE SMOOTH",
+"31 494 OFFCURVE",
+"12 464 OFFCURVE",
+"12 433 CURVE SMOOTH",
+"12 382 OFFCURVE",
+"60 351 OFFCURVE",
+"143 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 563 LINE",
+"173 583 LINE",
+"78 583 LINE",
+"78 563 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 585 OFFCURVE",
+"310 620 OFFCURVE",
+"310 671 CURVE SMOOTH",
+"310 727 OFFCURVE",
+"255 762 OFFCURVE",
+"166 762 CURVE SMOOTH",
+"70 762 OFFCURVE",
+"37 722 OFFCURVE",
+"37 682 CURVE SMOOTH",
+"37 653 OFFCURVE",
+"56 636 OFFCURVE",
+"85 636 CURVE SMOOTH",
+"109 636 OFFCURVE",
+"139 648 OFFCURVE",
+"139 677 CURVE SMOOTH",
+"139 706 OFFCURVE",
+"104 711 OFFCURVE",
+"104 726 CURVE SMOOTH",
+"104 738 OFFCURVE",
+"129 741 OFFCURVE",
+"148 741 CURVE SMOOTH",
+"179 741 OFFCURVE",
+"200 730 OFFCURVE",
+"200 677 CURVE SMOOTH",
+"200 617 OFFCURVE",
+"173 583 OFFCURVE",
+"99 583 CURVE",
+"140 577 LINE"
+);
+}
+);
+width = 346;
+}
+);
+},
+{
+glyphname = four.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"322 359 LINE",
+"322 376 LINE",
+"267 376 LINE",
+"267 469 LINE",
+"338 469 LINE",
+"338 424 LINE",
+"356 424 LINE",
+"356 531 LINE",
+"338 531 LINE",
+"338 488 LINE",
+"268 488 LINE",
+"268 762 LINE",
+"208 762 LINE",
+"8 488 LINE",
+"8 469 LINE",
+"175 469 LINE",
+"175 376 LINE",
+"115 376 LINE",
+"115 359 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 492 LINE",
+"171 679 LINE",
+"175 679 LINE",
+"175 488 LINE",
+"36 488 LINE"
+);
+}
+);
+width = 377;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 359 LINE",
+"332 377 LINE",
+"276 377 LINE",
+"276 469 LINE",
+"350 469 LINE",
+"350 424 LINE",
+"369 424 LINE",
+"369 532 LINE",
+"350 532 LINE",
+"350 488 LINE",
+"276 488 LINE",
+"276 762 LINE",
+"210 762 LINE",
+"7 489 LINE",
+"7 469 LINE",
+"176 469 LINE",
+"176 377 LINE",
+"114 377 LINE",
+"114 359 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 492 LINE",
+"172 677 LINE",
+"176 677 LINE",
+"176 488 LINE",
+"34 488 LINE"
+);
+}
+);
+width = 391;
+}
+);
+},
+{
+glyphname = five.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"251 351 OFFCURVE",
+"333 398 OFFCURVE",
+"333 482 CURVE SMOOTH",
+"333 548 OFFCURVE",
+"282 606 OFFCURVE",
+"170 606 CURVE SMOOTH",
+"124 606 OFFCURVE",
+"73 596 OFFCURVE",
+"63 590 CURVE",
+"56 561 LINE",
+"67 571 OFFCURVE",
+"101 578 OFFCURVE",
+"128 578 CURVE SMOOTH",
+"183 578 OFFCURVE",
+"222 547 OFFCURVE",
+"222 471 CURVE SMOOTH",
+"222 404 OFFCURVE",
+"192 372 OFFCURVE",
+"135 372 CURVE SMOOTH",
+"113 372 OFFCURVE",
+"81 376 OFFCURVE",
+"81 388 CURVE SMOOTH",
+"81 400 OFFCURVE",
+"117 401 OFFCURVE",
+"117 439 CURVE SMOOTH",
+"117 471 OFFCURVE",
+"92 484 OFFCURVE",
+"68 484 CURVE SMOOTH",
+"37 484 OFFCURVE",
+"15 462 OFFCURVE",
+"15 430 CURVE SMOOTH",
+"15 385 OFFCURVE",
+"62 351 OFFCURVE",
+"149 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 587 LINE",
+"84 754 LINE",
+"61 754 LINE",
+"47 568 LINE",
+"56 561 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 669 LINE",
+"312 776 LINE",
+"295 776 LINE",
+"288 757 OFFCURVE",
+"281 754 OFFCURVE",
+"259 754 CURVE SMOOTH",
+"65 754 LINE",
+"79 669 LINE"
+);
+}
+);
+width = 349;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 351 OFFCURVE",
+"346 397 OFFCURVE",
+"346 482 CURVE SMOOTH",
+"346 548 OFFCURVE",
+"298 607 OFFCURVE",
+"181 607 CURVE SMOOTH",
+"132 607 OFFCURVE",
+"75 597 OFFCURVE",
+"64 591 CURVE",
+"57 561 LINE",
+"67 570 OFFCURVE",
+"103 578 OFFCURVE",
+"131 578 CURVE SMOOTH",
+"187 578 OFFCURVE",
+"226 547 OFFCURVE",
+"226 471 CURVE SMOOTH",
+"226 404 OFFCURVE",
+"196 372 OFFCURVE",
+"139 372 CURVE SMOOTH",
+"120 372 OFFCURVE",
+"86 376 OFFCURVE",
+"86 387 CURVE SMOOTH",
+"86 399 OFFCURVE",
+"125 400 OFFCURVE",
+"125 440 CURVE SMOOTH",
+"125 473 OFFCURVE",
+"97 485 OFFCURVE",
+"72 485 CURVE SMOOTH",
+"38 485 OFFCURVE",
+"15 463 OFFCURVE",
+"15 431 CURVE SMOOTH",
+"15 385 OFFCURVE",
+"61 351 OFFCURVE",
+"154 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 588 LINE",
+"84 754 LINE",
+"60 754 LINE",
+"47 567 LINE",
+"57 561 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 665 LINE",
+"325 777 LINE",
+"307 777 LINE",
+"300 757 OFFCURVE",
+"293 754 OFFCURVE",
+"272 754 CURVE SMOOTH",
+"65 754 LINE",
+"78 665 LINE"
+);
+}
+);
+width = 362;
+}
+);
+},
+{
+glyphname = six.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"260 351 OFFCURVE",
+"334 409 OFFCURVE",
+"334 488 CURVE SMOOTH",
+"334 558 OFFCURVE",
+"275 612 OFFCURVE",
+"203 612 CURVE SMOOTH",
+"173 612 OFFCURVE",
+"153 603 OFFCURVE",
+"136 589 CURVE",
+"132 589 LINE",
+"144 671 OFFCURVE",
+"199 744 OFFCURVE",
+"287 754 CURVE",
+"287 774 LINE",
+"147 769 OFFCURVE",
+"25 647 OFFCURVE",
+"25 519 CURVE SMOOTH",
+"25 417 OFFCURVE",
+"94 351 OFFCURVE",
+"180 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 372 OFFCURVE",
+"121 400 OFFCURVE",
+"121 480 CURVE SMOOTH",
+"121 499 OFFCURVE",
+"121 527 OFFCURVE",
+"126 550 CURVE",
+"138 570 OFFCURVE",
+"157 588 OFFCURVE",
+"186 588 CURVE SMOOTH",
+"216 588 OFFCURVE",
+"233 569 OFFCURVE",
+"233 480 CURVE SMOOTH",
+"233 401 OFFCURVE",
+"220 372 OFFCURVE",
+"178 372 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"264 351 OFFCURVE",
+"338 409 OFFCURVE",
+"338 488 CURVE SMOOTH",
+"338 558 OFFCURVE",
+"281 611 OFFCURVE",
+"208 611 CURVE SMOOTH",
+"179 611 OFFCURVE",
+"159 602 OFFCURVE",
+"141 587 CURVE",
+"138 589 LINE",
+"150 670 OFFCURVE",
+"202 744 OFFCURVE",
+"288 754 CURVE",
+"288 775 LINE",
+"147 770 OFFCURVE",
+"24 647 OFFCURVE",
+"24 519 CURVE SMOOTH",
+"24 417 OFFCURVE",
+"95 351 OFFCURVE",
+"182 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 372 OFFCURVE",
+"126 401 OFFCURVE",
+"126 480 CURVE SMOOTH",
+"126 499 OFFCURVE",
+"126 526 OFFCURVE",
+"131 549 CURVE",
+"141 569 OFFCURVE",
+"159 587 OFFCURVE",
+"187 587 CURVE SMOOTH",
+"215 587 OFFCURVE",
+"233 568 OFFCURVE",
+"233 480 CURVE SMOOTH",
+"233 402 OFFCURVE",
+"220 372 OFFCURVE",
+"181 372 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+},
+{
+glyphname = seven.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"199 351 OFFCURVE",
+"226 366 OFFCURVE",
+"226 401 CURVE SMOOTH",
+"226 428 OFFCURVE",
+"209 460 OFFCURVE",
+"209 497 CURVE SMOOTH",
+"209 521 OFFCURVE",
+"220 551 OFFCURVE",
+"245 590 CURVE SMOOTH",
+"325 718 LINE",
+"325 754 LINE",
+"60 754 LINE",
+"20 607 LINE",
+"41 607 LINE",
+"59 659 OFFCURVE",
+"57 668 OFFCURVE",
+"70 668 CURVE SMOOTH",
+"261 668 LINE",
+"166 518 LINE SMOOTH",
+"127 457 OFFCURVE",
+"111 430 OFFCURVE",
+"111 401 CURVE SMOOTH",
+"111 371 OFFCURVE",
+"129 351 OFFCURVE",
+"166 351 CURVE SMOOTH"
+);
+}
+);
+width = 335;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 351 OFFCURVE",
+"237 367 OFFCURVE",
+"237 402 CURVE SMOOTH",
+"237 429 OFFCURVE",
+"220 464 OFFCURVE",
+"220 500 CURVE SMOOTH",
+"220 524 OFFCURVE",
+"232 553 OFFCURVE",
+"257 591 CURVE SMOOTH",
+"339 716 LINE",
+"339 754 LINE",
+"63 754 LINE",
+"20 603 LINE",
+"43 603 LINE",
+"60 657 OFFCURVE",
+"66 665 OFFCURVE",
+"75 665 CURVE SMOOTH",
+"269 665 LINE",
+"173 518 LINE SMOOTH",
+"134 458 OFFCURVE",
+"113 431 OFFCURVE",
+"113 401 CURVE SMOOTH",
+"113 372 OFFCURVE",
+"131 351 OFFCURVE",
+"171 351 CURVE SMOOTH"
+);
+}
+);
+width = 351;
+}
+);
+},
+{
+glyphname = eight.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"283 351 OFFCURVE",
+"334 397 OFFCURVE",
+"334 455 CURVE SMOOTH",
+"334 518 OFFCURVE",
+"283 550 OFFCURVE",
+"213 564 CURVE",
+"213 568 LINE",
+"140 568 LINE",
+"140 564 LINE",
+"68 551 OFFCURVE",
+"17 518 OFFCURVE",
+"17 455 CURVE SMOOTH",
+"17 397 OFFCURVE",
+"69 351 OFFCURVE",
+"176 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 368 OFFCURVE",
+"118 394 OFFCURVE",
+"118 459 CURVE SMOOTH",
+"118 522 OFFCURVE",
+"133 554 OFFCURVE",
+"176 554 CURVE SMOOTH",
+"219 554 OFFCURVE",
+"233 520 OFFCURVE",
+"233 459 CURVE SMOOTH",
+"233 394 OFFCURVE",
+"216 368 OFFCURVE",
+"176 368 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 575 OFFCURVE",
+"129 605 OFFCURVE",
+"129 662 CURVE SMOOTH",
+"129 718 OFFCURVE",
+"142 742 OFFCURVE",
+"176 742 CURVE SMOOTH",
+"211 742 OFFCURVE",
+"223 718 OFFCURVE",
+"223 662 CURVE SMOOTH",
+"223 605 OFFCURVE",
+"211 575 OFFCURVE",
+"176 575 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 564 OFFCURVE",
+"318 602 OFFCURVE",
+"318 663 CURVE SMOOTH",
+"318 715 OFFCURVE",
+"273 762 OFFCURVE",
+"175 762 CURVE SMOOTH",
+"81 762 OFFCURVE",
+"34 718 OFFCURVE",
+"34 664 CURVE SMOOTH",
+"34 602 OFFCURVE",
+"97 564 OFFCURVE",
+"176 564 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 351 OFFCURVE",
+"340 397 OFFCURVE",
+"340 455 CURVE SMOOTH",
+"340 519 OFFCURVE",
+"288 549 OFFCURVE",
+"215 563 CURVE",
+"215 569 LINE",
+"142 569 LINE",
+"142 563 LINE",
+"68 550 OFFCURVE",
+"16 519 OFFCURVE",
+"16 455 CURVE SMOOTH",
+"16 397 OFFCURVE",
+"68 351 OFFCURVE",
+"178 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 368 OFFCURVE",
+"123 394 OFFCURVE",
+"123 459 CURVE SMOOTH",
+"123 522 OFFCURVE",
+"137 553 OFFCURVE",
+"178 553 CURVE SMOOTH",
+"219 553 OFFCURVE",
+"233 520 OFFCURVE",
+"233 459 CURVE SMOOTH",
+"233 394 OFFCURVE",
+"216 368 OFFCURVE",
+"178 368 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 575 OFFCURVE",
+"134 606 OFFCURVE",
+"134 662 CURVE SMOOTH",
+"134 718 OFFCURVE",
+"146 741 OFFCURVE",
+"178 741 CURVE SMOOTH",
+"211 741 OFFCURVE",
+"222 718 OFFCURVE",
+"222 662 CURVE SMOOTH",
+"222 606 OFFCURVE",
+"211 575 OFFCURVE",
+"178 575 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 564 OFFCURVE",
+"324 602 OFFCURVE",
+"324 663 CURVE SMOOTH",
+"324 715 OFFCURVE",
+"278 762 OFFCURVE",
+"177 762 CURVE SMOOTH",
+"81 762 OFFCURVE",
+"32 718 OFFCURVE",
+"32 664 CURVE SMOOTH",
+"32 602 OFFCURVE",
+"97 564 OFFCURVE",
+"178 564 CURVE SMOOTH"
+);
+}
+);
+width = 356;
+}
+);
+},
+{
+glyphname = nine.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"196 360 OFFCURVE",
+"325 463 OFFCURVE",
+"325 594 CURVE SMOOTH",
+"325 696 OFFCURVE",
+"256 762 OFFCURVE",
+"169 762 CURVE SMOOTH",
+"89 762 OFFCURVE",
+"16 703 OFFCURVE",
+"16 625 CURVE SMOOTH",
+"16 555 OFFCURVE",
+"74 501 OFFCURVE",
+"147 501 CURVE SMOOTH",
+"176 501 OFFCURVE",
+"195 508 OFFCURVE",
+"213 523 CURVE",
+"217 523 LINE",
+"205 440 OFFCURVE",
+"145 384 OFFCURVE",
+"57 375 CURVE",
+"57 355 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 525 OFFCURVE",
+"116 544 OFFCURVE",
+"116 632 CURVE SMOOTH",
+"116 712 OFFCURVE",
+"129 742 OFFCURVE",
+"171 742 CURVE SMOOTH",
+"213 742 OFFCURVE",
+"228 712 OFFCURVE",
+"228 633 CURVE SMOOTH",
+"228 613 OFFCURVE",
+"228 586 OFFCURVE",
+"223 563 CURVE",
+"212 542 OFFCURVE",
+"192 525 OFFCURVE",
+"163 525 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"198 361 OFFCURVE",
+"328 464 OFFCURVE",
+"328 594 CURVE SMOOTH",
+"328 696 OFFCURVE",
+"257 762 OFFCURVE",
+"169 762 CURVE SMOOTH",
+"88 762 OFFCURVE",
+"13 704 OFFCURVE",
+"13 625 CURVE SMOOTH",
+"13 555 OFFCURVE",
+"71 502 OFFCURVE",
+"144 502 CURVE SMOOTH",
+"173 502 OFFCURVE",
+"192 511 OFFCURVE",
+"211 526 CURVE",
+"214 524 LINE",
+"202 442 OFFCURVE",
+"143 386 OFFCURVE",
+"56 376 CURVE",
+"56 356 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 526 OFFCURVE",
+"119 545 OFFCURVE",
+"119 633 CURVE SMOOTH",
+"119 711 OFFCURVE",
+"132 742 OFFCURVE",
+"171 742 CURVE SMOOTH",
+"211 742 OFFCURVE",
+"226 712 OFFCURVE",
+"226 633 CURVE SMOOTH",
+"226 614 OFFCURVE",
+"225 587 OFFCURVE",
+"220 564 CURVE",
+"210 544 OFFCURVE",
+"192 526 OFFCURVE",
+"164 526 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+},
+{
+glyphname = zeroinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"305 -108 OFFCURVE",
+"383 -25 OFFCURVE",
+"383 97 CURVE SMOOTH",
+"383 219 OFFCURVE",
+"305 303 OFFCURVE",
+"203 303 CURVE SMOOTH",
+"101 303 OFFCURVE",
+"24 219 OFFCURVE",
+"24 97 CURVE SMOOTH",
+"24 -25 OFFCURVE",
+"101 -108 OFFCURVE",
+"203 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 -87 OFFCURVE",
+"126 -53 OFFCURVE",
+"126 97 CURVE SMOOTH",
+"126 248 OFFCURVE",
+"144 283 OFFCURVE",
+"203 283 CURVE SMOOTH",
+"259 283 OFFCURVE",
+"280 248 OFFCURVE",
+"280 97 CURVE SMOOTH",
+"280 -53 OFFCURVE",
+"259 -87 OFFCURVE",
+"203 -87 CURVE SMOOTH"
+);
+}
+);
+width = 407;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH",
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH",
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 -108 OFFCURVE",
+"396 -26 OFFCURVE",
+"396 97 CURVE SMOOTH",
+"396 219 OFFCURVE",
+"314 303 OFFCURVE",
+"209 303 CURVE SMOOTH",
+"104 303 OFFCURVE",
+"23 219 OFFCURVE",
+"23 97 CURVE SMOOTH",
+"23 -26 OFFCURVE",
+"104 -108 OFFCURVE",
+"209 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 -87 OFFCURVE",
+"131 -54 OFFCURVE",
+"131 97 CURVE SMOOTH",
+"131 247 OFFCURVE",
+"149 282 OFFCURVE",
+"209 282 CURVE SMOOTH",
+"265 282 OFFCURVE",
+"287 247 OFFCURVE",
+"287 97 CURVE SMOOTH",
+"287 -54 OFFCURVE",
+"265 -87 OFFCURVE",
+"209 -87 CURVE SMOOTH"
+);
+}
+);
+width = 419;
+}
+);
+unicode = 2080;
+},
+{
+glyphname = oneinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 -100 LINE",
+"266 -83 LINE",
+"184 -83 LINE",
+"184 295 LINE",
+"4 295 LINE",
+"4 277 LINE",
+"91 277 LINE",
+"91 -83 LINE",
+"4 -83 LINE",
+"4 -100 LINE"
+);
+}
+);
+width = 270;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 -100 LINE",
+"275 -82 LINE",
+"192 -82 LINE",
+"192 295 LINE",
+"3 295 LINE",
+"3 277 LINE",
+"92 277 LINE",
+"92 -82 LINE",
+"3 -82 LINE",
+"3 -100 LINE"
+);
+}
+);
+width = 279;
+}
+);
+unicode = 2081;
+},
+{
+glyphname = twoinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 -100 LINE",
+"321 43 LINE",
+"304 43 LINE",
+"304 -10 OFFCURVE",
+"296 -15 OFFCURVE",
+"271 -15 CURVE SMOOTH",
+"89 -15 LINE",
+"89 -11 LINE",
+"247 84 LINE SMOOTH",
+"303 117 OFFCURVE",
+"321 156 OFFCURVE",
+"321 196 CURVE SMOOTH",
+"321 273 OFFCURVE",
+"249 303 OFFCURVE",
+"180 303 CURVE SMOOTH",
+"107 303 OFFCURVE",
+"34 270 OFFCURVE",
+"34 203 CURVE SMOOTH",
+"34 171 OFFCURVE",
+"51 136 OFFCURVE",
+"92 136 CURVE SMOOTH",
+"117 136 OFFCURVE",
+"141 151 OFFCURVE",
+"141 184 CURVE SMOOTH",
+"141 207 OFFCURVE",
+"129 225 OFFCURVE",
+"104 225 CURVE SMOOTH",
+"88 225 OFFCURVE",
+"82 218 OFFCURVE",
+"76 218 CURVE SMOOTH",
+"71 218 OFFCURVE",
+"68 222 OFFCURVE",
+"68 229 CURVE SMOOTH",
+"68 251 OFFCURVE",
+"102 279 OFFCURVE",
+"142 279 CURVE SMOOTH",
+"190 279 OFFCURVE",
+"220 240 OFFCURVE",
+"220 176 CURVE SMOOTH",
+"220 132 OFFCURVE",
+"206 100 OFFCURVE",
+"146 55 CURVE SMOOTH",
+"17 -43 LINE",
+"17 -100 LINE"
+);
+}
+);
+width = 350;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 -100 LINE",
+"332 47 LINE",
+"314 47 LINE",
+"314 -7 OFFCURVE",
+"306 -12 OFFCURVE",
+"280 -12 CURVE SMOOTH",
+"95 -12 LINE",
+"95 -8 LINE",
+"252 83 LINE SMOOTH",
+"309 116 OFFCURVE",
+"332 154 OFFCURVE",
+"332 196 CURVE SMOOTH",
+"332 274 OFFCURVE",
+"257 303 OFFCURVE",
+"186 303 CURVE SMOOTH",
+"111 303 OFFCURVE",
+"36 269 OFFCURVE",
+"36 202 CURVE SMOOTH",
+"36 170 OFFCURVE",
+"53 135 OFFCURVE",
+"95 135 CURVE SMOOTH",
+"123 135 OFFCURVE",
+"147 149 OFFCURVE",
+"147 184 CURVE SMOOTH",
+"147 207 OFFCURVE",
+"137 225 OFFCURVE",
+"109 225 CURVE SMOOTH",
+"93 225 OFFCURVE",
+"86 218 OFFCURVE",
+"81 218 CURVE SMOOTH",
+"77 218 OFFCURVE",
+"73 222 OFFCURVE",
+"73 230 CURVE SMOOTH",
+"73 251 OFFCURVE",
+"106 278 OFFCURVE",
+"144 278 CURVE SMOOTH",
+"192 278 OFFCURVE",
+"223 241 OFFCURVE",
+"223 176 CURVE SMOOTH",
+"223 132 OFFCURVE",
+"210 99 OFFCURVE",
+"149 55 CURVE SMOOTH",
+"16 -41 LINE",
+"16 -100 LINE"
+);
+}
+);
+width = 360;
+}
+);
+unicode = 2082;
+},
+{
+glyphname = threeinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"249 -108 OFFCURVE",
+"317 -50 OFFCURVE",
+"317 13 CURVE SMOOTH",
+"317 83 OFFCURVE",
+"253 116 OFFCURVE",
+"172 119 CURVE",
+"111 104 LINE",
+"182 104 OFFCURVE",
+"208 71 OFFCURVE",
+"208 9 CURVE SMOOTH",
+"208 -52 OFFCURVE",
+"183 -87 OFFCURVE",
+"133 -87 CURVE SMOOTH",
+"115 -87 OFFCURVE",
+"74 -83 OFFCURVE",
+"74 -69 CURVE SMOOTH",
+"74 -54 OFFCURVE",
+"111 -52 OFFCURVE",
+"111 -12 CURVE SMOOTH",
+"111 24 OFFCURVE",
+"83 32 OFFCURVE",
+"64 32 CURVE SMOOTH",
+"30 32 OFFCURVE",
+"13 4 OFFCURVE",
+"13 -27 CURVE SMOOTH",
+"13 -77 OFFCURVE",
+"61 -108 OFFCURVE",
+"141 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 104 LINE",
+"172 125 LINE",
+"76 125 LINE",
+"76 104 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 126 OFFCURVE",
+"299 162 OFFCURVE",
+"299 213 CURVE SMOOTH",
+"299 268 OFFCURVE",
+"247 303 OFFCURVE",
+"161 303 CURVE SMOOTH",
+"71 303 OFFCURVE",
+"36 264 OFFCURVE",
+"36 225 CURVE SMOOTH",
+"36 196 OFFCURVE",
+"55 180 OFFCURVE",
+"81 180 CURVE SMOOTH",
+"104 180 OFFCURVE",
+"130 192 OFFCURVE",
+"130 219 CURVE SMOOTH",
+"130 248 OFFCURVE",
+"99 253 OFFCURVE",
+"99 267 CURVE SMOOTH",
+"99 280 OFFCURVE",
+"123 283 OFFCURVE",
+"143 283 CURVE SMOOTH",
+"176 283 OFFCURVE",
+"197 271 OFFCURVE",
+"197 218 CURVE SMOOTH",
+"197 158 OFFCURVE",
+"170 125 OFFCURVE",
+"100 125 CURVE",
+"139 119 LINE"
+);
+}
+);
+width = 337;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 -108 OFFCURVE",
+"327 -51 OFFCURVE",
+"327 13 CURVE SMOOTH",
+"327 83 OFFCURVE",
+"258 115 OFFCURVE",
+"173 118 CURVE",
+"111 104 LINE",
+"183 104 OFFCURVE",
+"210 71 OFFCURVE",
+"210 8 CURVE SMOOTH",
+"210 -53 OFFCURVE",
+"186 -87 OFFCURVE",
+"136 -87 CURVE SMOOTH",
+"118 -87 OFFCURVE",
+"78 -83 OFFCURVE",
+"78 -69 CURVE SMOOTH",
+"78 -54 OFFCURVE",
+"118 -52 OFFCURVE",
+"118 -10 CURVE SMOOTH",
+"118 27 OFFCURVE",
+"86 35 OFFCURVE",
+"67 35 CURVE SMOOTH",
+"31 35 OFFCURVE",
+"12 5 OFFCURVE",
+"12 -26 CURVE SMOOTH",
+"12 -77 OFFCURVE",
+"60 -108 OFFCURVE",
+"143 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 104 LINE",
+"173 124 LINE",
+"78 124 LINE",
+"78 104 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 126 OFFCURVE",
+"310 161 OFFCURVE",
+"310 212 CURVE SMOOTH",
+"310 268 OFFCURVE",
+"255 303 OFFCURVE",
+"166 303 CURVE SMOOTH",
+"70 303 OFFCURVE",
+"37 263 OFFCURVE",
+"37 223 CURVE SMOOTH",
+"37 194 OFFCURVE",
+"56 177 OFFCURVE",
+"85 177 CURVE SMOOTH",
+"109 177 OFFCURVE",
+"139 189 OFFCURVE",
+"139 218 CURVE SMOOTH",
+"139 247 OFFCURVE",
+"104 252 OFFCURVE",
+"104 267 CURVE SMOOTH",
+"104 279 OFFCURVE",
+"129 282 OFFCURVE",
+"148 282 CURVE SMOOTH",
+"179 282 OFFCURVE",
+"200 271 OFFCURVE",
+"200 218 CURVE SMOOTH",
+"200 158 OFFCURVE",
+"173 124 OFFCURVE",
+"99 124 CURVE",
+"140 118 LINE"
+);
+}
+);
+width = 346;
+}
+);
+unicode = 2083;
+},
+{
+glyphname = fourinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"322 -100 LINE",
+"322 -83 LINE",
+"267 -83 LINE",
+"267 10 LINE",
+"338 10 LINE",
+"338 -35 LINE",
+"356 -35 LINE",
+"356 72 LINE",
+"338 72 LINE",
+"338 29 LINE",
+"268 29 LINE",
+"268 303 LINE",
+"208 303 LINE",
+"8 29 LINE",
+"8 10 LINE",
+"175 10 LINE",
+"175 -83 LINE",
+"115 -83 LINE",
+"115 -100 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 33 LINE",
+"171 220 LINE",
+"175 220 LINE",
+"175 29 LINE",
+"36 29 LINE"
+);
+}
+);
+width = 377;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 -100 LINE",
+"332 -82 LINE",
+"276 -82 LINE",
+"276 10 LINE",
+"350 10 LINE",
+"350 -35 LINE",
+"369 -35 LINE",
+"369 73 LINE",
+"350 73 LINE",
+"350 29 LINE",
+"276 29 LINE",
+"276 303 LINE",
+"210 303 LINE",
+"7 30 LINE",
+"7 10 LINE",
+"176 10 LINE",
+"176 -82 LINE",
+"114 -82 LINE",
+"114 -100 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 33 LINE",
+"172 218 LINE",
+"176 218 LINE",
+"176 29 LINE",
+"34 29 LINE"
+);
+}
+);
+width = 391;
+}
+);
+unicode = 2084;
+},
+{
+glyphname = fiveinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"251 -108 OFFCURVE",
+"333 -61 OFFCURVE",
+"333 23 CURVE SMOOTH",
+"333 89 OFFCURVE",
+"282 147 OFFCURVE",
+"170 147 CURVE SMOOTH",
+"124 147 OFFCURVE",
+"73 137 OFFCURVE",
+"63 131 CURVE",
+"56 102 LINE",
+"67 112 OFFCURVE",
+"101 119 OFFCURVE",
+"128 119 CURVE SMOOTH",
+"183 119 OFFCURVE",
+"222 88 OFFCURVE",
+"222 12 CURVE SMOOTH",
+"222 -55 OFFCURVE",
+"192 -87 OFFCURVE",
+"135 -87 CURVE SMOOTH",
+"113 -87 OFFCURVE",
+"81 -83 OFFCURVE",
+"81 -71 CURVE SMOOTH",
+"81 -59 OFFCURVE",
+"117 -58 OFFCURVE",
+"117 -20 CURVE SMOOTH",
+"117 12 OFFCURVE",
+"92 25 OFFCURVE",
+"68 25 CURVE SMOOTH",
+"37 25 OFFCURVE",
+"15 3 OFFCURVE",
+"15 -29 CURVE SMOOTH",
+"15 -74 OFFCURVE",
+"62 -108 OFFCURVE",
+"149 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 128 LINE",
+"84 295 LINE",
+"61 295 LINE",
+"47 109 LINE",
+"56 102 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 210 LINE",
+"312 317 LINE",
+"295 317 LINE",
+"288 298 OFFCURVE",
+"281 295 OFFCURVE",
+"259 295 CURVE SMOOTH",
+"65 295 LINE",
+"79 210 LINE"
+);
+}
+);
+width = 349;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 -108 OFFCURVE",
+"346 -62 OFFCURVE",
+"346 23 CURVE SMOOTH",
+"346 89 OFFCURVE",
+"298 148 OFFCURVE",
+"181 148 CURVE SMOOTH",
+"132 148 OFFCURVE",
+"75 138 OFFCURVE",
+"64 132 CURVE",
+"57 102 LINE",
+"67 111 OFFCURVE",
+"103 119 OFFCURVE",
+"131 119 CURVE SMOOTH",
+"187 119 OFFCURVE",
+"226 88 OFFCURVE",
+"226 12 CURVE SMOOTH",
+"226 -55 OFFCURVE",
+"196 -87 OFFCURVE",
+"139 -87 CURVE SMOOTH",
+"120 -87 OFFCURVE",
+"86 -83 OFFCURVE",
+"86 -72 CURVE SMOOTH",
+"86 -60 OFFCURVE",
+"125 -59 OFFCURVE",
+"125 -19 CURVE SMOOTH",
+"125 14 OFFCURVE",
+"97 26 OFFCURVE",
+"72 26 CURVE SMOOTH",
+"38 26 OFFCURVE",
+"15 4 OFFCURVE",
+"15 -28 CURVE SMOOTH",
+"15 -74 OFFCURVE",
+"61 -108 OFFCURVE",
+"154 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 129 LINE",
+"84 295 LINE",
+"60 295 LINE",
+"47 108 LINE",
+"57 102 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 206 LINE",
+"325 318 LINE",
+"307 318 LINE",
+"300 298 OFFCURVE",
+"293 295 OFFCURVE",
+"272 295 CURVE SMOOTH",
+"65 295 LINE",
+"78 206 LINE"
+);
+}
+);
+width = 362;
+}
+);
+unicode = 2085;
+},
+{
+glyphname = sixinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"260 -108 OFFCURVE",
+"334 -50 OFFCURVE",
+"334 29 CURVE SMOOTH",
+"334 99 OFFCURVE",
+"275 153 OFFCURVE",
+"203 153 CURVE SMOOTH",
+"173 153 OFFCURVE",
+"153 144 OFFCURVE",
+"136 130 CURVE",
+"132 130 LINE",
+"144 212 OFFCURVE",
+"199 285 OFFCURVE",
+"287 295 CURVE",
+"287 315 LINE",
+"147 310 OFFCURVE",
+"25 188 OFFCURVE",
+"25 60 CURVE SMOOTH",
+"25 -42 OFFCURVE",
+"94 -108 OFFCURVE",
+"180 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 -87 OFFCURVE",
+"121 -59 OFFCURVE",
+"121 21 CURVE SMOOTH",
+"121 40 OFFCURVE",
+"121 68 OFFCURVE",
+"126 91 CURVE",
+"138 111 OFFCURVE",
+"157 129 OFFCURVE",
+"186 129 CURVE SMOOTH",
+"216 129 OFFCURVE",
+"233 110 OFFCURVE",
+"233 21 CURVE SMOOTH",
+"233 -58 OFFCURVE",
+"220 -87 OFFCURVE",
+"178 -87 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"264 -108 OFFCURVE",
+"338 -50 OFFCURVE",
+"338 29 CURVE SMOOTH",
+"338 99 OFFCURVE",
+"281 152 OFFCURVE",
+"208 152 CURVE SMOOTH",
+"179 152 OFFCURVE",
+"159 143 OFFCURVE",
+"141 128 CURVE",
+"138 130 LINE",
+"150 211 OFFCURVE",
+"202 285 OFFCURVE",
+"288 295 CURVE",
+"288 316 LINE",
+"147 311 OFFCURVE",
+"24 188 OFFCURVE",
+"24 60 CURVE SMOOTH",
+"24 -42 OFFCURVE",
+"95 -108 OFFCURVE",
+"182 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 -87 OFFCURVE",
+"126 -58 OFFCURVE",
+"126 21 CURVE SMOOTH",
+"126 40 OFFCURVE",
+"126 67 OFFCURVE",
+"131 90 CURVE",
+"141 110 OFFCURVE",
+"159 128 OFFCURVE",
+"187 128 CURVE SMOOTH",
+"215 128 OFFCURVE",
+"233 109 OFFCURVE",
+"233 21 CURVE SMOOTH",
+"233 -57 OFFCURVE",
+"220 -87 OFFCURVE",
+"181 -87 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+unicode = 2086;
+},
+{
+glyphname = seveninferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"199 -108 OFFCURVE",
+"226 -93 OFFCURVE",
+"226 -58 CURVE SMOOTH",
+"226 -31 OFFCURVE",
+"209 1 OFFCURVE",
+"209 38 CURVE SMOOTH",
+"209 62 OFFCURVE",
+"220 92 OFFCURVE",
+"245 131 CURVE SMOOTH",
+"325 259 LINE",
+"325 295 LINE",
+"60 295 LINE",
+"20 148 LINE",
+"41 148 LINE",
+"59 200 OFFCURVE",
+"57 209 OFFCURVE",
+"70 209 CURVE SMOOTH",
+"261 209 LINE",
+"166 59 LINE SMOOTH",
+"127 -2 OFFCURVE",
+"111 -29 OFFCURVE",
+"111 -58 CURVE SMOOTH",
+"111 -88 OFFCURVE",
+"129 -108 OFFCURVE",
+"166 -108 CURVE SMOOTH"
+);
+}
+);
+width = 335;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 -108 OFFCURVE",
+"237 -92 OFFCURVE",
+"237 -57 CURVE SMOOTH",
+"237 -30 OFFCURVE",
+"220 5 OFFCURVE",
+"220 41 CURVE SMOOTH",
+"220 65 OFFCURVE",
+"232 94 OFFCURVE",
+"257 132 CURVE SMOOTH",
+"339 257 LINE",
+"339 295 LINE",
+"63 295 LINE",
+"20 144 LINE",
+"43 144 LINE",
+"60 198 OFFCURVE",
+"66 206 OFFCURVE",
+"75 206 CURVE SMOOTH",
+"269 206 LINE",
+"173 59 LINE SMOOTH",
+"134 -1 OFFCURVE",
+"113 -28 OFFCURVE",
+"113 -58 CURVE SMOOTH",
+"113 -87 OFFCURVE",
+"131 -108 OFFCURVE",
+"171 -108 CURVE SMOOTH"
+);
+}
+);
+width = 351;
+}
+);
+unicode = 2087;
+},
+{
+glyphname = eightinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"283 -108 OFFCURVE",
+"334 -62 OFFCURVE",
+"334 -4 CURVE SMOOTH",
+"334 59 OFFCURVE",
+"283 91 OFFCURVE",
+"213 105 CURVE",
+"213 109 LINE",
+"140 109 LINE",
+"140 105 LINE",
+"68 92 OFFCURVE",
+"17 59 OFFCURVE",
+"17 -4 CURVE SMOOTH",
+"17 -62 OFFCURVE",
+"69 -108 OFFCURVE",
+"176 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 -91 OFFCURVE",
+"118 -65 OFFCURVE",
+"118 0 CURVE SMOOTH",
+"118 63 OFFCURVE",
+"133 95 OFFCURVE",
+"176 95 CURVE SMOOTH",
+"219 95 OFFCURVE",
+"233 61 OFFCURVE",
+"233 0 CURVE SMOOTH",
+"233 -65 OFFCURVE",
+"216 -91 OFFCURVE",
+"176 -91 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 116 OFFCURVE",
+"129 146 OFFCURVE",
+"129 203 CURVE SMOOTH",
+"129 259 OFFCURVE",
+"142 283 OFFCURVE",
+"176 283 CURVE SMOOTH",
+"211 283 OFFCURVE",
+"223 259 OFFCURVE",
+"223 203 CURVE SMOOTH",
+"223 146 OFFCURVE",
+"211 116 OFFCURVE",
+"176 116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 105 OFFCURVE",
+"318 143 OFFCURVE",
+"318 204 CURVE SMOOTH",
+"318 256 OFFCURVE",
+"273 303 OFFCURVE",
+"175 303 CURVE SMOOTH",
+"81 303 OFFCURVE",
+"34 259 OFFCURVE",
+"34 205 CURVE SMOOTH",
+"34 143 OFFCURVE",
+"97 105 OFFCURVE",
+"176 105 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 -108 OFFCURVE",
+"340 -62 OFFCURVE",
+"340 -4 CURVE SMOOTH",
+"340 60 OFFCURVE",
+"288 90 OFFCURVE",
+"215 104 CURVE",
+"215 110 LINE",
+"142 110 LINE",
+"142 104 LINE",
+"68 91 OFFCURVE",
+"16 60 OFFCURVE",
+"16 -4 CURVE SMOOTH",
+"16 -62 OFFCURVE",
+"68 -108 OFFCURVE",
+"178 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 -91 OFFCURVE",
+"123 -65 OFFCURVE",
+"123 0 CURVE SMOOTH",
+"123 63 OFFCURVE",
+"137 94 OFFCURVE",
+"178 94 CURVE SMOOTH",
+"219 94 OFFCURVE",
+"233 61 OFFCURVE",
+"233 0 CURVE SMOOTH",
+"233 -65 OFFCURVE",
+"216 -91 OFFCURVE",
+"178 -91 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 116 OFFCURVE",
+"134 147 OFFCURVE",
+"134 203 CURVE SMOOTH",
+"134 259 OFFCURVE",
+"146 282 OFFCURVE",
+"178 282 CURVE SMOOTH",
+"211 282 OFFCURVE",
+"222 259 OFFCURVE",
+"222 203 CURVE SMOOTH",
+"222 147 OFFCURVE",
+"211 116 OFFCURVE",
+"178 116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 105 OFFCURVE",
+"324 143 OFFCURVE",
+"324 204 CURVE SMOOTH",
+"324 256 OFFCURVE",
+"278 303 OFFCURVE",
+"177 303 CURVE SMOOTH",
+"81 303 OFFCURVE",
+"32 259 OFFCURVE",
+"32 205 CURVE SMOOTH",
+"32 143 OFFCURVE",
+"97 105 OFFCURVE",
+"178 105 CURVE SMOOTH"
+);
+}
+);
+width = 356;
+}
+);
+unicode = 2088;
+},
+{
+glyphname = nineinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"196 -99 OFFCURVE",
+"325 4 OFFCURVE",
+"325 135 CURVE SMOOTH",
+"325 237 OFFCURVE",
+"256 303 OFFCURVE",
+"169 303 CURVE SMOOTH",
+"89 303 OFFCURVE",
+"16 244 OFFCURVE",
+"16 166 CURVE SMOOTH",
+"16 96 OFFCURVE",
+"74 42 OFFCURVE",
+"147 42 CURVE SMOOTH",
+"176 42 OFFCURVE",
+"195 49 OFFCURVE",
+"213 64 CURVE",
+"217 64 LINE",
+"205 -19 OFFCURVE",
+"145 -75 OFFCURVE",
+"57 -84 CURVE",
+"57 -104 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 66 OFFCURVE",
+"116 85 OFFCURVE",
+"116 173 CURVE SMOOTH",
+"116 253 OFFCURVE",
+"129 283 OFFCURVE",
+"171 283 CURVE SMOOTH",
+"213 283 OFFCURVE",
+"228 253 OFFCURVE",
+"228 174 CURVE SMOOTH",
+"228 154 OFFCURVE",
+"228 127 OFFCURVE",
+"223 104 CURVE",
+"212 83 OFFCURVE",
+"192 66 OFFCURVE",
+"163 66 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"198 -98 OFFCURVE",
+"328 5 OFFCURVE",
+"328 135 CURVE SMOOTH",
+"328 237 OFFCURVE",
+"257 303 OFFCURVE",
+"169 303 CURVE SMOOTH",
+"88 303 OFFCURVE",
+"13 245 OFFCURVE",
+"13 166 CURVE SMOOTH",
+"13 96 OFFCURVE",
+"71 43 OFFCURVE",
+"144 43 CURVE SMOOTH",
+"173 43 OFFCURVE",
+"192 52 OFFCURVE",
+"211 67 CURVE",
+"214 65 LINE",
+"202 -17 OFFCURVE",
+"143 -73 OFFCURVE",
+"56 -83 CURVE",
+"56 -103 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 67 OFFCURVE",
+"119 86 OFFCURVE",
+"119 174 CURVE SMOOTH",
+"119 252 OFFCURVE",
+"132 283 OFFCURVE",
+"171 283 CURVE SMOOTH",
+"211 283 OFFCURVE",
+"226 253 OFFCURVE",
+"226 174 CURVE SMOOTH",
+"226 155 OFFCURVE",
+"225 128 OFFCURVE",
+"220 105 CURVE",
+"210 85 OFFCURVE",
+"192 67 OFFCURVE",
+"164 67 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+unicode = 2089;
+},
+{
+glyphname = zerosuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"305 451 OFFCURVE",
+"383 534 OFFCURVE",
+"383 656 CURVE SMOOTH",
+"383 778 OFFCURVE",
+"305 862 OFFCURVE",
+"203 862 CURVE SMOOTH",
+"101 862 OFFCURVE",
+"24 778 OFFCURVE",
+"24 656 CURVE SMOOTH",
+"24 534 OFFCURVE",
+"101 451 OFFCURVE",
+"203 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 472 OFFCURVE",
+"126 506 OFFCURVE",
+"126 656 CURVE SMOOTH",
+"126 807 OFFCURVE",
+"144 842 OFFCURVE",
+"203 842 CURVE SMOOTH",
+"259 842 OFFCURVE",
+"280 807 OFFCURVE",
+"280 656 CURVE SMOOTH",
+"280 506 OFFCURVE",
+"259 472 OFFCURVE",
+"203 472 CURVE SMOOTH"
+);
+}
+);
+width = 407;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH",
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH",
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 451 OFFCURVE",
+"396 533 OFFCURVE",
+"396 656 CURVE SMOOTH",
+"396 778 OFFCURVE",
+"314 862 OFFCURVE",
+"209 862 CURVE SMOOTH",
+"104 862 OFFCURVE",
+"23 778 OFFCURVE",
+"23 656 CURVE SMOOTH",
+"23 533 OFFCURVE",
+"104 451 OFFCURVE",
+"209 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 472 OFFCURVE",
+"131 505 OFFCURVE",
+"131 656 CURVE SMOOTH",
+"131 806 OFFCURVE",
+"149 841 OFFCURVE",
+"209 841 CURVE SMOOTH",
+"265 841 OFFCURVE",
+"287 806 OFFCURVE",
+"287 656 CURVE SMOOTH",
+"287 505 OFFCURVE",
+"265 472 OFFCURVE",
+"209 472 CURVE SMOOTH"
+);
+}
+);
+width = 419;
+}
+);
+unicode = 2070;
+},
+{
+glyphname = onesuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 459 LINE",
+"266 476 LINE",
+"184 476 LINE",
+"184 854 LINE",
+"4 854 LINE",
+"4 836 LINE",
+"91 836 LINE",
+"91 476 LINE",
+"4 476 LINE",
+"4 459 LINE"
+);
+}
+);
+width = 270;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 459 LINE",
+"275 477 LINE",
+"192 477 LINE",
+"192 854 LINE",
+"3 854 LINE",
+"3 836 LINE",
+"92 836 LINE",
+"92 477 LINE",
+"3 477 LINE",
+"3 459 LINE"
+);
+}
+);
+width = 279;
+}
+);
+unicode = 00B9;
+},
+{
+glyphname = twosuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 459 LINE",
+"321 602 LINE",
+"304 602 LINE",
+"304 549 OFFCURVE",
+"296 544 OFFCURVE",
+"271 544 CURVE SMOOTH",
+"89 544 LINE",
+"89 548 LINE",
+"247 643 LINE SMOOTH",
+"303 676 OFFCURVE",
+"321 715 OFFCURVE",
+"321 755 CURVE SMOOTH",
+"321 832 OFFCURVE",
+"249 862 OFFCURVE",
+"180 862 CURVE SMOOTH",
+"107 862 OFFCURVE",
+"34 829 OFFCURVE",
+"34 762 CURVE SMOOTH",
+"34 730 OFFCURVE",
+"51 695 OFFCURVE",
+"92 695 CURVE SMOOTH",
+"117 695 OFFCURVE",
+"141 710 OFFCURVE",
+"141 743 CURVE SMOOTH",
+"141 766 OFFCURVE",
+"129 784 OFFCURVE",
+"104 784 CURVE SMOOTH",
+"88 784 OFFCURVE",
+"82 777 OFFCURVE",
+"76 777 CURVE SMOOTH",
+"71 777 OFFCURVE",
+"68 781 OFFCURVE",
+"68 788 CURVE SMOOTH",
+"68 810 OFFCURVE",
+"102 838 OFFCURVE",
+"142 838 CURVE SMOOTH",
+"190 838 OFFCURVE",
+"220 799 OFFCURVE",
+"220 735 CURVE SMOOTH",
+"220 691 OFFCURVE",
+"206 659 OFFCURVE",
+"146 614 CURVE SMOOTH",
+"17 516 LINE",
+"17 459 LINE"
+);
+}
+);
+width = 350;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 459 LINE",
+"332 606 LINE",
+"314 606 LINE",
+"314 552 OFFCURVE",
+"306 547 OFFCURVE",
+"280 547 CURVE SMOOTH",
+"95 547 LINE",
+"95 551 LINE",
+"252 642 LINE SMOOTH",
+"309 675 OFFCURVE",
+"332 713 OFFCURVE",
+"332 755 CURVE SMOOTH",
+"332 833 OFFCURVE",
+"257 862 OFFCURVE",
+"186 862 CURVE SMOOTH",
+"111 862 OFFCURVE",
+"36 828 OFFCURVE",
+"36 761 CURVE SMOOTH",
+"36 729 OFFCURVE",
+"53 694 OFFCURVE",
+"95 694 CURVE SMOOTH",
+"123 694 OFFCURVE",
+"147 708 OFFCURVE",
+"147 743 CURVE SMOOTH",
+"147 766 OFFCURVE",
+"137 784 OFFCURVE",
+"109 784 CURVE SMOOTH",
+"93 784 OFFCURVE",
+"86 777 OFFCURVE",
+"81 777 CURVE SMOOTH",
+"77 777 OFFCURVE",
+"73 781 OFFCURVE",
+"73 789 CURVE SMOOTH",
+"73 810 OFFCURVE",
+"106 837 OFFCURVE",
+"144 837 CURVE SMOOTH",
+"192 837 OFFCURVE",
+"223 800 OFFCURVE",
+"223 735 CURVE SMOOTH",
+"223 691 OFFCURVE",
+"210 658 OFFCURVE",
+"149 614 CURVE SMOOTH",
+"16 518 LINE",
+"16 459 LINE"
+);
+}
+);
+width = 360;
+}
+);
+unicode = 00B2;
+},
+{
+glyphname = threesuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"249 451 OFFCURVE",
+"317 509 OFFCURVE",
+"317 572 CURVE SMOOTH",
+"317 642 OFFCURVE",
+"253 675 OFFCURVE",
+"172 678 CURVE",
+"111 663 LINE",
+"182 663 OFFCURVE",
+"208 630 OFFCURVE",
+"208 568 CURVE SMOOTH",
+"208 507 OFFCURVE",
+"183 472 OFFCURVE",
+"133 472 CURVE SMOOTH",
+"115 472 OFFCURVE",
+"74 476 OFFCURVE",
+"74 490 CURVE SMOOTH",
+"74 505 OFFCURVE",
+"111 507 OFFCURVE",
+"111 547 CURVE SMOOTH",
+"111 583 OFFCURVE",
+"83 591 OFFCURVE",
+"64 591 CURVE SMOOTH",
+"30 591 OFFCURVE",
+"13 563 OFFCURVE",
+"13 532 CURVE SMOOTH",
+"13 482 OFFCURVE",
+"61 451 OFFCURVE",
+"141 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 663 LINE",
+"172 684 LINE",
+"76 684 LINE",
+"76 663 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 685 OFFCURVE",
+"299 721 OFFCURVE",
+"299 772 CURVE SMOOTH",
+"299 827 OFFCURVE",
+"247 862 OFFCURVE",
+"161 862 CURVE SMOOTH",
+"71 862 OFFCURVE",
+"36 823 OFFCURVE",
+"36 784 CURVE SMOOTH",
+"36 755 OFFCURVE",
+"55 739 OFFCURVE",
+"81 739 CURVE SMOOTH",
+"104 739 OFFCURVE",
+"130 751 OFFCURVE",
+"130 778 CURVE SMOOTH",
+"130 807 OFFCURVE",
+"99 812 OFFCURVE",
+"99 826 CURVE SMOOTH",
+"99 839 OFFCURVE",
+"123 842 OFFCURVE",
+"143 842 CURVE SMOOTH",
+"176 842 OFFCURVE",
+"197 830 OFFCURVE",
+"197 777 CURVE SMOOTH",
+"197 717 OFFCURVE",
+"170 684 OFFCURVE",
+"100 684 CURVE",
+"139 678 LINE"
+);
+}
+);
+width = 337;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 451 OFFCURVE",
+"327 508 OFFCURVE",
+"327 572 CURVE SMOOTH",
+"327 642 OFFCURVE",
+"258 674 OFFCURVE",
+"173 677 CURVE",
+"111 663 LINE",
+"183 663 OFFCURVE",
+"210 630 OFFCURVE",
+"210 567 CURVE SMOOTH",
+"210 506 OFFCURVE",
+"186 472 OFFCURVE",
+"136 472 CURVE SMOOTH",
+"118 472 OFFCURVE",
+"78 476 OFFCURVE",
+"78 490 CURVE SMOOTH",
+"78 505 OFFCURVE",
+"118 507 OFFCURVE",
+"118 549 CURVE SMOOTH",
+"118 586 OFFCURVE",
+"86 594 OFFCURVE",
+"67 594 CURVE SMOOTH",
+"31 594 OFFCURVE",
+"12 564 OFFCURVE",
+"12 533 CURVE SMOOTH",
+"12 482 OFFCURVE",
+"60 451 OFFCURVE",
+"143 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 663 LINE",
+"173 683 LINE",
+"78 683 LINE",
+"78 663 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 685 OFFCURVE",
+"310 720 OFFCURVE",
+"310 771 CURVE SMOOTH",
+"310 827 OFFCURVE",
+"255 862 OFFCURVE",
+"166 862 CURVE SMOOTH",
+"70 862 OFFCURVE",
+"37 822 OFFCURVE",
+"37 782 CURVE SMOOTH",
+"37 753 OFFCURVE",
+"56 736 OFFCURVE",
+"85 736 CURVE SMOOTH",
+"109 736 OFFCURVE",
+"139 748 OFFCURVE",
+"139 777 CURVE SMOOTH",
+"139 806 OFFCURVE",
+"104 811 OFFCURVE",
+"104 826 CURVE SMOOTH",
+"104 838 OFFCURVE",
+"129 841 OFFCURVE",
+"148 841 CURVE SMOOTH",
+"179 841 OFFCURVE",
+"200 830 OFFCURVE",
+"200 777 CURVE SMOOTH",
+"200 717 OFFCURVE",
+"173 683 OFFCURVE",
+"99 683 CURVE",
+"140 677 LINE"
+);
+}
+);
+width = 346;
+}
+);
+unicode = 00B3;
+},
+{
+glyphname = foursuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"322 459 LINE",
+"322 476 LINE",
+"267 476 LINE",
+"267 569 LINE",
+"338 569 LINE",
+"338 524 LINE",
+"356 524 LINE",
+"356 631 LINE",
+"338 631 LINE",
+"338 588 LINE",
+"268 588 LINE",
+"268 862 LINE",
+"208 862 LINE",
+"8 588 LINE",
+"8 569 LINE",
+"175 569 LINE",
+"175 476 LINE",
+"115 476 LINE",
+"115 459 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 592 LINE",
+"171 779 LINE",
+"175 779 LINE",
+"175 588 LINE",
+"36 588 LINE"
+);
+}
+);
+width = 377;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 459 LINE",
+"332 477 LINE",
+"276 477 LINE",
+"276 569 LINE",
+"350 569 LINE",
+"350 524 LINE",
+"369 524 LINE",
+"369 632 LINE",
+"350 632 LINE",
+"350 588 LINE",
+"276 588 LINE",
+"276 862 LINE",
+"210 862 LINE",
+"7 589 LINE",
+"7 569 LINE",
+"176 569 LINE",
+"176 477 LINE",
+"114 477 LINE",
+"114 459 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 592 LINE",
+"172 777 LINE",
+"176 777 LINE",
+"176 588 LINE",
+"34 588 LINE"
+);
+}
+);
+width = 391;
+}
+);
+unicode = 2074;
+},
+{
+glyphname = fivesuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"251 451 OFFCURVE",
+"333 498 OFFCURVE",
+"333 582 CURVE SMOOTH",
+"333 648 OFFCURVE",
+"282 706 OFFCURVE",
+"170 706 CURVE SMOOTH",
+"124 706 OFFCURVE",
+"73 696 OFFCURVE",
+"63 690 CURVE",
+"56 661 LINE",
+"67 671 OFFCURVE",
+"101 678 OFFCURVE",
+"128 678 CURVE SMOOTH",
+"183 678 OFFCURVE",
+"222 647 OFFCURVE",
+"222 571 CURVE SMOOTH",
+"222 504 OFFCURVE",
+"192 472 OFFCURVE",
+"135 472 CURVE SMOOTH",
+"113 472 OFFCURVE",
+"81 476 OFFCURVE",
+"81 488 CURVE SMOOTH",
+"81 500 OFFCURVE",
+"117 501 OFFCURVE",
+"117 539 CURVE SMOOTH",
+"117 571 OFFCURVE",
+"92 584 OFFCURVE",
+"68 584 CURVE SMOOTH",
+"37 584 OFFCURVE",
+"15 562 OFFCURVE",
+"15 530 CURVE SMOOTH",
+"15 485 OFFCURVE",
+"62 451 OFFCURVE",
+"149 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 687 LINE",
+"84 854 LINE",
+"61 854 LINE",
+"47 668 LINE",
+"56 661 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 769 LINE",
+"312 876 LINE",
+"295 876 LINE",
+"288 857 OFFCURVE",
+"281 854 OFFCURVE",
+"259 854 CURVE SMOOTH",
+"65 854 LINE",
+"79 769 LINE"
+);
+}
+);
+width = 349;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 451 OFFCURVE",
+"346 497 OFFCURVE",
+"346 582 CURVE SMOOTH",
+"346 648 OFFCURVE",
+"298 707 OFFCURVE",
+"181 707 CURVE SMOOTH",
+"132 707 OFFCURVE",
+"75 697 OFFCURVE",
+"64 691 CURVE",
+"57 661 LINE",
+"67 670 OFFCURVE",
+"103 678 OFFCURVE",
+"131 678 CURVE SMOOTH",
+"187 678 OFFCURVE",
+"226 647 OFFCURVE",
+"226 571 CURVE SMOOTH",
+"226 504 OFFCURVE",
+"196 472 OFFCURVE",
+"139 472 CURVE SMOOTH",
+"120 472 OFFCURVE",
+"86 476 OFFCURVE",
+"86 487 CURVE SMOOTH",
+"86 499 OFFCURVE",
+"125 500 OFFCURVE",
+"125 540 CURVE SMOOTH",
+"125 573 OFFCURVE",
+"97 585 OFFCURVE",
+"72 585 CURVE SMOOTH",
+"38 585 OFFCURVE",
+"15 563 OFFCURVE",
+"15 531 CURVE SMOOTH",
+"15 485 OFFCURVE",
+"61 451 OFFCURVE",
+"154 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 688 LINE",
+"84 854 LINE",
+"60 854 LINE",
+"47 667 LINE",
+"57 661 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 765 LINE",
+"325 877 LINE",
+"307 877 LINE",
+"300 857 OFFCURVE",
+"293 854 OFFCURVE",
+"272 854 CURVE SMOOTH",
+"65 854 LINE",
+"78 765 LINE"
+);
+}
+);
+width = 362;
+}
+);
+unicode = 2075;
+},
+{
+glyphname = sixsuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"260 451 OFFCURVE",
+"334 509 OFFCURVE",
+"334 588 CURVE SMOOTH",
+"334 658 OFFCURVE",
+"275 712 OFFCURVE",
+"203 712 CURVE SMOOTH",
+"173 712 OFFCURVE",
+"153 703 OFFCURVE",
+"136 689 CURVE",
+"132 689 LINE",
+"144 771 OFFCURVE",
+"199 844 OFFCURVE",
+"287 854 CURVE",
+"287 874 LINE",
+"147 869 OFFCURVE",
+"25 747 OFFCURVE",
+"25 619 CURVE SMOOTH",
+"25 517 OFFCURVE",
+"94 451 OFFCURVE",
+"180 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 472 OFFCURVE",
+"121 500 OFFCURVE",
+"121 580 CURVE SMOOTH",
+"121 599 OFFCURVE",
+"121 627 OFFCURVE",
+"126 650 CURVE",
+"138 670 OFFCURVE",
+"157 688 OFFCURVE",
+"186 688 CURVE SMOOTH",
+"216 688 OFFCURVE",
+"233 669 OFFCURVE",
+"233 580 CURVE SMOOTH",
+"233 501 OFFCURVE",
+"220 472 OFFCURVE",
+"178 472 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"264 451 OFFCURVE",
+"338 509 OFFCURVE",
+"338 588 CURVE SMOOTH",
+"338 658 OFFCURVE",
+"281 711 OFFCURVE",
+"208 711 CURVE SMOOTH",
+"179 711 OFFCURVE",
+"159 702 OFFCURVE",
+"141 687 CURVE",
+"138 689 LINE",
+"150 770 OFFCURVE",
+"202 844 OFFCURVE",
+"288 854 CURVE",
+"288 875 LINE",
+"147 870 OFFCURVE",
+"24 747 OFFCURVE",
+"24 619 CURVE SMOOTH",
+"24 517 OFFCURVE",
+"95 451 OFFCURVE",
+"182 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 472 OFFCURVE",
+"126 501 OFFCURVE",
+"126 580 CURVE SMOOTH",
+"126 599 OFFCURVE",
+"126 626 OFFCURVE",
+"131 649 CURVE",
+"141 669 OFFCURVE",
+"159 687 OFFCURVE",
+"187 687 CURVE SMOOTH",
+"215 687 OFFCURVE",
+"233 668 OFFCURVE",
+"233 580 CURVE SMOOTH",
+"233 502 OFFCURVE",
+"220 472 OFFCURVE",
+"181 472 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+unicode = 2076;
+},
+{
+glyphname = sevensuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"199 451 OFFCURVE",
+"226 466 OFFCURVE",
+"226 501 CURVE SMOOTH",
+"226 528 OFFCURVE",
+"209 560 OFFCURVE",
+"209 597 CURVE SMOOTH",
+"209 621 OFFCURVE",
+"220 651 OFFCURVE",
+"245 690 CURVE SMOOTH",
+"325 818 LINE",
+"325 854 LINE",
+"60 854 LINE",
+"20 707 LINE",
+"41 707 LINE",
+"59 759 OFFCURVE",
+"57 768 OFFCURVE",
+"70 768 CURVE SMOOTH",
+"261 768 LINE",
+"166 618 LINE SMOOTH",
+"127 557 OFFCURVE",
+"111 530 OFFCURVE",
+"111 501 CURVE SMOOTH",
+"111 471 OFFCURVE",
+"129 451 OFFCURVE",
+"166 451 CURVE SMOOTH"
+);
+}
+);
+width = 335;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 451 OFFCURVE",
+"237 467 OFFCURVE",
+"237 502 CURVE SMOOTH",
+"237 529 OFFCURVE",
+"220 564 OFFCURVE",
+"220 600 CURVE SMOOTH",
+"220 624 OFFCURVE",
+"232 653 OFFCURVE",
+"257 691 CURVE SMOOTH",
+"339 816 LINE",
+"339 854 LINE",
+"63 854 LINE",
+"20 703 LINE",
+"43 703 LINE",
+"60 757 OFFCURVE",
+"66 765 OFFCURVE",
+"75 765 CURVE SMOOTH",
+"269 765 LINE",
+"173 618 LINE SMOOTH",
+"134 558 OFFCURVE",
+"113 531 OFFCURVE",
+"113 501 CURVE SMOOTH",
+"113 472 OFFCURVE",
+"131 451 OFFCURVE",
+"171 451 CURVE SMOOTH"
+);
+}
+);
+width = 351;
+}
+);
+unicode = 2077;
+},
+{
+glyphname = eightsuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"283 451 OFFCURVE",
+"334 497 OFFCURVE",
+"334 555 CURVE SMOOTH",
+"334 618 OFFCURVE",
+"283 650 OFFCURVE",
+"213 664 CURVE",
+"213 668 LINE",
+"140 668 LINE",
+"140 664 LINE",
+"68 651 OFFCURVE",
+"17 618 OFFCURVE",
+"17 555 CURVE SMOOTH",
+"17 497 OFFCURVE",
+"69 451 OFFCURVE",
+"176 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 468 OFFCURVE",
+"118 494 OFFCURVE",
+"118 559 CURVE SMOOTH",
+"118 622 OFFCURVE",
+"133 654 OFFCURVE",
+"176 654 CURVE SMOOTH",
+"219 654 OFFCURVE",
+"233 620 OFFCURVE",
+"233 559 CURVE SMOOTH",
+"233 494 OFFCURVE",
+"216 468 OFFCURVE",
+"176 468 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 675 OFFCURVE",
+"129 705 OFFCURVE",
+"129 762 CURVE SMOOTH",
+"129 818 OFFCURVE",
+"142 842 OFFCURVE",
+"176 842 CURVE SMOOTH",
+"211 842 OFFCURVE",
+"223 818 OFFCURVE",
+"223 762 CURVE SMOOTH",
+"223 705 OFFCURVE",
+"211 675 OFFCURVE",
+"176 675 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 664 OFFCURVE",
+"318 702 OFFCURVE",
+"318 763 CURVE SMOOTH",
+"318 815 OFFCURVE",
+"273 862 OFFCURVE",
+"175 862 CURVE SMOOTH",
+"81 862 OFFCURVE",
+"34 818 OFFCURVE",
+"34 764 CURVE SMOOTH",
+"34 702 OFFCURVE",
+"97 664 OFFCURVE",
+"176 664 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 451 OFFCURVE",
+"340 497 OFFCURVE",
+"340 555 CURVE SMOOTH",
+"340 619 OFFCURVE",
+"288 649 OFFCURVE",
+"215 663 CURVE",
+"215 669 LINE",
+"142 669 LINE",
+"142 663 LINE",
+"68 650 OFFCURVE",
+"16 619 OFFCURVE",
+"16 555 CURVE SMOOTH",
+"16 497 OFFCURVE",
+"68 451 OFFCURVE",
+"178 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 468 OFFCURVE",
+"123 494 OFFCURVE",
+"123 559 CURVE SMOOTH",
+"123 622 OFFCURVE",
+"137 653 OFFCURVE",
+"178 653 CURVE SMOOTH",
+"219 653 OFFCURVE",
+"233 620 OFFCURVE",
+"233 559 CURVE SMOOTH",
+"233 494 OFFCURVE",
+"216 468 OFFCURVE",
+"178 468 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 675 OFFCURVE",
+"134 706 OFFCURVE",
+"134 762 CURVE SMOOTH",
+"134 818 OFFCURVE",
+"146 841 OFFCURVE",
+"178 841 CURVE SMOOTH",
+"211 841 OFFCURVE",
+"222 818 OFFCURVE",
+"222 762 CURVE SMOOTH",
+"222 706 OFFCURVE",
+"211 675 OFFCURVE",
+"178 675 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 664 OFFCURVE",
+"324 702 OFFCURVE",
+"324 763 CURVE SMOOTH",
+"324 815 OFFCURVE",
+"278 862 OFFCURVE",
+"177 862 CURVE SMOOTH",
+"81 862 OFFCURVE",
+"32 818 OFFCURVE",
+"32 764 CURVE SMOOTH",
+"32 702 OFFCURVE",
+"97 664 OFFCURVE",
+"178 664 CURVE SMOOTH"
+);
+}
+);
+width = 356;
+}
+);
+unicode = 2078;
+},
+{
+glyphname = ninesuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"196 460 OFFCURVE",
+"325 563 OFFCURVE",
+"325 694 CURVE SMOOTH",
+"325 796 OFFCURVE",
+"256 862 OFFCURVE",
+"169 862 CURVE SMOOTH",
+"89 862 OFFCURVE",
+"16 803 OFFCURVE",
+"16 725 CURVE SMOOTH",
+"16 655 OFFCURVE",
+"74 601 OFFCURVE",
+"147 601 CURVE SMOOTH",
+"176 601 OFFCURVE",
+"195 608 OFFCURVE",
+"213 623 CURVE",
+"217 623 LINE",
+"205 540 OFFCURVE",
+"145 484 OFFCURVE",
+"57 475 CURVE",
+"57 455 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 625 OFFCURVE",
+"116 644 OFFCURVE",
+"116 732 CURVE SMOOTH",
+"116 812 OFFCURVE",
+"129 842 OFFCURVE",
+"171 842 CURVE SMOOTH",
+"213 842 OFFCURVE",
+"228 812 OFFCURVE",
+"228 733 CURVE SMOOTH",
+"228 713 OFFCURVE",
+"228 686 OFFCURVE",
+"223 663 CURVE",
+"212 642 OFFCURVE",
+"192 625 OFFCURVE",
+"163 625 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"198 461 OFFCURVE",
+"328 564 OFFCURVE",
+"328 694 CURVE SMOOTH",
+"328 796 OFFCURVE",
+"257 862 OFFCURVE",
+"169 862 CURVE SMOOTH",
+"88 862 OFFCURVE",
+"13 804 OFFCURVE",
+"13 725 CURVE SMOOTH",
+"13 655 OFFCURVE",
+"71 602 OFFCURVE",
+"144 602 CURVE SMOOTH",
+"173 602 OFFCURVE",
+"192 611 OFFCURVE",
+"211 626 CURVE",
+"214 624 LINE",
+"202 542 OFFCURVE",
+"143 486 OFFCURVE",
+"56 476 CURVE",
+"56 456 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 626 OFFCURVE",
+"119 645 OFFCURVE",
+"119 733 CURVE SMOOTH",
+"119 811 OFFCURVE",
+"132 842 OFFCURVE",
+"171 842 CURVE SMOOTH",
+"211 842 OFFCURVE",
+"226 812 OFFCURVE",
+"226 733 CURVE SMOOTH",
+"226 714 OFFCURVE",
+"225 687 OFFCURVE",
+"220 664 CURVE",
+"210 644 OFFCURVE",
+"192 626 OFFCURVE",
+"164 626 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+unicode = 2079;
+},
+{
+glyphname = fraction;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"59 0 LINE",
+"489 753 LINE",
+"430 753 LINE",
+"0 0 LINE"
+);
+}
+);
+width = 489;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"79 0 LINE",
+"489 753 LINE",
+"410 753 LINE",
+"0 0 LINE"
+);
+}
+);
+width = 489;
+}
+);
+unicode = 2044;
+},
+{
+glyphname = onehalf;
+lastChange = "2016-08-19 16:52:41 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 215, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = two.denominator;
+transform = "{1, 0, 0, 1, 506, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 220, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = two.denominator;
+transform = "{1, 0, 0, 1, 506, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 00BD;
+},
+{
+glyphname = onethird;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = three.denominator;
+transform = "{1, 0, 0, 1, 502, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 194, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = three.denominator;
+transform = "{1, 0, 0, 1, 502, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 194, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 2153;
+},
+{
+glyphname = twothirds;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = two.numerator;
+transform = "{1, 0, 0, 1, 43, 0}";
+},
+{
+name = three.denominator;
+transform = "{1, 0, 0, 1, 502, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 215, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = two.numerator;
+transform = "{1, 0, 0, 1, 43, 0}";
+},
+{
+name = three.denominator;
+transform = "{1, 0, 0, 1, 502, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 221, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 2154;
+},
+{
+glyphname = onequarter;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = four.denominator;
+transform = "{1, 0, 0, 1, 469, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 220, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = four.denominator;
+transform = "{1, 0, 0, 1, 469, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 220, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 00BC;
+},
+{
+glyphname = threequarters;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = three.numerator;
+transform = "{1, 0, 0, 1, 61, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 220, 0}";
+},
+{
+name = four.denominator;
+transform = "{1, 0, 0, 1, 469, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = three.numerator;
+transform = "{1, 0, 0, 1, 61, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 226, 0}";
+},
+{
+name = four.denominator;
+transform = "{1, 0, 0, 1, 469, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 00BE;
+},
+{
+glyphname = oneeighth;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 493, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 194, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 493, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 194, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 215B;
+},
+{
+glyphname = threeeighths;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+},
+{
+name = three.numerator;
+transform = "{1, 0, 0, 1, 61, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 214, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+},
+{
+name = three.numerator;
+transform = "{1, 0, 0, 1, 61, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 216, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 215C;
+},
+{
+glyphname = fiveeighths;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = five.numerator;
+transform = "{1, 0, 0, 1, 57, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 214, 0}";
+},
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = five.numerator;
+transform = "{1, 0, 0, 1, 57, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 218, 0}";
+},
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 215D;
+},
+{
+glyphname = seveneighths;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = seven.numerator;
+transform = "{1, 0, 0, 1, 63, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 205, 0}";
+},
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = seven.numerator;
+transform = "{1, 0, 0, 1, 63, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 205, 0}";
+},
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 215E;
+},
+{
+glyphname = CR;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 206;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 160;
+}
+);
+unicode = 000D;
+},
+{
+glyphname = NULL;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 0;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 0;
+}
+);
+},
+{
+glyphname = .notdef;
+lastChange = "2016-10-31 10:00:55 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"682 -326 LINE",
+"682 924 LINE",
+"127 924 LINE",
+"127 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 899 LINE",
+"588 899 LINE",
+"588 -301 LINE",
+"221 -301 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 -301 LINE",
+"221 924 LINE",
+"201 899 LINE",
+"588 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 899 LINE",
+"588 924 LINE",
+"201 -301 LINE",
+"221 -326 LINE"
+);
+}
+);
+width = 809;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"682 -326 LINE",
+"682 924 LINE",
+"127 924 LINE",
+"127 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 899 LINE",
+"588 899 LINE",
+"588 -301 LINE",
+"221 -301 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 -301 LINE",
+"221 924 LINE",
+"201 899 LINE",
+"588 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 899 LINE",
+"588 924 LINE",
+"201 -301 LINE",
+"221 -326 LINE"
+);
+}
+);
+width = 809;
+}
+);
+},
+{
+glyphname = space;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 206;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 160;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = nbspace;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 206;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 160;
+}
+);
+unicode = 00A0;
+},
+{
+glyphname = period;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"153 -12 OFFCURVE",
+"186 21 OFFCURVE",
+"186 61 CURVE SMOOTH",
+"186 101 OFFCURVE",
+"153 134 OFFCURVE",
+"113 134 CURVE SMOOTH",
+"73 134 OFFCURVE",
+"40 101 OFFCURVE",
+"40 61 CURVE SMOOTH",
+"40 21 OFFCURVE",
+"73 -12 OFFCURVE",
+"113 -12 CURVE SMOOTH"
+);
+}
+);
+width = 226;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"86 150 OFFCURVE",
+"75 147 OFFCURVE",
+"67 142 CURVE",
+"49 134 OFFCURVE",
+"27 107 OFFCURVE",
+"22 89 CURVE",
+"22 77 OFFCURVE",
+"22 54 OFFCURVE",
+"22 41 CURVE",
+"30 8 OFFCURVE",
+"63 -19 OFFCURVE",
+"99 -24 CURVE SMOOTH",
+"126 -27 OFFCURVE",
+"151 -18 OFFCURVE",
+"171 3 CURVE SMOOTH",
+"183 17 OFFCURVE",
+"195 29 OFFCURVE",
+"195 45 CURVE",
+"199 61 OFFCURVE",
+"198 70 OFFCURVE",
+"193 89 CURVE SMOOTH",
+"188 104 OFFCURVE",
+"185 110 OFFCURVE",
+"179 120 CURVE",
+"174 126 OFFCURVE",
+"167 133 OFFCURVE",
+"166 134 CURVE SMOOTH",
+"151 145 OFFCURVE",
+"119 155 OFFCURVE",
+"99 152 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 002E;
+},
+{
+glyphname = comma;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"55 -165 LINE",
+"144 -128 OFFCURVE",
+"198 -57 OFFCURVE",
+"198 22 CURVE SMOOTH",
+"198 86 OFFCURVE",
+"163 125 OFFCURVE",
+"106 125 CURVE SMOOTH",
+"61 125 OFFCURVE",
+"34 101 OFFCURVE",
+"34 60 CURVE SMOOTH",
+"34 22 OFFCURVE",
+"57 -3 OFFCURVE",
+"94 -3 CURVE SMOOTH",
+"137 -3 OFFCURVE",
+"130 32 OFFCURVE",
+"151 32 CURVE SMOOTH",
+"162 32 OFFCURVE",
+"168 23 OFFCURVE",
+"168 4 CURVE SMOOTH",
+"168 -49 OFFCURVE",
+"120 -108 OFFCURVE",
+"49 -143 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"144 -128 OFFCURVE",
+"198 -57 OFFCURVE",
+"198 22 CURVE SMOOTH",
+"198 86 OFFCURVE",
+"163 125 OFFCURVE",
+"106 125 CURVE SMOOTH",
+"61 125 OFFCURVE",
+"34 101 OFFCURVE",
+"34 60 CURVE SMOOTH",
+"34 22 OFFCURVE",
+"57 -3 OFFCURVE",
+"94 -3 CURVE SMOOTH",
+"137 -3 OFFCURVE",
+"130 32 OFFCURVE",
+"151 32 CURVE SMOOTH",
+"162 32 OFFCURVE",
+"168 23 OFFCURVE",
+"168 4 CURVE SMOOTH",
+"168 -49 OFFCURVE",
+"120 -108 OFFCURVE",
+"49 -143 CURVE",
+"55 -165 LINE"
+);
+}
+);
+width = 232;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"258 95 OFFCURVE",
+"213 159 OFFCURVE",
+"142 159 CURVE SMOOTH",
+"86 159 OFFCURVE",
+"50 119 OFFCURVE",
+"50 67 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"73 -13 OFFCURVE",
+"123 -13 CURVE SMOOTH",
+"171 -13 OFFCURVE",
+"183 23 OFFCURVE",
+"198 23 CURVE SMOOTH",
+"204 23 OFFCURVE",
+"209 17 OFFCURVE",
+"209 -7 CURVE SMOOTH",
+"209 -71 OFFCURVE",
+"174 -123 OFFCURVE",
+"96 -183 CURVE",
+"113 -204 LINE",
+"197 -152 OFFCURVE",
+"258 -80 OFFCURVE",
+"258 14 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 -152 OFFCURVE",
+"258 -80 OFFCURVE",
+"258 14 CURVE SMOOTH",
+"258 95 OFFCURVE",
+"213 159 OFFCURVE",
+"142 159 CURVE SMOOTH",
+"86 159 OFFCURVE",
+"50 119 OFFCURVE",
+"50 67 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"73 -13 OFFCURVE",
+"123 -13 CURVE SMOOTH",
+"171 -13 OFFCURVE",
+"183 23 OFFCURVE",
+"198 23 CURVE SMOOTH",
+"204 23 OFFCURVE",
+"209 17 OFFCURVE",
+"209 -7 CURVE SMOOTH",
+"209 -71 OFFCURVE",
+"174 -123 OFFCURVE",
+"96 -183 CURVE",
+"113 -204 LINE"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 002C;
+},
+{
+glyphname = colon;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 21 OFFCURVE",
+"73 -12 OFFCURVE",
+"113 -12 CURVE SMOOTH",
+"153 -12 OFFCURVE",
+"186 21 OFFCURVE",
+"186 61 CURVE SMOOTH",
+"186 101 OFFCURVE",
+"153 134 OFFCURVE",
+"113 134 CURVE SMOOTH",
+"73 134 OFFCURVE",
+"40 101 OFFCURVE",
+"40 61 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"40 318 OFFCURVE",
+"73 285 OFFCURVE",
+"113 285 CURVE SMOOTH",
+"153 285 OFFCURVE",
+"186 318 OFFCURVE",
+"186 358 CURVE SMOOTH",
+"186 398 OFFCURVE",
+"153 431 OFFCURVE",
+"113 431 CURVE SMOOTH",
+"73 431 OFFCURVE",
+"40 398 OFFCURVE",
+"40 358 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"153 285 OFFCURVE",
+"186 318 OFFCURVE",
+"186 358 CURVE SMOOTH",
+"186 398 OFFCURVE",
+"153 431 OFFCURVE",
+"113 431 CURVE SMOOTH",
+"73 431 OFFCURVE",
+"40 398 OFFCURVE",
+"40 358 CURVE SMOOTH",
+"40 318 OFFCURVE",
+"73 285 OFFCURVE",
+"113 285 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"153 -12 OFFCURVE",
+"186 21 OFFCURVE",
+"186 61 CURVE SMOOTH",
+"186 101 OFFCURVE",
+"153 134 OFFCURVE",
+"113 134 CURVE SMOOTH",
+"73 134 OFFCURVE",
+"40 101 OFFCURVE",
+"40 61 CURVE SMOOTH",
+"40 21 OFFCURVE",
+"73 -12 OFFCURVE",
+"113 -12 CURVE SMOOTH"
+);
+}
+);
+width = 226;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 319 OFFCURVE",
+"89 280 OFFCURVE",
+"137 280 CURVE SMOOTH",
+"185 280 OFFCURVE",
+"224 319 OFFCURVE",
+"224 367 CURVE SMOOTH",
+"224 415 OFFCURVE",
+"185 454 OFFCURVE",
+"137 454 CURVE SMOOTH",
+"89 454 OFFCURVE",
+"50 415 OFFCURVE",
+"50 367 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH",
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"185 280 OFFCURVE",
+"224 319 OFFCURVE",
+"224 367 CURVE SMOOTH",
+"224 415 OFFCURVE",
+"185 454 OFFCURVE",
+"137 454 CURVE SMOOTH",
+"89 454 OFFCURVE",
+"50 415 OFFCURVE",
+"50 367 CURVE SMOOTH",
+"50 319 OFFCURVE",
+"89 280 OFFCURVE",
+"137 280 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 003A;
+},
+{
+glyphname = semicolon;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"230 73 OFFCURVE",
+"191 123 OFFCURVE",
+"131 123 CURVE SMOOTH",
+"82 123 OFFCURVE",
+"50 89 OFFCURVE",
+"50 48 CURVE SMOOTH",
+"50 18 OFFCURVE",
+"68 -12 OFFCURVE",
+"108 -12 CURVE SMOOTH",
+"162 -12 OFFCURVE",
+"163 42 OFFCURVE",
+"178 42 CURVE SMOOTH",
+"186 42 OFFCURVE",
+"201 25 OFFCURVE",
+"201 -2 CURVE SMOOTH",
+"201 -45 OFFCURVE",
+"164 -107 OFFCURVE",
+"98 -154 CURVE",
+"115 -175 LINE",
+"179 -131 OFFCURVE",
+"230 -67 OFFCURVE",
+"230 8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"53 318 OFFCURVE",
+"86 285 OFFCURVE",
+"126 285 CURVE SMOOTH",
+"166 285 OFFCURVE",
+"199 318 OFFCURVE",
+"199 358 CURVE SMOOTH",
+"199 398 OFFCURVE",
+"166 431 OFFCURVE",
+"126 431 CURVE SMOOTH",
+"86 431 OFFCURVE",
+"53 398 OFFCURVE",
+"53 358 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"55 -165 LINE",
+"144 -128 OFFCURVE",
+"198 -57 OFFCURVE",
+"198 22 CURVE SMOOTH",
+"198 86 OFFCURVE",
+"163 125 OFFCURVE",
+"106 125 CURVE SMOOTH",
+"61 125 OFFCURVE",
+"34 101 OFFCURVE",
+"34 60 CURVE SMOOTH",
+"34 22 OFFCURVE",
+"57 -3 OFFCURVE",
+"94 -3 CURVE SMOOTH",
+"137 -3 OFFCURVE",
+"130 32 OFFCURVE",
+"151 32 CURVE SMOOTH",
+"162 32 OFFCURVE",
+"168 23 OFFCURVE",
+"168 4 CURVE SMOOTH",
+"168 -49 OFFCURVE",
+"120 -108 OFFCURVE",
+"49 -143 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"144 -128 OFFCURVE",
+"198 -57 OFFCURVE",
+"198 22 CURVE SMOOTH",
+"198 86 OFFCURVE",
+"163 125 OFFCURVE",
+"106 125 CURVE SMOOTH",
+"61 125 OFFCURVE",
+"34 101 OFFCURVE",
+"34 60 CURVE SMOOTH",
+"34 22 OFFCURVE",
+"57 -3 OFFCURVE",
+"94 -3 CURVE SMOOTH",
+"137 -3 OFFCURVE",
+"130 32 OFFCURVE",
+"151 32 CURVE SMOOTH",
+"162 32 OFFCURVE",
+"168 23 OFFCURVE",
+"168 4 CURVE SMOOTH",
+"168 -49 OFFCURVE",
+"120 -108 OFFCURVE",
+"49 -143 CURVE",
+"55 -165 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 285 OFFCURVE",
+"189 318 OFFCURVE",
+"189 358 CURVE SMOOTH",
+"189 398 OFFCURVE",
+"156 431 OFFCURVE",
+"116 431 CURVE SMOOTH",
+"76 431 OFFCURVE",
+"43 398 OFFCURVE",
+"43 358 CURVE SMOOTH",
+"43 318 OFFCURVE",
+"76 285 OFFCURVE",
+"116 285 CURVE SMOOTH"
+);
+}
+);
+width = 280;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"114 434 OFFCURVE",
+"95 424 OFFCURVE",
+"87 416 CURVE SMOOTH",
+"77 407 OFFCURVE",
+"66 391 OFFCURVE",
+"63 378 CURVE",
+"57 359 OFFCURVE",
+"60 327 OFFCURVE",
+"71 309 CURVE",
+"78 295 OFFCURVE",
+"101 279 OFFCURVE",
+"119 276 CURVE",
+"130 272 OFFCURVE",
+"152 272 OFFCURVE",
+"167 274 CURVE",
+"187 279 OFFCURVE",
+"209 298 OFFCURVE",
+"221 319 CURVE SMOOTH",
+"228 332 OFFCURVE",
+"231 354 OFFCURVE",
+"228 367 CURVE SMOOTH",
+"223 394 OFFCURVE",
+"205 420 OFFCURVE",
+"180 431 CURVE",
+"169 437 OFFCURVE",
+"165 437 OFFCURVE",
+"149 437 CURVE",
+"140 439 OFFCURVE",
+"129 437 OFFCURVE",
+"125 437 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"108 148 OFFCURVE",
+"82 136 OFFCURVE",
+"74 127 CURVE SMOOTH",
+"66 119 OFFCURVE",
+"57 101 OFFCURVE",
+"53 92 CURVE",
+"53 88 OFFCURVE",
+"52 82 OFFCURVE",
+"50 77 CURVE SMOOTH",
+"45 66 OFFCURVE",
+"47 44 OFFCURVE",
+"55 29 CURVE SMOOTH",
+"65 10 OFFCURVE",
+"76 -3 OFFCURVE",
+"97 -9 CURVE SMOOTH",
+"113 -14 OFFCURVE",
+"130 -12 OFFCURVE",
+"146 -8 CURVE",
+"160 -3 OFFCURVE",
+"163 -1 OFFCURVE",
+"180 15 CURVE SMOOTH",
+"193 28 LINE",
+"196 24 LINE SMOOTH",
+"204 16 OFFCURVE",
+"207 7 OFFCURVE",
+"207 -12 CURVE",
+"209 -33 OFFCURVE",
+"205 -49 OFFCURVE",
+"196 -68 CURVE SMOOTH",
+"191 -80 OFFCURVE",
+"173 -107 OFFCURVE",
+"162 -118 CURVE SMOOTH",
+"151 -131 OFFCURVE",
+"124 -153 OFFCURVE",
+"113 -160 CURVE",
+"100 -166 OFFCURVE",
+"93 -174 OFFCURVE",
+"93 -182 CURVE SMOOTH",
+"93 -192 OFFCURVE",
+"97 -198 OFFCURVE",
+"106 -198 CURVE SMOOTH",
+"130 -198 OFFCURVE",
+"204 -129 OFFCURVE",
+"228 -84 CURVE",
+"233 -78 OFFCURVE",
+"239 -60 OFFCURVE",
+"244 -49 CURVE",
+"250 -30 OFFCURVE",
+"252 -20 OFFCURVE",
+"255 -1 CURVE SMOOTH",
+"258 24 OFFCURVE",
+"258 24 OFFCURVE",
+"253 48 CURVE",
+"252 61 OFFCURVE",
+"249 76 OFFCURVE",
+"249 79 CURVE",
+"244 88 OFFCURVE",
+"226 116 OFFCURVE",
+"215 125 CURVE SMOOTH",
+"205 133 OFFCURVE",
+"185 144 OFFCURVE",
+"173 148 CURVE SMOOTH",
+"164 151 OFFCURVE",
+"132 152 OFFCURVE",
+"121 151 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 -152 OFFCURVE",
+"258 -80 OFFCURVE",
+"258 14 CURVE SMOOTH",
+"258 95 OFFCURVE",
+"213 159 OFFCURVE",
+"142 159 CURVE SMOOTH",
+"86 159 OFFCURVE",
+"50 119 OFFCURVE",
+"50 67 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"73 -13 OFFCURVE",
+"123 -13 CURVE SMOOTH",
+"171 -13 OFFCURVE",
+"183 23 OFFCURVE",
+"198 23 CURVE SMOOTH",
+"204 23 OFFCURVE",
+"209 17 OFFCURVE",
+"209 -7 CURVE SMOOTH",
+"209 -71 OFFCURVE",
+"174 -123 OFFCURVE",
+"96 -183 CURVE",
+"113 -204 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 280 OFFCURVE",
+"224 319 OFFCURVE",
+"224 367 CURVE SMOOTH",
+"224 415 OFFCURVE",
+"185 454 OFFCURVE",
+"137 454 CURVE SMOOTH",
+"89 454 OFFCURVE",
+"50 415 OFFCURVE",
+"50 367 CURVE SMOOTH",
+"50 319 OFFCURVE",
+"89 280 OFFCURVE",
+"137 280 CURVE SMOOTH"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 003B;
+},
+{
+glyphname = ellipsis;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"655 -13 OFFCURVE",
+"688 20 OFFCURVE",
+"688 60 CURVE SMOOTH",
+"688 100 OFFCURVE",
+"655 133 OFFCURVE",
+"615 133 CURVE SMOOTH",
+"575 133 OFFCURVE",
+"542 100 OFFCURVE",
+"542 60 CURVE SMOOTH",
+"542 20 OFFCURVE",
+"575 -13 OFFCURVE",
+"615 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"163 -13 OFFCURVE",
+"196 20 OFFCURVE",
+"196 60 CURVE SMOOTH",
+"196 100 OFFCURVE",
+"163 133 OFFCURVE",
+"123 133 CURVE SMOOTH",
+"83 133 OFFCURVE",
+"50 100 OFFCURVE",
+"50 60 CURVE SMOOTH",
+"50 20 OFFCURVE",
+"83 -13 OFFCURVE",
+"123 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"409 -13 OFFCURVE",
+"442 20 OFFCURVE",
+"442 60 CURVE SMOOTH",
+"442 100 OFFCURVE",
+"409 133 OFFCURVE",
+"369 133 CURVE SMOOTH",
+"329 133 OFFCURVE",
+"296 100 OFFCURVE",
+"296 60 CURVE SMOOTH",
+"296 20 OFFCURVE",
+"329 -13 OFFCURVE",
+"369 -13 CURVE SMOOTH"
+);
+}
+);
+width = 738;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"733 -13 OFFCURVE",
+"772 26 OFFCURVE",
+"772 74 CURVE SMOOTH",
+"772 122 OFFCURVE",
+"733 161 OFFCURVE",
+"685 161 CURVE SMOOTH",
+"637 161 OFFCURVE",
+"598 122 OFFCURVE",
+"598 74 CURVE SMOOTH",
+"598 26 OFFCURVE",
+"637 -13 OFFCURVE",
+"685 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"459 -13 OFFCURVE",
+"498 26 OFFCURVE",
+"498 74 CURVE SMOOTH",
+"498 122 OFFCURVE",
+"459 161 OFFCURVE",
+"411 161 CURVE SMOOTH",
+"363 161 OFFCURVE",
+"324 122 OFFCURVE",
+"324 74 CURVE SMOOTH",
+"324 26 OFFCURVE",
+"363 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+}
+);
+width = 822;
+}
+);
+unicode = 2026;
+},
+{
+glyphname = exclam;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"142 224 LINE",
+"142 496 OFFCURVE",
+"200 576 OFFCURVE",
+"200 669 CURVE SMOOTH",
+"200 748 OFFCURVE",
+"167 766 OFFCURVE",
+"127 766 CURVE SMOOTH",
+"80 766 OFFCURVE",
+"54 741 OFFCURVE",
+"54 671 CURVE SMOOTH",
+"54 577 OFFCURVE",
+"111 496 OFFCURVE",
+"111 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"167 -12 OFFCURVE",
+"200 21 OFFCURVE",
+"200 61 CURVE SMOOTH",
+"200 101 OFFCURVE",
+"167 134 OFFCURVE",
+"127 134 CURVE SMOOTH",
+"87 134 OFFCURVE",
+"54 101 OFFCURVE",
+"54 61 CURVE SMOOTH",
+"54 21 OFFCURVE",
+"87 -12 OFFCURVE",
+"127 -12 CURVE SMOOTH"
+);
+}
+);
+width = 254;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"87 727 OFFCURVE",
+"68 711 OFFCURVE",
+"58 695 CURVE",
+"48 674 OFFCURVE",
+"44 635 OFFCURVE",
+"48 611 CURVE",
+"52 597 OFFCURVE",
+"61 565 OFFCURVE",
+"66 544 CURVE",
+"69 536 OFFCURVE",
+"72 525 OFFCURVE",
+"74 519 CURVE SMOOTH",
+"76 511 OFFCURVE",
+"77 503 OFFCURVE",
+"79 501 CURVE",
+"80 498 OFFCURVE",
+"84 487 OFFCURVE",
+"87 475 CURVE",
+"88 464 OFFCURVE",
+"93 448 OFFCURVE",
+"95 440 CURVE SMOOTH",
+"101 415 OFFCURVE",
+"103 400 OFFCURVE",
+"104 386 CURVE SMOOTH",
+"104 378 OFFCURVE",
+"106 370 OFFCURVE",
+"108 365 CURVE",
+"109 355 OFFCURVE",
+"111 320 OFFCURVE",
+"112 282 CURVE SMOOTH",
+"112 247 OFFCURVE",
+"112 245 OFFCURVE",
+"116 240 CURVE SMOOTH",
+"119 237 OFFCURVE",
+"121 235 OFFCURVE",
+"130 235 CURVE SMOOTH",
+"144 235 OFFCURVE",
+"144 237 OFFCURVE",
+"144 279 CURVE SMOOTH",
+"144 298 OFFCURVE",
+"146 320 OFFCURVE",
+"148 330 CURVE",
+"148 338 OFFCURVE",
+"151 352 OFFCURVE",
+"151 362 CURVE",
+"152 371 OFFCURVE",
+"154 381 OFFCURVE",
+"156 384 CURVE",
+"156 386 OFFCURVE",
+"159 399 OFFCURVE",
+"160 413 CURVE SMOOTH",
+"162 427 OFFCURVE",
+"164 440 OFFCURVE",
+"165 440 CURVE",
+"165 442 OFFCURVE",
+"167 447 OFFCURVE",
+"167 453 CURVE SMOOTH",
+"167 464 OFFCURVE",
+"175 482 OFFCURVE",
+"192 536 CURVE",
+"215 597 OFFCURVE",
+"215 618 OFFCURVE",
+"215 648 CURVE",
+"212 685 OFFCURVE",
+"204 704 OFFCURVE",
+"183 720 CURVE SMOOTH",
+"176 725 OFFCURVE",
+"167 730 OFFCURVE",
+"162 731 CURVE SMOOTH",
+"149 735 OFFCURVE",
+"116 736 OFFCURVE",
+"106 733 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"93 159 OFFCURVE",
+"69 146 OFFCURVE",
+"60 131 CURVE SMOOTH",
+"58 128 OFFCURVE",
+"53 123 OFFCURVE",
+"52 122 CURVE SMOOTH",
+"47 117 OFFCURVE",
+"44 107 OFFCURVE",
+"40 88 CURVE SMOOTH",
+"36 66 OFFCURVE",
+"39 45 OFFCURVE",
+"53 29 CURVE SMOOTH",
+"58 23 OFFCURVE",
+"61 18 OFFCURVE",
+"61 16 CURVE SMOOTH",
+"61 16 OFFCURVE",
+"67 10 OFFCURVE",
+"76 5 CURVE",
+"90 -5 OFFCURVE",
+"95 -6 OFFCURVE",
+"104 -9 CURVE",
+"165 -24 OFFCURVE",
+"214 13 OFFCURVE",
+"216 75 CURVE",
+"218 96 OFFCURVE",
+"215 107 OFFCURVE",
+"204 123 CURVE SMOOTH",
+"192 139 OFFCURVE",
+"186 146 OFFCURVE",
+"175 152 CURVE SMOOTH",
+"159 162 OFFCURVE",
+"140 165 OFFCURVE",
+"111 162 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"171 224 LINE",
+"171 490 OFFCURVE",
+"241 562 OFFCURVE",
+"241 659 CURVE SMOOTH",
+"241 736 OFFCURVE",
+"201 763 OFFCURVE",
+"152 763 CURVE SMOOTH",
+"97 763 OFFCURVE",
+"65 729 OFFCURVE",
+"65 660 CURVE SMOOTH",
+"65 564 OFFCURVE",
+"134 490 OFFCURVE",
+"134 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 -13 OFFCURVE",
+"242 27 OFFCURVE",
+"242 75 CURVE SMOOTH",
+"242 123 OFFCURVE",
+"202 163 OFFCURVE",
+"154 163 CURVE SMOOTH",
+"106 163 OFFCURVE",
+"66 123 OFFCURVE",
+"66 75 CURVE SMOOTH",
+"66 27 OFFCURVE",
+"106 -13 OFFCURVE",
+"154 -13 CURVE SMOOTH"
+);
+}
+);
+width = 307;
+}
+);
+unicode = 0021;
+},
+{
+glyphname = exclamdown;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"54 419 OFFCURVE",
+"87 452 OFFCURVE",
+"127 452 CURVE SMOOTH",
+"167 452 OFFCURVE",
+"200 419 OFFCURVE",
+"200 379 CURVE SMOOTH",
+"200 339 OFFCURVE",
+"167 306 OFFCURVE",
+"127 306 CURVE SMOOTH",
+"87 306 OFFCURVE",
+"54 339 OFFCURVE",
+"54 379 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 216 LINE",
+"142 -56 OFFCURVE",
+"200 -136 OFFCURVE",
+"200 -229 CURVE SMOOTH",
+"200 -308 OFFCURVE",
+"167 -326 OFFCURVE",
+"127 -326 CURVE SMOOTH",
+"80 -326 OFFCURVE",
+"54 -301 OFFCURVE",
+"54 -231 CURVE SMOOTH",
+"54 -137 OFFCURVE",
+"111 -56 OFFCURVE",
+"111 216 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"167 -326 OFFCURVE",
+"200 -308 OFFCURVE",
+"200 -229 CURVE SMOOTH",
+"200 -136 OFFCURVE",
+"142 -56 OFFCURVE",
+"142 216 CURVE",
+"111 216 LINE",
+"111 -56 OFFCURVE",
+"54 -137 OFFCURVE",
+"54 -231 CURVE SMOOTH",
+"54 -301 OFFCURVE",
+"80 -326 OFFCURVE",
+"127 -326 CURVE SMOOTH",
+"127 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"167 306 OFFCURVE",
+"200 339 OFFCURVE",
+"200 379 CURVE SMOOTH",
+"200 419 OFFCURVE",
+"167 452 OFFCURVE",
+"127 452 CURVE SMOOTH",
+"87 452 OFFCURVE",
+"54 419 OFFCURVE",
+"54 379 CURVE SMOOTH",
+"54 339 OFFCURVE",
+"87 306 OFFCURVE",
+"127 306 CURVE SMOOTH"
+);
+}
+);
+width = 254;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 413 OFFCURVE",
+"201 453 OFFCURVE",
+"153 453 CURVE SMOOTH",
+"105 453 OFFCURVE",
+"65 413 OFFCURVE",
+"65 365 CURVE SMOOTH",
+"65 317 OFFCURVE",
+"105 277 OFFCURVE",
+"153 277 CURVE SMOOTH",
+"201 277 OFFCURVE",
+"241 317 OFFCURVE",
+"241 365 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 216 LINE",
+"136 -50 OFFCURVE",
+"66 -122 OFFCURVE",
+"66 -219 CURVE SMOOTH",
+"66 -296 OFFCURVE",
+"106 -323 OFFCURVE",
+"155 -323 CURVE SMOOTH",
+"210 -323 OFFCURVE",
+"242 -289 OFFCURVE",
+"242 -220 CURVE SMOOTH",
+"242 -124 OFFCURVE",
+"173 -50 OFFCURVE",
+"173 216 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"210 -323 OFFCURVE",
+"242 -289 OFFCURVE",
+"242 -220 CURVE SMOOTH",
+"242 -124 OFFCURVE",
+"173 -50 OFFCURVE",
+"173 216 CURVE",
+"136 216 LINE",
+"136 -50 OFFCURVE",
+"66 -122 OFFCURVE",
+"66 -219 CURVE SMOOTH",
+"66 -296 OFFCURVE",
+"106 -323 OFFCURVE",
+"155 -323 CURVE SMOOTH",
+"155 -323 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 277 OFFCURVE",
+"241 317 OFFCURVE",
+"241 365 CURVE SMOOTH",
+"241 413 OFFCURVE",
+"201 453 OFFCURVE",
+"153 453 CURVE SMOOTH",
+"105 453 OFFCURVE",
+"65 413 OFFCURVE",
+"65 365 CURVE SMOOTH",
+"65 317 OFFCURVE",
+"105 277 OFFCURVE",
+"153 277 CURVE SMOOTH"
+);
+}
+);
+width = 307;
+}
+);
+unicode = 00A1;
+},
+{
+glyphname = question;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"182 222 LINE",
+"182 376 OFFCURVE",
+"382 399 OFFCURVE",
+"382 567 CURVE SMOOTH",
+"382 690 OFFCURVE",
+"306 766 OFFCURVE",
+"191 766 CURVE SMOOTH",
+"93 766 OFFCURVE",
+"24 697 OFFCURVE",
+"24 627 CURVE SMOOTH",
+"24 578 OFFCURVE",
+"50 554 OFFCURVE",
+"83 554 CURVE SMOOTH",
+"112 554 OFFCURVE",
+"136 566 OFFCURVE",
+"136 598 CURVE SMOOTH",
+"136 653 OFFCURVE",
+"82 639 OFFCURVE",
+"82 674 CURVE SMOOTH",
+"82 703 OFFCURVE",
+"132 739 OFFCURVE",
+"197 739 CURVE SMOOTH",
+"260 739 OFFCURVE",
+"320 699 OFFCURVE",
+"320 628 CURVE SMOOTH",
+"320 522 OFFCURVE",
+"143 502 OFFCURVE",
+"143 307 CURVE SMOOTH",
+"143 292 OFFCURVE",
+"143 260 OFFCURVE",
+"152 222 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 -12 OFFCURVE",
+"251 21 OFFCURVE",
+"251 61 CURVE SMOOTH",
+"251 101 OFFCURVE",
+"218 134 OFFCURVE",
+"178 134 CURVE SMOOTH",
+"138 134 OFFCURVE",
+"105 101 OFFCURVE",
+"105 61 CURVE SMOOTH",
+"105 21 OFFCURVE",
+"138 -12 OFFCURVE",
+"178 -12 CURVE SMOOTH"
+);
+}
+);
+width = 414;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"171 748 OFFCURVE",
+"137 737 OFFCURVE",
+"123 726 CURVE SMOOTH",
+"121 724 OFFCURVE",
+"117 722 OFFCURVE",
+"117 722 CURVE",
+"113 722 OFFCURVE",
+"86 698 OFFCURVE",
+"78 687 CURVE",
+"73 682 OFFCURVE",
+"69 676 OFFCURVE",
+"67 673 CURVE SMOOTH",
+"62 666 OFFCURVE",
+"53 646 OFFCURVE",
+"49 633 CURVE",
+"49 628 OFFCURVE",
+"48 618 OFFCURVE",
+"48 610 CURVE SMOOTH",
+"48 591 OFFCURVE",
+"55 574 OFFCURVE",
+"65 559 CURVE",
+"81 542 OFFCURVE",
+"103 534 OFFCURVE",
+"126 538 CURVE SMOOTH",
+"148 542 OFFCURVE",
+"170 556 OFFCURVE",
+"179 574 CURVE SMOOTH",
+"185 585 OFFCURVE",
+"189 602 OFFCURVE",
+"187 612 CURVE SMOOTH",
+"184 633 OFFCURVE",
+"168 655 OFFCURVE",
+"147 665 CURVE SMOOTH",
+"136 670 OFFCURVE",
+"129 676 OFFCURVE",
+"129 682 CURVE SMOOTH",
+"129 684 OFFCURVE",
+"133 690 OFFCURVE",
+"139 695 CURVE",
+"145 702 OFFCURVE",
+"152 705 OFFCURVE",
+"165 710 CURVE SMOOTH",
+"177 714 OFFCURVE",
+"189 718 OFFCURVE",
+"189 719 CURVE",
+"198 724 OFFCURVE",
+"217 724 OFFCURVE",
+"230 719 CURVE",
+"236 718 OFFCURVE",
+"243 716 OFFCURVE",
+"249 716 CURVE SMOOTH",
+"257 716 OFFCURVE",
+"280 708 OFFCURVE",
+"285 705 CURVE",
+"285 703 OFFCURVE",
+"288 702 OFFCURVE",
+"291 698 CURVE",
+"313 686 OFFCURVE",
+"321 674 OFFCURVE",
+"326 652 CURVE",
+"326 642 OFFCURVE",
+"326 641 OFFCURVE",
+"326 625 CURVE",
+"323 607 OFFCURVE",
+"320 601 OFFCURVE",
+"310 588 CURVE SMOOTH",
+"302 577 OFFCURVE",
+"265 538 OFFCURVE",
+"246 522 CURVE SMOOTH",
+"240 516 OFFCURVE",
+"232 508 OFFCURVE",
+"229 505 CURVE",
+"227 500 OFFCURVE",
+"219 492 OFFCURVE",
+"213 486 CURVE SMOOTH",
+"206 479 OFFCURVE",
+"200 471 OFFCURVE",
+"198 468 CURVE SMOOTH",
+"197 465 OFFCURVE",
+"193 460 OFFCURVE",
+"190 457 CURVE SMOOTH",
+"187 454 OFFCURVE",
+"182 447 OFFCURVE",
+"181 444 CURVE SMOOTH",
+"171 426 OFFCURVE",
+"165 412 OFFCURVE",
+"163 406 CURVE",
+"163 402 OFFCURVE",
+"161 394 OFFCURVE",
+"160 390 CURVE",
+"160 372 OFFCURVE",
+"160 322 OFFCURVE",
+"160 295 CURVE",
+"163 279 OFFCURVE",
+"169 258 OFFCURVE",
+"174 250 CURVE",
+"174 241 OFFCURVE",
+"195 238 OFFCURVE",
+"195 244 CURVE",
+"200 247 OFFCURVE",
+"200 247 OFFCURVE",
+"200 268 CURVE",
+"198 286 OFFCURVE",
+"200 290 OFFCURVE",
+"203 298 CURVE SMOOTH",
+"208 311 OFFCURVE",
+"220 324 OFFCURVE",
+"240 337 CURVE SMOOTH",
+"247 342 OFFCURVE",
+"257 346 OFFCURVE",
+"257 348 CURVE SMOOTH",
+"257 350 OFFCURVE",
+"269 358 OFFCURVE",
+"281 364 CURVE",
+"340 402 OFFCURVE",
+"369 426 OFFCURVE",
+"395 460 CURVE SMOOTH",
+"412 482 OFFCURVE",
+"425 514 OFFCURVE",
+"432 546 CURVE",
+"433 562 OFFCURVE",
+"432 594 OFFCURVE",
+"429 606 CURVE",
+"427 610 OFFCURVE",
+"424 620 OFFCURVE",
+"422 626 CURVE SMOOTH",
+"417 650 OFFCURVE",
+"384 695 OFFCURVE",
+"361 711 CURVE SMOOTH",
+"357 713 OFFCURVE",
+"350 718 OFFCURVE",
+"345 721 CURVE SMOOTH",
+"337 727 OFFCURVE",
+"329 730 OFFCURVE",
+"305 740 CURVE SMOOTH",
+"283 748 OFFCURVE",
+"232 754 OFFCURVE",
+"203 751 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 161 OFFCURVE",
+"192 160 OFFCURVE",
+"187 160 CURVE",
+"168 156 OFFCURVE",
+"160 153 OFFCURVE",
+"147 142 CURVE SMOOTH",
+"141 137 OFFCURVE",
+"134 129 OFFCURVE",
+"133 126 CURVE SMOOTH",
+"133 124 OFFCURVE",
+"129 120 OFFCURVE",
+"128 118 CURVE SMOOTH",
+"117 105 OFFCURVE",
+"112 81 OFFCURVE",
+"115 64 CURVE",
+"115 44 OFFCURVE",
+"128 32 OFFCURVE",
+"134 20 CURVE",
+"157 -7 OFFCURVE",
+"184 -16 OFFCURVE",
+"219 -10 CURVE SMOOTH",
+"248 -5 OFFCURVE",
+"269 9 OFFCURVE",
+"281 36 CURVE",
+"289 51 OFFCURVE",
+"291 54 OFFCURVE",
+"291 68 CURVE",
+"296 118 OFFCURVE",
+"261 160 OFFCURVE",
+"213 161 CURVE",
+"203 163 OFFCURVE",
+"197 163 OFFCURVE",
+"195 161 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"182 224 LINE",
+"182 361 OFFCURVE",
+"430 367 OFFCURVE",
+"430 569 CURVE SMOOTH",
+"430 675 OFFCURVE",
+"345 754 OFFCURVE",
+"215 754 CURVE SMOOTH",
+"113 754 OFFCURVE",
+"45 684 OFFCURVE",
+"45 606 CURVE SMOOTH",
+"45 560 OFFCURVE",
+"78 538 OFFCURVE",
+"117 538 CURVE SMOOTH",
+"157 538 OFFCURVE",
+"187 564 OFFCURVE",
+"187 595 CURVE SMOOTH",
+"187 663 OFFCURVE",
+"126 654 OFFCURVE",
+"126 680 CURVE SMOOTH",
+"126 699 OFFCURVE",
+"165 722 OFFCURVE",
+"217 722 CURVE SMOOTH",
+"279 722 OFFCURVE",
+"331 687 OFFCURVE",
+"331 627 CURVE SMOOTH",
+"331 513 OFFCURVE",
+"148 511 OFFCURVE",
+"148 291 CURVE SMOOTH",
+"148 275 OFFCURVE",
+"149 249 OFFCURVE",
+"152 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"223 -13 OFFCURVE",
+"263 27 OFFCURVE",
+"263 74 CURVE SMOOTH",
+"263 122 OFFCURVE",
+"223 162 OFFCURVE",
+"175 162 CURVE SMOOTH",
+"128 162 OFFCURVE",
+"88 122 OFFCURVE",
+"88 74 CURVE SMOOTH",
+"88 27 OFFCURVE",
+"128 -13 OFFCURVE",
+"175 -13 CURVE SMOOTH"
+);
+}
+);
+width = 470;
+}
+);
+unicode = 003F;
+},
+{
+glyphname = questiondown;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"232 230 LINE",
+"232 76 OFFCURVE",
+"32 53 OFFCURVE",
+"32 -115 CURVE SMOOTH",
+"32 -238 OFFCURVE",
+"108 -314 OFFCURVE",
+"223 -314 CURVE SMOOTH",
+"321 -314 OFFCURVE",
+"390 -245 OFFCURVE",
+"390 -175 CURVE SMOOTH",
+"390 -126 OFFCURVE",
+"364 -102 OFFCURVE",
+"331 -102 CURVE SMOOTH",
+"302 -102 OFFCURVE",
+"278 -114 OFFCURVE",
+"278 -146 CURVE SMOOTH",
+"278 -201 OFFCURVE",
+"332 -187 OFFCURVE",
+"332 -222 CURVE SMOOTH",
+"332 -251 OFFCURVE",
+"282 -287 OFFCURVE",
+"217 -287 CURVE SMOOTH",
+"154 -287 OFFCURVE",
+"94 -247 OFFCURVE",
+"94 -176 CURVE SMOOTH",
+"94 -70 OFFCURVE",
+"271 -50 OFFCURVE",
+"271 145 CURVE SMOOTH",
+"271 160 OFFCURVE",
+"271 192 OFFCURVE",
+"262 230 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"309 429 OFFCURVE",
+"276 462 OFFCURVE",
+"236 462 CURVE SMOOTH",
+"196 462 OFFCURVE",
+"163 429 OFFCURVE",
+"163 389 CURVE SMOOTH",
+"163 349 OFFCURVE",
+"196 316 OFFCURVE",
+"236 316 CURVE SMOOTH",
+"276 316 OFFCURVE",
+"309 349 OFFCURVE",
+"309 389 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 -314 OFFCURVE",
+"390 -245 OFFCURVE",
+"390 -175 CURVE SMOOTH",
+"390 -126 OFFCURVE",
+"364 -102 OFFCURVE",
+"331 -102 CURVE SMOOTH",
+"302 -102 OFFCURVE",
+"278 -114 OFFCURVE",
+"278 -146 CURVE SMOOTH",
+"278 -201 OFFCURVE",
+"332 -187 OFFCURVE",
+"332 -222 CURVE SMOOTH",
+"332 -251 OFFCURVE",
+"282 -287 OFFCURVE",
+"217 -287 CURVE SMOOTH",
+"154 -287 OFFCURVE",
+"94 -247 OFFCURVE",
+"94 -176 CURVE SMOOTH",
+"94 -70 OFFCURVE",
+"271 -50 OFFCURVE",
+"271 145 CURVE SMOOTH",
+"271 160 OFFCURVE",
+"271 192 OFFCURVE",
+"262 230 CURVE",
+"232 230 LINE",
+"232 76 OFFCURVE",
+"32 53 OFFCURVE",
+"32 -115 CURVE SMOOTH",
+"32 -238 OFFCURVE",
+"108 -314 OFFCURVE",
+"223 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 316 OFFCURVE",
+"309 349 OFFCURVE",
+"309 389 CURVE SMOOTH",
+"309 429 OFFCURVE",
+"276 462 OFFCURVE",
+"236 462 CURVE SMOOTH",
+"196 462 OFFCURVE",
+"163 429 OFFCURVE",
+"163 389 CURVE SMOOTH",
+"163 349 OFFCURVE",
+"196 316 OFFCURVE",
+"236 316 CURVE SMOOTH"
+);
+}
+);
+width = 414;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"382 422 OFFCURVE",
+"342 462 OFFCURVE",
+"295 462 CURVE SMOOTH",
+"247 462 OFFCURVE",
+"207 422 OFFCURVE",
+"207 375 CURVE SMOOTH",
+"207 327 OFFCURVE",
+"247 287 OFFCURVE",
+"295 287 CURVE SMOOTH",
+"342 287 OFFCURVE",
+"382 327 OFFCURVE",
+"382 375 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"288 216 LINE",
+"288 79 OFFCURVE",
+"40 73 OFFCURVE",
+"40 -129 CURVE SMOOTH",
+"40 -235 OFFCURVE",
+"125 -314 OFFCURVE",
+"255 -314 CURVE SMOOTH",
+"357 -314 OFFCURVE",
+"425 -244 OFFCURVE",
+"425 -166 CURVE SMOOTH",
+"425 -120 OFFCURVE",
+"392 -98 OFFCURVE",
+"353 -98 CURVE SMOOTH",
+"313 -98 OFFCURVE",
+"283 -124 OFFCURVE",
+"283 -155 CURVE SMOOTH",
+"283 -223 OFFCURVE",
+"344 -214 OFFCURVE",
+"344 -240 CURVE SMOOTH",
+"344 -259 OFFCURVE",
+"305 -282 OFFCURVE",
+"253 -282 CURVE SMOOTH",
+"191 -282 OFFCURVE",
+"139 -247 OFFCURVE",
+"139 -187 CURVE SMOOTH",
+"139 -73 OFFCURVE",
+"322 -71 OFFCURVE",
+"322 149 CURVE SMOOTH",
+"322 165 OFFCURVE",
+"321 191 OFFCURVE",
+"318 216 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"357 -314 OFFCURVE",
+"425 -244 OFFCURVE",
+"425 -166 CURVE SMOOTH",
+"425 -120 OFFCURVE",
+"392 -98 OFFCURVE",
+"353 -98 CURVE SMOOTH",
+"313 -98 OFFCURVE",
+"283 -124 OFFCURVE",
+"283 -155 CURVE SMOOTH",
+"283 -223 OFFCURVE",
+"344 -214 OFFCURVE",
+"344 -240 CURVE SMOOTH",
+"344 -259 OFFCURVE",
+"305 -282 OFFCURVE",
+"253 -282 CURVE SMOOTH",
+"191 -282 OFFCURVE",
+"139 -247 OFFCURVE",
+"139 -187 CURVE SMOOTH",
+"139 -73 OFFCURVE",
+"322 -71 OFFCURVE",
+"322 149 CURVE SMOOTH",
+"322 165 OFFCURVE",
+"321 191 OFFCURVE",
+"318 216 CURVE",
+"288 216 LINE",
+"288 79 OFFCURVE",
+"40 73 OFFCURVE",
+"40 -129 CURVE SMOOTH",
+"40 -235 OFFCURVE",
+"125 -314 OFFCURVE",
+"255 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 287 OFFCURVE",
+"382 327 OFFCURVE",
+"382 375 CURVE SMOOTH",
+"382 422 OFFCURVE",
+"342 462 OFFCURVE",
+"295 462 CURVE SMOOTH",
+"247 462 OFFCURVE",
+"207 422 OFFCURVE",
+"207 375 CURVE SMOOTH",
+"207 327 OFFCURVE",
+"247 287 OFFCURVE",
+"295 287 CURVE SMOOTH"
+);
+}
+);
+width = 470;
+}
+);
+unicode = 00BF;
+},
+{
+glyphname = periodcentered;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"123 177 OFFCURVE",
+"156 210 OFFCURVE",
+"156 250 CURVE SMOOTH",
+"156 290 OFFCURVE",
+"123 323 OFFCURVE",
+"83 323 CURVE SMOOTH",
+"43 323 OFFCURVE",
+"10 290 OFFCURVE",
+"10 250 CURVE SMOOTH",
+"10 210 OFFCURVE",
+"43 177 OFFCURVE",
+"83 177 CURVE SMOOTH"
+);
+}
+);
+width = 166;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"185 167 OFFCURVE",
+"224 206 OFFCURVE",
+"224 254 CURVE SMOOTH",
+"224 302 OFFCURVE",
+"185 341 OFFCURVE",
+"137 341 CURVE SMOOTH",
+"89 341 OFFCURVE",
+"50 302 OFFCURVE",
+"50 254 CURVE SMOOTH",
+"50 206 OFFCURVE",
+"89 167 OFFCURVE",
+"137 167 CURVE SMOOTH"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 00B7;
+},
+{
+glyphname = bullet;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"275 265 OFFCURVE",
+"320 317 OFFCURVE",
+"320 380 CURVE SMOOTH",
+"320 443 OFFCURVE",
+"275 495 OFFCURVE",
+"205 495 CURVE SMOOTH",
+"135 495 OFFCURVE",
+"90 443 OFFCURVE",
+"90 380 CURVE SMOOTH",
+"90 317 OFFCURVE",
+"135 265 OFFCURVE",
+"205 265 CURVE SMOOTH"
+);
+}
+);
+width = 410;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 265 OFFCURVE",
+"320 317 OFFCURVE",
+"320 380 CURVE SMOOTH",
+"320 443 OFFCURVE",
+"275 495 OFFCURVE",
+"205 495 CURVE SMOOTH",
+"135 495 OFFCURVE",
+"90 443 OFFCURVE",
+"90 380 CURVE SMOOTH",
+"90 317 OFFCURVE",
+"135 265 OFFCURVE",
+"205 265 CURVE SMOOTH"
+);
+}
+);
+width = 410;
+}
+);
+unicode = 2022;
+},
+{
+glyphname = asterisk;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"254 336 OFFCURVE",
+"269 361 OFFCURVE",
+"269 390 CURVE SMOOTH",
+"269 427 OFFCURVE",
+"244 457 OFFCURVE",
+"238 520 CURVE",
+"241 522 LINE",
+"305 482 OFFCURVE",
+"317 419 OFFCURVE",
+"366 419 CURVE SMOOTH",
+"399 419 OFFCURVE",
+"413 447 OFFCURVE",
+"413 467 CURVE SMOOTH",
+"413 485 OFFCURVE",
+"401 500 OFFCURVE",
+"384 510 CURVE SMOOTH",
+"351 529 OFFCURVE",
+"315 521 OFFCURVE",
+"258 547 CURVE",
+"258 551 LINE",
+"315 577 OFFCURVE",
+"351 569 OFFCURVE",
+"384 588 CURVE SMOOTH",
+"401 598 OFFCURVE",
+"413 613 OFFCURVE",
+"413 631 CURVE SMOOTH",
+"413 651 OFFCURVE",
+"399 679 OFFCURVE",
+"366 679 CURVE SMOOTH",
+"317 679 OFFCURVE",
+"305 616 OFFCURVE",
+"241 576 CURVE",
+"238 578 LINE",
+"244 643 OFFCURVE",
+"269 671 OFFCURVE",
+"269 709 CURVE SMOOTH",
+"269 738 OFFCURVE",
+"254 763 OFFCURVE",
+"221 763 CURVE SMOOTH",
+"190 763 OFFCURVE",
+"175 741 OFFCURVE",
+"175 711 CURVE SMOOTH",
+"175 672 OFFCURVE",
+"201 643 OFFCURVE",
+"206 578 CURVE",
+"203 576 LINE",
+"135 618 OFFCURVE",
+"126 679 OFFCURVE",
+"76 679 CURVE SMOOTH",
+"44 679 OFFCURVE",
+"30 655 OFFCURVE",
+"30 633 CURVE SMOOTH",
+"30 614 OFFCURVE",
+"41 600 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"96 568 OFFCURVE",
+"129 578 OFFCURVE",
+"187 551 CURVE",
+"187 547 LINE",
+"129 520 OFFCURVE",
+"96 530 OFFCURVE",
+"59 508 CURVE SMOOTH",
+"41 498 OFFCURVE",
+"30 484 OFFCURVE",
+"30 465 CURVE SMOOTH",
+"30 443 OFFCURVE",
+"44 419 OFFCURVE",
+"76 419 CURVE SMOOTH",
+"127 419 OFFCURVE",
+"135 480 OFFCURVE",
+"203 522 CURVE",
+"206 520 LINE",
+"200 455 OFFCURVE",
+"175 426 OFFCURVE",
+"175 388 CURVE SMOOTH",
+"175 358 OFFCURVE",
+"190 336 OFFCURVE",
+"221 336 CURVE SMOOTH"
+);
+}
+);
+width = 443;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 336 OFFCURVE",
+"279 364 OFFCURVE",
+"279 393 CURVE SMOOTH",
+"279 433 OFFCURVE",
+"246 458 OFFCURVE",
+"238 520 CURVE",
+"241 522 LINE",
+"307 477 OFFCURVE",
+"315 409 OFFCURVE",
+"368 409 CURVE SMOOTH",
+"405 409 OFFCURVE",
+"423 443 OFFCURVE",
+"423 466 CURVE SMOOTH",
+"423 488 OFFCURVE",
+"406 510 OFFCURVE",
+"384 520 CURVE SMOOTH",
+"354 534 OFFCURVE",
+"315 522 OFFCURVE",
+"258 547 CURVE",
+"258 551 LINE",
+"315 575 OFFCURVE",
+"354 564 OFFCURVE",
+"384 578 CURVE SMOOTH",
+"406 588 OFFCURVE",
+"423 610 OFFCURVE",
+"423 632 CURVE SMOOTH",
+"423 655 OFFCURVE",
+"405 689 OFFCURVE",
+"368 689 CURVE SMOOTH",
+"315 689 OFFCURVE",
+"307 621 OFFCURVE",
+"241 576 CURVE",
+"238 578 LINE",
+"246 642 OFFCURVE",
+"279 665 OFFCURVE",
+"279 705 CURVE SMOOTH",
+"279 735 OFFCURVE",
+"261 763 OFFCURVE",
+"221 763 CURVE SMOOTH",
+"183 763 OFFCURVE",
+"165 738 OFFCURVE",
+"165 708 CURVE SMOOTH",
+"165 666 OFFCURVE",
+"199 642 OFFCURVE",
+"206 578 CURVE",
+"203 576 LINE",
+"133 623 OFFCURVE",
+"128 689 OFFCURVE",
+"74 689 CURVE SMOOTH",
+"39 689 OFFCURVE",
+"20 661 OFFCURVE",
+"20 635 CURVE SMOOTH",
+"20 611 OFFCURVE",
+"35 591 OFFCURVE",
+"59 580 CURVE SMOOTH",
+"94 564 OFFCURVE",
+"129 577 OFFCURVE",
+"187 551 CURVE",
+"187 547 LINE",
+"129 520 OFFCURVE",
+"94 534 OFFCURVE",
+"59 518 CURVE SMOOTH",
+"35 507 OFFCURVE",
+"20 487 OFFCURVE",
+"20 464 CURVE SMOOTH",
+"20 438 OFFCURVE",
+"38 409 OFFCURVE",
+"74 409 CURVE SMOOTH",
+"129 409 OFFCURVE",
+"134 475 OFFCURVE",
+"203 522 CURVE",
+"206 520 LINE",
+"198 456 OFFCURVE",
+"165 432 OFFCURVE",
+"165 391 CURVE SMOOTH",
+"165 361 OFFCURVE",
+"183 336 OFFCURVE",
+"221 336 CURVE SMOOTH"
+);
+}
+);
+width = 443;
+}
+);
+unicode = 002A;
+},
+{
+glyphname = numbersign;
+lastChange = "2016-10-31 10:00:25 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"187 763 LINE",
+"67 0 LINE",
+"135 0 LINE",
+"255 763 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 224 LINE",
+"498 224 LINE",
+"498 288 LINE",
+"0 288 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 763 LINE",
+"284 0 LINE",
+"352 0 LINE",
+"472 763 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"49 463 LINE",
+"547 463 LINE",
+"547 527 LINE",
+"49 527 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"498 236 LINE",
+"498 276 LINE",
+"0 276 LINE",
+"0 236 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 475 LINE",
+"547 515 LINE",
+"49 515 LINE",
+"49 475 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"125 0 LINE",
+"245 763 LINE",
+"197 763 LINE",
+"77 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 0 LINE",
+"462 763 LINE",
+"414 763 LINE",
+"294 0 LINE"
+);
+}
+);
+width = 546;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"177 763 LINE",
+"57 0 LINE",
+"145 0 LINE",
+"265 763 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 219 LINE",
+"498 219 LINE",
+"498 293 LINE",
+"0 293 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"394 763 LINE",
+"274 0 LINE",
+"362 0 LINE",
+"482 763 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"49 458 LINE",
+"547 458 LINE",
+"547 532 LINE",
+"49 532 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"498 232 LINE",
+"498 281 LINE",
+"0 281 LINE",
+"0 232 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 470 LINE",
+"547 520 LINE",
+"49 520 LINE",
+"49 470 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 0 LINE",
+"253 763 LINE",
+"189 763 LINE",
+"69 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 0 LINE",
+"462 763 LINE",
+"406 763 LINE",
+"286 0 LINE"
+);
+}
+);
+width = 546;
+}
+);
+unicode = 0023;
+},
+{
+glyphname = slash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"39 0 LINE",
+"249 753 LINE",
+"190 753 LINE",
+"-20 0 LINE"
+);
+}
+);
+width = 190;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"59 0 LINE",
+"249 753 LINE",
+"170 753 LINE",
+"-20 0 LINE"
+);
+}
+);
+width = 190;
+}
+);
+unicode = 002F;
+},
+{
+glyphname = backslash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"209 0 LINE",
+"-1 753 LINE",
+"-60 753 LINE",
+"150 0 LINE"
+);
+}
+);
+width = 149;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"209 0 LINE",
+"19 753 LINE",
+"-60 753 LINE",
+"130 0 LINE"
+);
+}
+);
+width = 149;
+}
+);
+unicode = 005C;
+},
+{
+glyphname = hyphen;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 190 LINE",
+"345 190 LINE",
+"345 258 LINE",
+"50 258 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"345 202 LINE",
+"345 246 LINE",
+"50 246 LINE",
+"50 202 LINE"
+);
+}
+);
+width = 395;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 170 LINE",
+"345 170 LINE",
+"345 258 LINE",
+"50 258 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"345 182 LINE",
+"345 246 LINE",
+"50 246 LINE",
+"50 182 LINE"
+);
+}
+);
+width = 395;
+}
+);
+unicode = 002D;
+},
+{
+glyphname = softhyphen;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 190 LINE",
+"345 190 LINE",
+"345 258 LINE",
+"50 258 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"345 202 LINE",
+"345 246 LINE",
+"50 246 LINE",
+"50 202 LINE"
+);
+}
+);
+width = 395;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 170 LINE",
+"345 170 LINE",
+"345 258 LINE",
+"50 258 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"345 182 LINE",
+"345 246 LINE",
+"50 246 LINE",
+"50 182 LINE"
+);
+}
+);
+width = 395;
+}
+);
+unicode = 00AD;
+},
+{
+glyphname = endash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 190 LINE",
+"538 190 LINE",
+"538 258 LINE",
+"0 258 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"538 202 LINE",
+"538 246 LINE",
+"0 246 LINE",
+"0 202 LINE"
+);
+}
+);
+width = 538;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 180 LINE",
+"584 180 LINE",
+"584 258 LINE",
+"0 258 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"584 192 LINE",
+"584 246 LINE",
+"0 246 LINE",
+"0 192 LINE"
+);
+}
+);
+width = 584;
+}
+);
+unicode = 2013;
+},
+{
+glyphname = emdash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 190 LINE",
+"828 190 LINE",
+"828 258 LINE",
+"0 258 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"828 202 LINE",
+"828 246 LINE",
+"0 246 LINE",
+"0 202 LINE"
+);
+}
+);
+width = 828;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 180 LINE",
+"875 180 LINE",
+"875 258 LINE",
+"0 258 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"875 192 LINE",
+"875 246 LINE",
+"0 246 LINE",
+"0 192 LINE"
+);
+}
+);
+width = 875;
+}
+);
+unicode = 2014;
+},
+{
+glyphname = underscore;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 -126 LINE",
+"538 -126 LINE",
+"538 -58 LINE",
+"0 -58 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"538 -114 LINE",
+"538 -70 LINE",
+"0 -70 LINE",
+"0 -114 LINE"
+);
+}
+);
+width = 538;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 -136 LINE",
+"584 -136 LINE",
+"584 -58 LINE",
+"0 -58 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"584 -124 LINE",
+"584 -70 LINE",
+"0 -70 LINE",
+"0 -124 LINE"
+);
+}
+);
+width = 584;
+}
+);
+unicode = 005F;
+},
+{
+glyphname = parenleft;
+lastChange = "2016-08-19 16:54:48 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"307 -123 LINE",
+"248 -46 OFFCURVE",
+"178 86 OFFCURVE",
+"178 334 CURVE SMOOTH",
+"178 590 OFFCURVE",
+"253 713 OFFCURVE",
+"309 788 CURVE",
+"284 804 LINE",
+"136 642 OFFCURVE",
+"70 498 OFFCURVE",
+"70 332 CURVE SMOOTH",
+"70 164 OFFCURVE",
+"137 17 OFFCURVE",
+"282 -136 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"307 -123 LINE",
+"248 -46 OFFCURVE",
+"178 86 OFFCURVE",
+"178 334 CURVE SMOOTH",
+"178 590 OFFCURVE",
+"253 713 OFFCURVE",
+"309 788 CURVE",
+"284 804 LINE",
+"136 642 OFFCURVE",
+"70 498 OFFCURVE",
+"70 332 CURVE SMOOTH",
+"70 164 OFFCURVE",
+"137 17 OFFCURVE",
+"282 -136 CURVE"
+);
+}
+);
+width = 309;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"287 -123 LINE",
+"190 31 OFFCURVE",
+"180 162 OFFCURVE",
+"180 327 CURVE SMOOTH",
+"180 530 OFFCURVE",
+"195 637 OFFCURVE",
+"289 788 CURVE",
+"264 804 LINE",
+"86 627 OFFCURVE",
+"30 482 OFFCURVE",
+"30 332 CURVE SMOOTH",
+"30 188 OFFCURVE",
+"81 38 OFFCURVE",
+"262 -136 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 -123 LINE",
+"190 31 OFFCURVE",
+"180 162 OFFCURVE",
+"180 327 CURVE SMOOTH",
+"180 530 OFFCURVE",
+"195 637 OFFCURVE",
+"289 788 CURVE",
+"264 804 LINE",
+"86 627 OFFCURVE",
+"30 482 OFFCURVE",
+"30 332 CURVE SMOOTH",
+"30 188 OFFCURVE",
+"81 38 OFFCURVE",
+"262 -136 CURVE"
+);
+}
+);
+width = 309;
+}
+);
+unicode = 0028;
+},
+{
+glyphname = parenright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"172 17 OFFCURVE",
+"239 164 OFFCURVE",
+"239 332 CURVE SMOOTH",
+"239 498 OFFCURVE",
+"173 642 OFFCURVE",
+"25 804 CURVE",
+"0 788 LINE",
+"56 713 OFFCURVE",
+"131 590 OFFCURVE",
+"131 334 CURVE SMOOTH",
+"131 86 OFFCURVE",
+"61 -46 OFFCURVE",
+"2 -123 CURVE",
+"27 -136 LINE"
+);
+}
+);
+width = 309;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"228 38 OFFCURVE",
+"279 188 OFFCURVE",
+"279 332 CURVE SMOOTH",
+"279 482 OFFCURVE",
+"223 627 OFFCURVE",
+"45 804 CURVE",
+"20 788 LINE",
+"114 637 OFFCURVE",
+"129 531 OFFCURVE",
+"129 324 CURVE SMOOTH",
+"129 163 OFFCURVE",
+"119 31 OFFCURVE",
+"22 -123 CURVE",
+"47 -136 LINE"
+);
+}
+);
+width = 309;
+}
+);
+unicode = 0029;
+},
+{
+glyphname = braceleft;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"319 -98 LINE",
+"248 -98 OFFCURVE",
+"229 -69 OFFCURVE",
+"229 32 CURVE SMOOTH",
+"229 204 LINE SMOOTH",
+"229 287 OFFCURVE",
+"204 321 OFFCURVE",
+"127 330 CURVE",
+"127 334 LINE",
+"204 343 OFFCURVE",
+"229 376 OFFCURVE",
+"229 459 CURVE SMOOTH",
+"229 632 LINE SMOOTH",
+"229 733 OFFCURVE",
+"248 762 OFFCURVE",
+"319 762 CURVE",
+"319 787 LINE",
+"146 787 OFFCURVE",
+"120 758 OFFCURVE",
+"120 605 CURVE SMOOTH",
+"120 462 LINE SMOOTH",
+"120 368 OFFCURVE",
+"106 340 OFFCURVE",
+"54 340 CURVE",
+"54 323 LINE",
+"106 323 OFFCURVE",
+"120 295 OFFCURVE",
+"120 201 CURVE SMOOTH",
+"120 59 LINE SMOOTH",
+"120 -94 OFFCURVE",
+"146 -123 OFFCURVE",
+"319 -123 CURVE"
+);
+}
+);
+width = 312;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"54 323 LINE",
+"106 323 OFFCURVE",
+"120 295 OFFCURVE",
+"120 201 CURVE SMOOTH",
+"120 59 LINE SMOOTH",
+"120 -94 OFFCURVE",
+"146 -123 OFFCURVE",
+"319 -123 CURVE",
+"319 -98 LINE",
+"248 -98 OFFCURVE",
+"229 -69 OFFCURVE",
+"229 32 CURVE SMOOTH",
+"229 204 LINE SMOOTH",
+"229 287 OFFCURVE",
+"204 321 OFFCURVE",
+"127 330 CURVE",
+"127 334 LINE",
+"204 343 OFFCURVE",
+"229 376 OFFCURVE",
+"229 459 CURVE SMOOTH",
+"229 632 LINE SMOOTH",
+"229 733 OFFCURVE",
+"248 762 OFFCURVE",
+"319 762 CURVE",
+"319 787 LINE",
+"146 787 OFFCURVE",
+"120 758 OFFCURVE",
+"120 605 CURVE SMOOTH",
+"120 462 LINE SMOOTH",
+"120 368 OFFCURVE",
+"106 340 OFFCURVE",
+"54 340 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 -91 LINE",
+"228 -91 OFFCURVE",
+"210 -62 OFFCURVE",
+"210 39 CURVE SMOOTH",
+"210 206 LINE SMOOTH",
+"210 289 OFFCURVE",
+"185 323 OFFCURVE",
+"108 332 CURVE",
+"108 336 LINE",
+"185 345 OFFCURVE",
+"210 378 OFFCURVE",
+"210 461 CURVE SMOOTH",
+"210 627 LINE SMOOTH",
+"210 728 OFFCURVE",
+"228 757 OFFCURVE",
+"295 757 CURVE",
+"295 787 LINE",
+"104 787 OFFCURVE",
+"76 758 OFFCURVE",
+"76 605 CURVE SMOOTH",
+"76 464 LINE SMOOTH",
+"76 374 OFFCURVE",
+"62 347 OFFCURVE",
+"10 347 CURVE",
+"10 320 LINE",
+"62 320 OFFCURVE",
+"76 293 OFFCURVE",
+"76 203 CURVE SMOOTH",
+"76 61 LINE SMOOTH",
+"76 -92 OFFCURVE",
+"104 -121 OFFCURVE",
+"295 -121 CURVE"
+);
+}
+);
+width = 300;
+}
+);
+unicode = 007B;
+},
+{
+glyphname = braceright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"166 -123 OFFCURVE",
+"192 -94 OFFCURVE",
+"192 59 CURVE SMOOTH",
+"192 201 LINE SMOOTH",
+"192 295 OFFCURVE",
+"206 323 OFFCURVE",
+"258 323 CURVE",
+"258 340 LINE",
+"206 340 OFFCURVE",
+"192 368 OFFCURVE",
+"192 462 CURVE SMOOTH",
+"192 605 LINE SMOOTH",
+"192 758 OFFCURVE",
+"166 787 OFFCURVE",
+"-7 787 CURVE",
+"-7 762 LINE",
+"64 762 OFFCURVE",
+"83 733 OFFCURVE",
+"83 632 CURVE SMOOTH",
+"83 459 LINE SMOOTH",
+"83 376 OFFCURVE",
+"108 343 OFFCURVE",
+"185 334 CURVE",
+"185 330 LINE",
+"108 321 OFFCURVE",
+"83 287 OFFCURVE",
+"83 204 CURVE SMOOTH",
+"83 32 LINE SMOOTH",
+"83 -69 OFFCURVE",
+"64 -98 OFFCURVE",
+"-7 -98 CURVE",
+"-7 -123 LINE"
+);
+}
+);
+width = 312;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"290 326 LINE",
+"238 326 OFFCURVE",
+"224 353 OFFCURVE",
+"224 443 CURVE SMOOTH",
+"224 572 LINE SMOOTH",
+"224 725 OFFCURVE",
+"196 754 OFFCURVE",
+"5 754 CURVE",
+"5 724 LINE",
+"72 724 OFFCURVE",
+"90 696 OFFCURVE",
+"90 599 CURVE SMOOTH",
+"90 440 LINE SMOOTH",
+"90 357 OFFCURVE",
+"115 324 OFFCURVE",
+"192 315 CURVE",
+"192 311 LINE",
+"115 302 OFFCURVE",
+"90 268 OFFCURVE",
+"90 185 CURVE SMOOTH",
+"90 25 LINE SMOOTH",
+"90 -72 OFFCURVE",
+"72 -100 OFFCURVE",
+"5 -100 CURVE",
+"5 -130 LINE",
+"196 -130 OFFCURVE",
+"224 -101 OFFCURVE",
+"224 52 CURVE SMOOTH",
+"224 182 LINE SMOOTH",
+"224 272 OFFCURVE",
+"238 299 OFFCURVE",
+"290 299 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 -121 OFFCURVE",
+"225 -92 OFFCURVE",
+"225 61 CURVE SMOOTH",
+"225 203 LINE SMOOTH",
+"225 293 OFFCURVE",
+"239 320 OFFCURVE",
+"291 320 CURVE",
+"291 347 LINE",
+"239 347 OFFCURVE",
+"225 374 OFFCURVE",
+"225 464 CURVE SMOOTH",
+"225 605 LINE SMOOTH",
+"225 758 OFFCURVE",
+"197 787 OFFCURVE",
+"6 787 CURVE",
+"6 757 LINE",
+"73 757 OFFCURVE",
+"91 728 OFFCURVE",
+"91 627 CURVE SMOOTH",
+"91 461 LINE SMOOTH",
+"91 378 OFFCURVE",
+"116 345 OFFCURVE",
+"193 336 CURVE",
+"193 332 LINE",
+"116 323 OFFCURVE",
+"91 289 OFFCURVE",
+"91 206 CURVE SMOOTH",
+"91 39 LINE SMOOTH",
+"91 -62 OFFCURVE",
+"73 -91 OFFCURVE",
+"6 -91 CURVE",
+"6 -121 LINE"
+);
+}
+);
+width = 300;
+}
+);
+unicode = 007D;
+},
+{
+glyphname = bracketleft;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"301 -123 LINE",
+"301 -98 LINE",
+"191 -98 LINE",
+"191 763 LINE",
+"301 763 LINE",
+"301 788 LINE",
+"82 788 LINE",
+"82 -123 LINE"
+);
+}
+);
+width = 318;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"82 -108 LINE",
+"191 -108 LINE",
+"191 788 LINE",
+"82 788 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"82 -123 LINE",
+"301 -123 LINE",
+"301 -98 LINE",
+"82 -98 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"82 763 LINE",
+"301 763 LINE",
+"301 788 LINE",
+"82 788 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 -123 LINE",
+"314 -93 LINE",
+"219 -93 LINE",
+"219 758 LINE",
+"314 758 LINE",
+"314 788 LINE",
+"85 788 LINE",
+"85 -123 LINE"
+);
+}
+);
+width = 319;
+}
+);
+unicode = 005B;
+},
+{
+glyphname = bracketright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"236 -123 LINE",
+"236 788 LINE",
+"17 788 LINE",
+"17 763 LINE",
+"127 763 LINE",
+"127 -98 LINE",
+"17 -98 LINE",
+"17 -123 LINE"
+);
+}
+);
+width = 318;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"234 754 LINE",
+"100 754 LINE",
+"100 -115 LINE",
+"234 -115 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 -100 LINE",
+"5 -100 LINE",
+"5 -130 LINE",
+"234 -130 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 754 LINE",
+"5 754 LINE",
+"5 724 LINE",
+"234 724 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"234 -123 LINE",
+"234 788 LINE",
+"5 788 LINE",
+"5 758 LINE",
+"100 758 LINE",
+"100 -93 LINE",
+"5 -93 LINE",
+"5 -123 LINE"
+);
+}
+);
+width = 319;
+}
+);
+unicode = 005D;
+},
+{
+glyphname = quotesinglbase;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"162 -109 OFFCURVE",
+"213 -45 OFFCURVE",
+"213 30 CURVE SMOOTH",
+"213 95 OFFCURVE",
+"174 145 OFFCURVE",
+"111 145 CURVE SMOOTH",
+"59 145 OFFCURVE",
+"27 111 OFFCURVE",
+"27 70 CURVE SMOOTH",
+"27 40 OFFCURVE",
+"45 10 OFFCURVE",
+"87 10 CURVE SMOOTH",
+"143 10 OFFCURVE",
+"143 64 OFFCURVE",
+"158 64 CURVE SMOOTH",
+"166 64 OFFCURVE",
+"181 47 OFFCURVE",
+"181 20 CURVE SMOOTH",
+"181 -23 OFFCURVE",
+"144 -85 OFFCURVE",
+"78 -132 CURVE",
+"95 -153 LINE"
+);
+}
+);
+width = 253;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"79 704 OFFCURVE",
+"66 697 OFFCURVE",
+"50 681 CURVE SMOOTH",
+"39 669 OFFCURVE",
+"36 664 OFFCURVE",
+"31 654 CURVE",
+"26 640 OFFCURVE",
+"22 616 OFFCURVE",
+"23 613 CURVE",
+"25 613 OFFCURVE",
+"25 606 OFFCURVE",
+"26 600 CURVE",
+"26 584 OFFCURVE",
+"35 574 OFFCURVE",
+"44 563 CURVE SMOOTH",
+"51 555 OFFCURVE",
+"68 545 OFFCURVE",
+"82 542 CURVE SMOOTH",
+"94 539 OFFCURVE",
+"122 542 OFFCURVE",
+"134 549 CURVE SMOOTH",
+"140 552 OFFCURVE",
+"158 571 OFFCURVE",
+"167 584 CURVE",
+"172 589 LINE",
+"175 584 LINE",
+"182 577 OFFCURVE",
+"183 566 OFFCURVE",
+"185 541 CURVE",
+"185 515 OFFCURVE",
+"183 512 OFFCURVE",
+"170 485 CURVE SMOOTH",
+"151 445 OFFCURVE",
+"130 422 OFFCURVE",
+"87 395 CURVE SMOOTH",
+"71 384 OFFCURVE",
+"66 377 OFFCURVE",
+"70 368 CURVE SMOOTH",
+"73 360 OFFCURVE",
+"78 355 OFFCURVE",
+"86 355 CURVE SMOOTH",
+"87 355 OFFCURVE",
+"94 357 OFFCURVE",
+"98 360 CURVE SMOOTH",
+"102 363 OFFCURVE",
+"108 368 OFFCURVE",
+"111 369 CURVE SMOOTH",
+"122 374 OFFCURVE",
+"166 414 OFFCURVE",
+"174 425 CURVE SMOOTH",
+"177 430 OFFCURVE",
+"185 440 OFFCURVE",
+"190 446 CURVE SMOOTH",
+"203 462 OFFCURVE",
+"216 491 OFFCURVE",
+"222 512 CURVE",
+"223 520 OFFCURVE",
+"226 528 OFFCURVE",
+"226 528 CURVE",
+"228 529 OFFCURVE",
+"230 541 OFFCURVE",
+"231 552 CURVE",
+"231 569 OFFCURVE",
+"231 576 OFFCURVE",
+"231 592 CURVE",
+"230 601 OFFCURVE",
+"228 616 OFFCURVE",
+"226 622 CURVE SMOOTH",
+"218 653 OFFCURVE",
+"191 688 OFFCURVE",
+"166 699 CURVE SMOOTH",
+"143 710 OFFCURVE",
+"124 712 OFFCURVE",
+"98 707 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 -119 OFFCURVE",
+"258 -47 OFFCURVE",
+"258 47 CURVE SMOOTH",
+"258 128 OFFCURVE",
+"213 192 OFFCURVE",
+"142 192 CURVE SMOOTH",
+"86 192 OFFCURVE",
+"50 152 OFFCURVE",
+"50 100 CURVE SMOOTH",
+"50 59 OFFCURVE",
+"73 20 OFFCURVE",
+"123 20 CURVE SMOOTH",
+"171 20 OFFCURVE",
+"183 56 OFFCURVE",
+"198 56 CURVE SMOOTH",
+"204 56 OFFCURVE",
+"209 50 OFFCURVE",
+"209 26 CURVE SMOOTH",
+"209 -38 OFFCURVE",
+"174 -90 OFFCURVE",
+"96 -150 CURVE",
+"113 -171 LINE"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 201A;
+},
+{
+glyphname = quotedblbase;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"213 95 OFFCURVE",
+"174 145 OFFCURVE",
+"111 145 CURVE SMOOTH",
+"59 145 OFFCURVE",
+"27 111 OFFCURVE",
+"27 70 CURVE SMOOTH",
+"27 40 OFFCURVE",
+"45 10 OFFCURVE",
+"87 10 CURVE SMOOTH",
+"143 10 OFFCURVE",
+"143 64 OFFCURVE",
+"158 64 CURVE SMOOTH",
+"166 64 OFFCURVE",
+"181 47 OFFCURVE",
+"181 20 CURVE SMOOTH",
+"181 -23 OFFCURVE",
+"144 -85 OFFCURVE",
+"78 -132 CURVE",
+"95 -153 LINE",
+"162 -109 OFFCURVE",
+"213 -45 OFFCURVE",
+"213 30 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"459 95 OFFCURVE",
+"420 145 OFFCURVE",
+"357 145 CURVE SMOOTH",
+"305 145 OFFCURVE",
+"273 111 OFFCURVE",
+"273 70 CURVE SMOOTH",
+"273 40 OFFCURVE",
+"291 10 OFFCURVE",
+"333 10 CURVE SMOOTH",
+"389 10 OFFCURVE",
+"389 64 OFFCURVE",
+"404 64 CURVE SMOOTH",
+"412 64 OFFCURVE",
+"427 47 OFFCURVE",
+"427 20 CURVE SMOOTH",
+"427 -23 OFFCURVE",
+"390 -85 OFFCURVE",
+"324 -132 CURVE",
+"341 -153 LINE",
+"408 -109 OFFCURVE",
+"459 -45 OFFCURVE",
+"459 30 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"408 -109 OFFCURVE",
+"459 -45 OFFCURVE",
+"459 30 CURVE SMOOTH",
+"459 95 OFFCURVE",
+"420 145 OFFCURVE",
+"357 145 CURVE SMOOTH",
+"305 145 OFFCURVE",
+"273 111 OFFCURVE",
+"273 70 CURVE SMOOTH",
+"273 40 OFFCURVE",
+"291 10 OFFCURVE",
+"333 10 CURVE SMOOTH",
+"389 10 OFFCURVE",
+"389 64 OFFCURVE",
+"404 64 CURVE SMOOTH",
+"412 64 OFFCURVE",
+"427 47 OFFCURVE",
+"427 20 CURVE SMOOTH",
+"427 -23 OFFCURVE",
+"390 -85 OFFCURVE",
+"324 -132 CURVE",
+"341 -153 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 -109 OFFCURVE",
+"213 -45 OFFCURVE",
+"213 30 CURVE SMOOTH",
+"213 95 OFFCURVE",
+"174 145 OFFCURVE",
+"111 145 CURVE SMOOTH",
+"59 145 OFFCURVE",
+"27 111 OFFCURVE",
+"27 70 CURVE SMOOTH",
+"27 40 OFFCURVE",
+"45 10 OFFCURVE",
+"87 10 CURVE SMOOTH",
+"143 10 OFFCURVE",
+"143 64 OFFCURVE",
+"158 64 CURVE SMOOTH",
+"166 64 OFFCURVE",
+"181 47 OFFCURVE",
+"181 20 CURVE SMOOTH",
+"181 -23 OFFCURVE",
+"144 -85 OFFCURVE",
+"78 -132 CURVE",
+"95 -153 LINE"
+);
+}
+);
+width = 500;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"258 128 OFFCURVE",
+"213 192 OFFCURVE",
+"142 192 CURVE SMOOTH",
+"86 192 OFFCURVE",
+"50 152 OFFCURVE",
+"50 100 CURVE SMOOTH",
+"50 59 OFFCURVE",
+"73 20 OFFCURVE",
+"123 20 CURVE SMOOTH",
+"171 20 OFFCURVE",
+"183 56 OFFCURVE",
+"198 56 CURVE SMOOTH",
+"204 56 OFFCURVE",
+"209 50 OFFCURVE",
+"209 26 CURVE SMOOTH",
+"209 -38 OFFCURVE",
+"174 -90 OFFCURVE",
+"96 -150 CURVE",
+"113 -171 LINE",
+"197 -119 OFFCURVE",
+"258 -47 OFFCURVE",
+"258 47 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 128 OFFCURVE",
+"466 192 OFFCURVE",
+"395 192 CURVE SMOOTH",
+"339 192 OFFCURVE",
+"303 152 OFFCURVE",
+"303 100 CURVE SMOOTH",
+"303 59 OFFCURVE",
+"326 20 OFFCURVE",
+"376 20 CURVE SMOOTH",
+"424 20 OFFCURVE",
+"436 56 OFFCURVE",
+"451 56 CURVE SMOOTH",
+"457 56 OFFCURVE",
+"462 50 OFFCURVE",
+"462 26 CURVE SMOOTH",
+"462 -38 OFFCURVE",
+"427 -90 OFFCURVE",
+"349 -150 CURVE",
+"366 -171 LINE",
+"450 -119 OFFCURVE",
+"511 -47 OFFCURVE",
+"511 47 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 -119 OFFCURVE",
+"511 -47 OFFCURVE",
+"511 47 CURVE SMOOTH",
+"511 128 OFFCURVE",
+"466 192 OFFCURVE",
+"395 192 CURVE SMOOTH",
+"339 192 OFFCURVE",
+"303 152 OFFCURVE",
+"303 100 CURVE SMOOTH",
+"303 59 OFFCURVE",
+"326 20 OFFCURVE",
+"376 20 CURVE SMOOTH",
+"424 20 OFFCURVE",
+"436 56 OFFCURVE",
+"451 56 CURVE SMOOTH",
+"457 56 OFFCURVE",
+"462 50 OFFCURVE",
+"462 26 CURVE SMOOTH",
+"462 -38 OFFCURVE",
+"427 -90 OFFCURVE",
+"349 -150 CURVE",
+"366 -171 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 -119 OFFCURVE",
+"258 -47 OFFCURVE",
+"258 47 CURVE SMOOTH",
+"258 128 OFFCURVE",
+"213 192 OFFCURVE",
+"142 192 CURVE SMOOTH",
+"86 192 OFFCURVE",
+"50 152 OFFCURVE",
+"50 100 CURVE SMOOTH",
+"50 59 OFFCURVE",
+"73 20 OFFCURVE",
+"123 20 CURVE SMOOTH",
+"171 20 OFFCURVE",
+"183 56 OFFCURVE",
+"198 56 CURVE SMOOTH",
+"204 56 OFFCURVE",
+"209 50 OFFCURVE",
+"209 26 CURVE SMOOTH",
+"209 -38 OFFCURVE",
+"174 -90 OFFCURVE",
+"96 -150 CURVE",
+"113 -171 LINE"
+);
+}
+);
+width = 561;
+}
+);
+unicode = 201E;
+},
+{
+glyphname = quotedblleft;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"27 515 OFFCURVE",
+"66 465 OFFCURVE",
+"129 465 CURVE SMOOTH",
+"181 465 OFFCURVE",
+"213 499 OFFCURVE",
+"213 540 CURVE SMOOTH",
+"213 570 OFFCURVE",
+"195 600 OFFCURVE",
+"153 600 CURVE SMOOTH",
+"97 600 OFFCURVE",
+"97 546 OFFCURVE",
+"82 546 CURVE SMOOTH",
+"74 546 OFFCURVE",
+"59 563 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"59 633 OFFCURVE",
+"96 695 OFFCURVE",
+"162 742 CURVE",
+"145 763 LINE",
+"78 719 OFFCURVE",
+"27 655 OFFCURVE",
+"27 580 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 515 OFFCURVE",
+"312 465 OFFCURVE",
+"375 465 CURVE SMOOTH",
+"427 465 OFFCURVE",
+"459 499 OFFCURVE",
+"459 540 CURVE SMOOTH",
+"459 570 OFFCURVE",
+"441 600 OFFCURVE",
+"399 600 CURVE SMOOTH",
+"343 600 OFFCURVE",
+"343 546 OFFCURVE",
+"328 546 CURVE SMOOTH",
+"320 546 OFFCURVE",
+"305 563 OFFCURVE",
+"305 590 CURVE SMOOTH",
+"305 633 OFFCURVE",
+"342 695 OFFCURVE",
+"408 742 CURVE",
+"391 763 LINE",
+"324 719 OFFCURVE",
+"273 655 OFFCURVE",
+"273 580 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"427 465 OFFCURVE",
+"459 499 OFFCURVE",
+"459 540 CURVE SMOOTH",
+"459 570 OFFCURVE",
+"441 600 OFFCURVE",
+"399 600 CURVE SMOOTH",
+"343 600 OFFCURVE",
+"343 546 OFFCURVE",
+"328 546 CURVE SMOOTH",
+"320 546 OFFCURVE",
+"305 563 OFFCURVE",
+"305 590 CURVE SMOOTH",
+"305 633 OFFCURVE",
+"342 695 OFFCURVE",
+"408 742 CURVE",
+"391 763 LINE",
+"324 719 OFFCURVE",
+"273 655 OFFCURVE",
+"273 580 CURVE SMOOTH",
+"273 515 OFFCURVE",
+"312 465 OFFCURVE",
+"375 465 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 465 OFFCURVE",
+"213 499 OFFCURVE",
+"213 540 CURVE SMOOTH",
+"213 570 OFFCURVE",
+"195 600 OFFCURVE",
+"153 600 CURVE SMOOTH",
+"97 600 OFFCURVE",
+"97 546 OFFCURVE",
+"82 546 CURVE SMOOTH",
+"74 546 OFFCURVE",
+"59 563 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"59 633 OFFCURVE",
+"96 695 OFFCURVE",
+"162 742 CURVE",
+"145 763 LINE",
+"78 719 OFFCURVE",
+"27 655 OFFCURVE",
+"27 580 CURVE SMOOTH",
+"27 515 OFFCURVE",
+"66 465 OFFCURVE",
+"129 465 CURVE SMOOTH"
+);
+}
+);
+width = 496;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 474 OFFCURVE",
+"95 410 OFFCURVE",
+"166 410 CURVE SMOOTH",
+"222 410 OFFCURVE",
+"258 450 OFFCURVE",
+"258 502 CURVE SMOOTH",
+"258 543 OFFCURVE",
+"235 582 OFFCURVE",
+"185 582 CURVE SMOOTH",
+"137 582 OFFCURVE",
+"125 546 OFFCURVE",
+"110 546 CURVE SMOOTH",
+"104 546 OFFCURVE",
+"99 552 OFFCURVE",
+"99 576 CURVE SMOOTH",
+"99 640 OFFCURVE",
+"134 692 OFFCURVE",
+"212 752 CURVE",
+"195 773 LINE",
+"111 721 OFFCURVE",
+"50 649 OFFCURVE",
+"50 555 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"303 474 OFFCURVE",
+"348 410 OFFCURVE",
+"419 410 CURVE SMOOTH",
+"475 410 OFFCURVE",
+"511 450 OFFCURVE",
+"511 502 CURVE SMOOTH",
+"511 543 OFFCURVE",
+"488 582 OFFCURVE",
+"438 582 CURVE SMOOTH",
+"390 582 OFFCURVE",
+"378 546 OFFCURVE",
+"363 546 CURVE SMOOTH",
+"357 546 OFFCURVE",
+"352 552 OFFCURVE",
+"352 576 CURVE SMOOTH",
+"352 640 OFFCURVE",
+"387 692 OFFCURVE",
+"465 752 CURVE",
+"448 773 LINE",
+"364 721 OFFCURVE",
+"303 649 OFFCURVE",
+"303 555 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"475 410 OFFCURVE",
+"511 450 OFFCURVE",
+"511 502 CURVE SMOOTH",
+"511 543 OFFCURVE",
+"488 582 OFFCURVE",
+"438 582 CURVE SMOOTH",
+"390 582 OFFCURVE",
+"378 546 OFFCURVE",
+"363 546 CURVE SMOOTH",
+"357 546 OFFCURVE",
+"352 552 OFFCURVE",
+"352 576 CURVE SMOOTH",
+"352 640 OFFCURVE",
+"387 692 OFFCURVE",
+"465 752 CURVE",
+"448 773 LINE",
+"364 721 OFFCURVE",
+"303 649 OFFCURVE",
+"303 555 CURVE SMOOTH",
+"303 474 OFFCURVE",
+"348 410 OFFCURVE",
+"419 410 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 410 OFFCURVE",
+"258 450 OFFCURVE",
+"258 502 CURVE SMOOTH",
+"258 543 OFFCURVE",
+"235 582 OFFCURVE",
+"185 582 CURVE SMOOTH",
+"137 582 OFFCURVE",
+"125 546 OFFCURVE",
+"110 546 CURVE SMOOTH",
+"104 546 OFFCURVE",
+"99 552 OFFCURVE",
+"99 576 CURVE SMOOTH",
+"99 640 OFFCURVE",
+"134 692 OFFCURVE",
+"212 752 CURVE",
+"195 773 LINE",
+"111 721 OFFCURVE",
+"50 649 OFFCURVE",
+"50 555 CURVE SMOOTH",
+"50 474 OFFCURVE",
+"95 410 OFFCURVE",
+"166 410 CURVE SMOOTH"
+);
+}
+);
+width = 561;
+}
+);
+unicode = 201C;
+},
+{
+glyphname = quotedblright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"408 509 OFFCURVE",
+"459 573 OFFCURVE",
+"459 648 CURVE SMOOTH",
+"459 713 OFFCURVE",
+"420 763 OFFCURVE",
+"357 763 CURVE SMOOTH",
+"305 763 OFFCURVE",
+"273 729 OFFCURVE",
+"273 688 CURVE SMOOTH",
+"273 658 OFFCURVE",
+"291 628 OFFCURVE",
+"333 628 CURVE SMOOTH",
+"389 628 OFFCURVE",
+"389 682 OFFCURVE",
+"404 682 CURVE SMOOTH",
+"412 682 OFFCURVE",
+"427 665 OFFCURVE",
+"427 638 CURVE SMOOTH",
+"427 595 OFFCURVE",
+"390 533 OFFCURVE",
+"324 486 CURVE",
+"341 465 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 509 OFFCURVE",
+"213 573 OFFCURVE",
+"213 648 CURVE SMOOTH",
+"213 713 OFFCURVE",
+"174 763 OFFCURVE",
+"111 763 CURVE SMOOTH",
+"59 763 OFFCURVE",
+"27 729 OFFCURVE",
+"27 688 CURVE SMOOTH",
+"27 658 OFFCURVE",
+"45 628 OFFCURVE",
+"87 628 CURVE SMOOTH",
+"143 628 OFFCURVE",
+"143 682 OFFCURVE",
+"158 682 CURVE SMOOTH",
+"166 682 OFFCURVE",
+"181 665 OFFCURVE",
+"181 638 CURVE SMOOTH",
+"181 595 OFFCURVE",
+"144 533 OFFCURVE",
+"78 486 CURVE",
+"95 465 LINE"
+);
+}
+);
+width = 500;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"370 717 OFFCURVE",
+"360 715 OFFCURVE",
+"355 712 CURVE",
+"346 709 OFFCURVE",
+"320 693 OFFCURVE",
+"320 689 CURVE SMOOTH",
+"320 689 OFFCURVE",
+"318 685 OFFCURVE",
+"314 681 CURVE SMOOTH",
+"307 672 OFFCURVE",
+"301 661 OFFCURVE",
+"298 643 CURVE",
+"298 633 OFFCURVE",
+"298 629 OFFCURVE",
+"298 616 CURVE SMOOTH",
+"298 608 OFFCURVE",
+"299 597 OFFCURVE",
+"301 592 CURVE",
+"301 581 OFFCURVE",
+"301 574 OFFCURVE",
+"323 561 CURVE SMOOTH",
+"340 552 OFFCURVE",
+"360 544 OFFCURVE",
+"371 545 CURVE",
+"371 545 OFFCURVE",
+"394 547 OFFCURVE",
+"394 550 CURVE",
+"405 555 OFFCURVE",
+"409 557 OFFCURVE",
+"424 573 CURVE",
+"437 582 OFFCURVE",
+"443 590 OFFCURVE",
+"443 590 CURVE",
+"445 590 OFFCURVE",
+"450 577 OFFCURVE",
+"453 565 CURVE",
+"453 552 OFFCURVE",
+"453 541 OFFCURVE",
+"453 523 CURVE",
+"448 507 OFFCURVE",
+"435 475 OFFCURVE",
+"429 470 CURVE",
+"424 464 OFFCURVE",
+"406 443 OFFCURVE",
+"406 441 CURVE SMOOTH",
+"406 438 OFFCURVE",
+"394 427 OFFCURVE",
+"382 422 CURVE",
+"371 416 OFFCURVE",
+"368 416 OFFCURVE",
+"362 416 CURVE SMOOTH",
+"355 416 OFFCURVE",
+"354 416 OFFCURVE",
+"349 411 CURVE SMOOTH",
+"344 405 OFFCURVE",
+"339 387 OFFCURVE",
+"339 379 CURVE SMOOTH",
+"339 373 OFFCURVE",
+"346 361 OFFCURVE",
+"352 360 CURVE SMOOTH",
+"355 360 OFFCURVE",
+"358 361 OFFCURVE",
+"365 365 CURVE",
+"376 369 OFFCURVE",
+"412 400 OFFCURVE",
+"422 409 CURVE",
+"422 413 OFFCURVE",
+"443 422 OFFCURVE",
+"443 430 CURVE",
+"463 453 OFFCURVE",
+"476 475 OFFCURVE",
+"491 507 CURVE SMOOTH",
+"501 531 OFFCURVE",
+"504 547 OFFCURVE",
+"504 584 CURVE SMOOTH",
+"504 614 OFFCURVE",
+"504 617 OFFCURVE",
+"499 632 CURVE SMOOTH",
+"493 651 OFFCURVE",
+"485 665 OFFCURVE",
+"474 678 CURVE SMOOTH",
+"454 699 OFFCURVE",
+"432 713 OFFCURVE",
+"411 717 CURVE SMOOTH",
+"395 720 OFFCURVE",
+"395 720 OFFCURVE",
+"376 717 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"43 699 OFFCURVE",
+"24 670 OFFCURVE",
+"22 617 CURVE SMOOTH",
+"22 605 OFFCURVE",
+"24 601 OFFCURVE",
+"29 592 CURVE",
+"34 576 OFFCURVE",
+"51 563 OFFCURVE",
+"66 555 CURVE SMOOTH",
+"77 550 OFFCURVE",
+"82 550 OFFCURVE",
+"93 549 CURVE",
+"117 549 OFFCURVE",
+"127 553 OFFCURVE",
+"146 568 CURVE SMOOTH",
+"162 582 OFFCURVE",
+"168 585 OFFCURVE",
+"173 584 CURVE SMOOTH",
+"178 582 OFFCURVE",
+"181 574 OFFCURVE",
+"182 557 CURVE",
+"184 542 OFFCURVE",
+"184 539 OFFCURVE",
+"178 515 CURVE SMOOTH",
+"174 502 OFFCURVE",
+"158 470 OFFCURVE",
+"155 469 CURVE",
+"154 469 OFFCURVE",
+"150 464 OFFCURVE",
+"147 459 CURVE SMOOTH",
+"146 456 OFFCURVE",
+"136 445 OFFCURVE",
+"128 437 CURVE SMOOTH",
+"120 427 OFFCURVE",
+"112 419 OFFCURVE",
+"112 417 CURVE SMOOTH",
+"112 416 OFFCURVE",
+"106 413 OFFCURVE",
+"99 409 CURVE SMOOTH",
+"85 403 OFFCURVE",
+"69 392 OFFCURVE",
+"66 387 CURVE SMOOTH",
+"64 382 OFFCURVE",
+"69 369 OFFCURVE",
+"75 365 CURVE SMOOTH",
+"79 361 OFFCURVE",
+"79 361 OFFCURVE",
+"88 365 CURVE",
+"98 368 OFFCURVE",
+"115 379 OFFCURVE",
+"130 392 CURVE SMOOTH",
+"150 408 OFFCURVE",
+"179 440 OFFCURVE",
+"187 453 CURVE",
+"192 459 OFFCURVE",
+"197 467 OFFCURVE",
+"198 469 CURVE SMOOTH",
+"200 472 OFFCURVE",
+"205 480 OFFCURVE",
+"208 488 CURVE SMOOTH",
+"211 496 OFFCURVE",
+"216 505 OFFCURVE",
+"218 509 CURVE SMOOTH",
+"224 517 OFFCURVE",
+"230 531 OFFCURVE",
+"229 534 CURVE SMOOTH",
+"229 536 OFFCURVE",
+"229 547 OFFCURVE",
+"229 560 CURVE",
+"235 627 OFFCURVE",
+"214 677 OFFCURVE",
+"170 704 CURVE SMOOTH",
+"150 717 OFFCURVE",
+"110 721 OFFCURVE",
+"90 713 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 462 OFFCURVE",
+"511 534 OFFCURVE",
+"511 628 CURVE SMOOTH",
+"511 709 OFFCURVE",
+"466 773 OFFCURVE",
+"395 773 CURVE SMOOTH",
+"339 773 OFFCURVE",
+"303 733 OFFCURVE",
+"303 681 CURVE SMOOTH",
+"303 640 OFFCURVE",
+"326 601 OFFCURVE",
+"376 601 CURVE SMOOTH",
+"424 601 OFFCURVE",
+"436 637 OFFCURVE",
+"451 637 CURVE SMOOTH",
+"457 637 OFFCURVE",
+"462 631 OFFCURVE",
+"462 607 CURVE SMOOTH",
+"462 543 OFFCURVE",
+"427 491 OFFCURVE",
+"349 431 CURVE",
+"366 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 462 OFFCURVE",
+"258 534 OFFCURVE",
+"258 628 CURVE SMOOTH",
+"258 709 OFFCURVE",
+"213 773 OFFCURVE",
+"142 773 CURVE SMOOTH",
+"86 773 OFFCURVE",
+"50 733 OFFCURVE",
+"50 681 CURVE SMOOTH",
+"50 640 OFFCURVE",
+"73 601 OFFCURVE",
+"123 601 CURVE SMOOTH",
+"171 601 OFFCURVE",
+"183 637 OFFCURVE",
+"198 637 CURVE SMOOTH",
+"204 637 OFFCURVE",
+"209 631 OFFCURVE",
+"209 607 CURVE SMOOTH",
+"209 543 OFFCURVE",
+"174 491 OFFCURVE",
+"96 431 CURVE",
+"113 410 LINE"
+);
+}
+);
+width = 561;
+}
+);
+unicode = 201D;
+},
+{
+glyphname = quoteleft;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"181 465 OFFCURVE",
+"213 499 OFFCURVE",
+"213 540 CURVE SMOOTH",
+"213 570 OFFCURVE",
+"195 600 OFFCURVE",
+"153 600 CURVE SMOOTH",
+"97 600 OFFCURVE",
+"97 546 OFFCURVE",
+"82 546 CURVE SMOOTH",
+"74 546 OFFCURVE",
+"59 563 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"59 633 OFFCURVE",
+"96 695 OFFCURVE",
+"162 742 CURVE",
+"145 763 LINE",
+"78 719 OFFCURVE",
+"27 655 OFFCURVE",
+"27 580 CURVE",
+"27 515 OFFCURVE",
+"66 465 OFFCURVE",
+"129 465 CURVE SMOOTH"
+);
+}
+);
+width = 249;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"108 707 OFFCURVE",
+"90 701 OFFCURVE",
+"85 697 CURVE SMOOTH",
+"84 696 OFFCURVE",
+"81 693 OFFCURVE",
+"77 691 CURVE SMOOTH",
+"69 688 OFFCURVE",
+"52 667 OFFCURVE",
+"44 654 CURVE",
+"41 646 OFFCURVE",
+"37 637 OFFCURVE",
+"36 632 CURVE SMOOTH",
+"34 625 OFFCURVE",
+"31 616 OFFCURVE",
+"29 609 CURVE SMOOTH",
+"23 592 OFFCURVE",
+"21 565 OFFCURVE",
+"26 545 CURVE",
+"29 537 OFFCURVE",
+"31 525 OFFCURVE",
+"33 518 CURVE",
+"34 510 OFFCURVE",
+"37 502 OFFCURVE",
+"39 499 CURVE SMOOTH",
+"51 477 OFFCURVE",
+"51 467 OFFCURVE",
+"63 454 CURVE",
+"73 438 OFFCURVE",
+"98 409 OFFCURVE",
+"108 401 CURVE",
+"111 400 OFFCURVE",
+"119 393 OFFCURVE",
+"124 387 CURVE",
+"124 382 OFFCURVE",
+"145 373 OFFCURVE",
+"145 368 CURVE",
+"154 360 OFFCURVE",
+"164 355 OFFCURVE",
+"173 357 CURVE SMOOTH",
+"180 358 OFFCURVE",
+"186 368 OFFCURVE",
+"186 376 CURVE SMOOTH",
+"186 382 OFFCURVE",
+"185 384 OFFCURVE",
+"167 395 CURVE",
+"149 408 OFFCURVE",
+"146 409 OFFCURVE",
+"143 409 CURVE SMOOTH",
+"140 409 OFFCURVE",
+"138 409 OFFCURVE",
+"138 411 CURVE SMOOTH",
+"138 413 OFFCURVE",
+"129 425 OFFCURVE",
+"121 433 CURVE SMOOTH",
+"93 461 OFFCURVE",
+"69 512 OFFCURVE",
+"68 544 CURVE SMOOTH",
+"68 565 OFFCURVE",
+"71 582 OFFCURVE",
+"79 589 CURVE",
+"84 595 OFFCURVE",
+"84 595 OFFCURVE",
+"95 582 CURVE SMOOTH",
+"103 571 OFFCURVE",
+"120 553 OFFCURVE",
+"129 550 CURVE SMOOTH",
+"162 536 OFFCURVE",
+"199 545 OFFCURVE",
+"218 574 CURVE SMOOTH",
+"228 589 OFFCURVE",
+"231 601 OFFCURVE",
+"231 621 CURVE SMOOTH",
+"231 641 OFFCURVE",
+"228 653 OFFCURVE",
+"220 667 CURVE SMOOTH",
+"201 699 OFFCURVE",
+"159 717 OFFCURVE",
+"121 710 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"222 410 OFFCURVE",
+"258 450 OFFCURVE",
+"258 502 CURVE SMOOTH",
+"258 543 OFFCURVE",
+"235 582 OFFCURVE",
+"185 582 CURVE SMOOTH",
+"137 582 OFFCURVE",
+"125 546 OFFCURVE",
+"110 546 CURVE SMOOTH",
+"104 546 OFFCURVE",
+"99 552 OFFCURVE",
+"99 576 CURVE SMOOTH",
+"99 640 OFFCURVE",
+"134 692 OFFCURVE",
+"212 752 CURVE",
+"195 773 LINE",
+"111 721 OFFCURVE",
+"50 649 OFFCURVE",
+"50 555 CURVE",
+"50 474 OFFCURVE",
+"95 410 OFFCURVE",
+"166 410 CURVE SMOOTH"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 2018;
+},
+{
+glyphname = quoteright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"162 509 OFFCURVE",
+"213 573 OFFCURVE",
+"213 648 CURVE SMOOTH",
+"213 713 OFFCURVE",
+"174 763 OFFCURVE",
+"111 763 CURVE SMOOTH",
+"59 763 OFFCURVE",
+"27 729 OFFCURVE",
+"27 688 CURVE SMOOTH",
+"27 658 OFFCURVE",
+"45 628 OFFCURVE",
+"87 628 CURVE SMOOTH",
+"143 628 OFFCURVE",
+"143 682 OFFCURVE",
+"158 682 CURVE SMOOTH",
+"166 682 OFFCURVE",
+"181 665 OFFCURVE",
+"181 638 CURVE SMOOTH",
+"181 595 OFFCURVE",
+"144 533 OFFCURVE",
+"78 486 CURVE",
+"95 465 LINE"
+);
+}
+);
+width = 253;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"79 704 OFFCURVE",
+"66 697 OFFCURVE",
+"50 681 CURVE SMOOTH",
+"39 669 OFFCURVE",
+"36 664 OFFCURVE",
+"31 654 CURVE",
+"26 640 OFFCURVE",
+"22 616 OFFCURVE",
+"23 613 CURVE",
+"25 613 OFFCURVE",
+"25 606 OFFCURVE",
+"26 600 CURVE",
+"26 584 OFFCURVE",
+"35 574 OFFCURVE",
+"44 563 CURVE SMOOTH",
+"51 555 OFFCURVE",
+"68 545 OFFCURVE",
+"82 542 CURVE SMOOTH",
+"94 539 OFFCURVE",
+"122 542 OFFCURVE",
+"134 549 CURVE SMOOTH",
+"140 552 OFFCURVE",
+"158 571 OFFCURVE",
+"167 584 CURVE",
+"172 589 LINE",
+"175 584 LINE",
+"182 577 OFFCURVE",
+"183 566 OFFCURVE",
+"185 541 CURVE",
+"185 515 OFFCURVE",
+"183 512 OFFCURVE",
+"170 485 CURVE SMOOTH",
+"151 445 OFFCURVE",
+"130 422 OFFCURVE",
+"87 395 CURVE SMOOTH",
+"71 384 OFFCURVE",
+"66 377 OFFCURVE",
+"70 368 CURVE SMOOTH",
+"73 360 OFFCURVE",
+"78 355 OFFCURVE",
+"86 355 CURVE SMOOTH",
+"87 355 OFFCURVE",
+"94 357 OFFCURVE",
+"98 360 CURVE SMOOTH",
+"102 363 OFFCURVE",
+"108 368 OFFCURVE",
+"111 369 CURVE SMOOTH",
+"122 374 OFFCURVE",
+"166 414 OFFCURVE",
+"174 425 CURVE SMOOTH",
+"177 430 OFFCURVE",
+"185 440 OFFCURVE",
+"190 446 CURVE SMOOTH",
+"203 462 OFFCURVE",
+"216 491 OFFCURVE",
+"222 512 CURVE",
+"223 520 OFFCURVE",
+"226 528 OFFCURVE",
+"226 528 CURVE",
+"228 529 OFFCURVE",
+"230 541 OFFCURVE",
+"231 552 CURVE",
+"231 569 OFFCURVE",
+"231 576 OFFCURVE",
+"231 592 CURVE",
+"230 601 OFFCURVE",
+"228 616 OFFCURVE",
+"226 622 CURVE SMOOTH",
+"218 653 OFFCURVE",
+"191 688 OFFCURVE",
+"166 699 CURVE SMOOTH",
+"143 710 OFFCURVE",
+"124 712 OFFCURVE",
+"98 707 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 452 OFFCURVE",
+"258 524 OFFCURVE",
+"258 618 CURVE SMOOTH",
+"258 699 OFFCURVE",
+"213 763 OFFCURVE",
+"142 763 CURVE SMOOTH",
+"86 763 OFFCURVE",
+"50 723 OFFCURVE",
+"50 671 CURVE SMOOTH",
+"50 630 OFFCURVE",
+"73 591 OFFCURVE",
+"123 591 CURVE SMOOTH",
+"171 591 OFFCURVE",
+"183 627 OFFCURVE",
+"198 627 CURVE SMOOTH",
+"204 627 OFFCURVE",
+"209 621 OFFCURVE",
+"209 597 CURVE SMOOTH",
+"209 533 OFFCURVE",
+"174 481 OFFCURVE",
+"96 421 CURVE",
+"113 400 LINE"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 2019;
+},
+{
+glyphname = guillemetleft;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"495 53 LINE",
+"384 220 LINE",
+"495 391 LINE",
+"480 402 LINE",
+"280 231 LINE",
+"280 209 LINE",
+"480 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 53 LINE",
+"174 220 LINE",
+"285 391 LINE",
+"270 402 LINE",
+"70 231 LINE",
+"70 209 LINE",
+"270 38 LINE"
+);
+}
+);
+width = 555;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"448 43 LINE",
+"357 220 LINE",
+"448 401 LINE",
+"433 412 LINE",
+"213 231 LINE",
+"213 209 LINE",
+"433 28 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 43 LINE",
+"174 220 LINE",
+"265 401 LINE",
+"250 412 LINE",
+"30 231 LINE",
+"30 209 LINE",
+"250 28 LINE"
+);
+}
+);
+width = 508;
+}
+);
+unicode = 00AB;
+},
+{
+glyphname = guillemetright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"85 38 LINE",
+"285 209 LINE",
+"285 231 LINE",
+"85 402 LINE",
+"70 391 LINE",
+"181 220 LINE",
+"70 53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"295 38 LINE",
+"495 209 LINE",
+"495 231 LINE",
+"295 402 LINE",
+"280 391 LINE",
+"391 220 LINE",
+"280 53 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"495 209 LINE",
+"495 231 LINE",
+"295 402 LINE",
+"280 391 LINE",
+"391 220 LINE",
+"280 53 LINE",
+"295 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 209 LINE",
+"285 231 LINE",
+"85 402 LINE",
+"70 391 LINE",
+"181 220 LINE",
+"70 53 LINE",
+"85 38 LINE"
+);
+}
+);
+width = 555;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"75 28 LINE",
+"295 209 LINE",
+"295 231 LINE",
+"75 412 LINE",
+"60 401 LINE",
+"151 220 LINE",
+"60 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"258 28 LINE",
+"478 209 LINE",
+"478 231 LINE",
+"258 412 LINE",
+"243 401 LINE",
+"334 220 LINE",
+"243 43 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"478 209 LINE",
+"478 231 LINE",
+"258 412 LINE",
+"243 401 LINE",
+"334 220 LINE",
+"243 43 LINE",
+"258 28 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"295 209 LINE",
+"295 231 LINE",
+"75 412 LINE",
+"60 401 LINE",
+"151 220 LINE",
+"60 43 LINE",
+"75 28 LINE"
+);
+}
+);
+width = 508;
+}
+);
+unicode = 00BB;
+},
+{
+glyphname = guilsinglleft;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"285 53 LINE",
+"174 220 LINE",
+"285 391 LINE",
+"270 402 LINE",
+"70 231 LINE",
+"70 209 LINE",
+"270 38 LINE"
+);
+}
+);
+width = 345;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"285 43 LINE",
+"204 220 LINE",
+"285 401 LINE",
+"270 412 LINE",
+"60 231 LINE",
+"60 209 LINE",
+"270 28 LINE"
+);
+}
+);
+width = 345;
+}
+);
+unicode = 2039;
+},
+{
+glyphname = guilsinglright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"275 209 LINE",
+"275 231 LINE",
+"75 402 LINE",
+"60 391 LINE",
+"171 220 LINE",
+"60 53 LINE",
+"75 38 LINE"
+);
+}
+);
+width = 345;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 209 LINE",
+"295 231 LINE",
+"75 412 LINE",
+"60 401 LINE",
+"151 220 LINE",
+"60 43 LINE",
+"75 28 LINE"
+);
+}
+);
+width = 345;
+}
+);
+unicode = 203A;
+},
+{
+glyphname = quotedbl;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"296 463 LINE",
+"296 627 OFFCURVE",
+"345 647 OFFCURVE",
+"345 704 CURVE SMOOTH",
+"345 745 OFFCURVE",
+"316 763 OFFCURVE",
+"283 763 CURVE SMOOTH",
+"250 763 OFFCURVE",
+"221 745 OFFCURVE",
+"221 704 CURVE SMOOTH",
+"221 647 OFFCURVE",
+"270 627 OFFCURVE",
+"270 463 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"125 463 LINE",
+"125 627 OFFCURVE",
+"174 647 OFFCURVE",
+"174 704 CURVE SMOOTH",
+"174 745 OFFCURVE",
+"145 763 OFFCURVE",
+"112 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"50 745 OFFCURVE",
+"50 704 CURVE SMOOTH",
+"50 647 OFFCURVE",
+"99 627 OFFCURVE",
+"99 463 CURVE"
+);
+}
+);
+width = 395;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"338 403 LINE",
+"338 595 OFFCURVE",
+"407 619 OFFCURVE",
+"407 684 CURVE SMOOTH",
+"407 739 OFFCURVE",
+"368 763 OFFCURVE",
+"325 763 CURVE SMOOTH",
+"282 763 OFFCURVE",
+"243 739 OFFCURVE",
+"243 684 CURVE SMOOTH",
+"243 619 OFFCURVE",
+"312 595 OFFCURVE",
+"312 403 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 403 LINE",
+"135 595 OFFCURVE",
+"204 619 OFFCURVE",
+"204 684 CURVE SMOOTH",
+"204 739 OFFCURVE",
+"165 763 OFFCURVE",
+"122 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"40 739 OFFCURVE",
+"40 684 CURVE SMOOTH",
+"40 619 OFFCURVE",
+"109 595 OFFCURVE",
+"109 403 CURVE"
+);
+}
+);
+width = 447;
+}
+);
+unicode = 0022;
+},
+{
+glyphname = quotesingle;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"125 463 LINE",
+"125 627 OFFCURVE",
+"174 647 OFFCURVE",
+"174 704 CURVE SMOOTH",
+"174 745 OFFCURVE",
+"145 763 OFFCURVE",
+"112 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"50 745 OFFCURVE",
+"50 704 CURVE SMOOTH",
+"50 647 OFFCURVE",
+"99 627 OFFCURVE",
+"99 463 CURVE"
+);
+}
+);
+width = 224;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"258 699 OFFCURVE",
+"213 763 OFFCURVE",
+"142 763 CURVE SMOOTH",
+"86 763 OFFCURVE",
+"50 723 OFFCURVE",
+"50 671 CURVE SMOOTH",
+"50 630 OFFCURVE",
+"73 591 OFFCURVE",
+"123 591 CURVE SMOOTH",
+"171 591 OFFCURVE",
+"183 627 OFFCURVE",
+"198 627 CURVE SMOOTH",
+"204 627 OFFCURVE",
+"209 621 OFFCURVE",
+"209 597 CURVE SMOOTH",
+"209 533 OFFCURVE",
+"174 481 OFFCURVE",
+"96 421 CURVE",
+"113 400 LINE",
+"197 452 OFFCURVE",
+"258 524 OFFCURVE",
+"258 618 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"135 403 LINE",
+"135 595 OFFCURVE",
+"204 619 OFFCURVE",
+"204 684 CURVE SMOOTH",
+"204 739 OFFCURVE",
+"165 763 OFFCURVE",
+"122 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"40 739 OFFCURVE",
+"40 684 CURVE SMOOTH",
+"40 619 OFFCURVE",
+"109 595 OFFCURVE",
+"109 403 CURVE"
+);
+}
+);
+width = 244;
+}
+);
+unicode = 0027;
+},
+{
+glyphname = florin;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"32 -314 OFFCURVE",
+"144 -249 OFFCURVE",
+"194 45 CURVE SMOOTH",
+"271 501 LINE SMOOTH",
+"300 676 OFFCURVE",
+"335 724 OFFCURVE",
+"385 724 CURVE SMOOTH",
+"407 724 OFFCURVE",
+"420 715 OFFCURVE",
+"420 705 CURVE SMOOTH",
+"420 693 OFFCURVE",
+"402 682 OFFCURVE",
+"402 658 CURVE SMOOTH",
+"402 633 OFFCURVE",
+"420 613 OFFCURVE",
+"453 613 CURVE SMOOTH",
+"488 613 OFFCURVE",
+"505 636 OFFCURVE",
+"505 666 CURVE SMOOTH",
+"505 721 OFFCURVE",
+"447 754 OFFCURVE",
+"388 754 CURVE SMOOTH",
+"280 754 OFFCURVE",
+"160 644 OFFCURVE",
+"130 440 CURVE SMOOTH",
+"44 -140 LINE SMOOTH",
+"28 -247 OFFCURVE",
+"1 -284 OFFCURVE",
+"-40 -284 CURVE SMOOTH",
+"-59 -284 OFFCURVE",
+"-64 -276 OFFCURVE",
+"-64 -265 CURVE SMOOTH",
+"-64 -259 OFFCURVE",
+"-63 -246 OFFCURVE",
+"-63 -240 CURVE SMOOTH",
+"-63 -210 OFFCURVE",
+"-86 -193 OFFCURVE",
+"-112 -193 CURVE SMOOTH",
+"-139 -193 OFFCURVE",
+"-159 -211 OFFCURVE",
+"-159 -240 CURVE SMOOTH",
+"-159 -292 OFFCURVE",
+"-93 -314 OFFCURVE",
+"-47 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 396 LINE",
+"362 440 LINE",
+"41 440 LINE",
+"41 396 LINE"
+);
+}
+);
+width = 435;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"10 -314 OFFCURVE",
+"144 -250 OFFCURVE",
+"194 45 CURVE SMOOTH",
+"271 501 LINE SMOOTH",
+"300 673 OFFCURVE",
+"334 724 OFFCURVE",
+"383 724 CURVE SMOOTH",
+"403 724 OFFCURVE",
+"415 715 OFFCURVE",
+"415 705 CURVE SMOOTH",
+"415 691 OFFCURVE",
+"393 676 OFFCURVE",
+"393 643 CURVE SMOOTH",
+"393 614 OFFCURVE",
+"411 588 OFFCURVE",
+"453 588 CURVE SMOOTH",
+"497 588 OFFCURVE",
+"520 615 OFFCURVE",
+"520 654 CURVE SMOOTH",
+"520 721 OFFCURVE",
+"453 754 OFFCURVE",
+"389 754 CURVE SMOOTH",
+"275 754 OFFCURVE",
+"141 649 OFFCURVE",
+"102 387 CURVE SMOOTH",
+"24 -140 LINE SMOOTH",
+"8 -247 OFFCURVE",
+"-24 -284 OFFCURVE",
+"-70 -284 CURVE SMOOTH",
+"-89 -284 OFFCURVE",
+"-94 -276 OFFCURVE",
+"-94 -265 CURVE SMOOTH",
+"-94 -257 OFFCURVE",
+"-88 -238 OFFCURVE",
+"-88 -230 CURVE SMOOTH",
+"-88 -194 OFFCURVE",
+"-115 -173 OFFCURVE",
+"-142 -173 CURVE SMOOTH",
+"-181 -173 OFFCURVE",
+"-209 -195 OFFCURVE",
+"-209 -230 CURVE SMOOTH",
+"-209 -289 OFFCURVE",
+"-132 -314 OFFCURVE",
+"-76 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 391 LINE",
+"382 440 LINE",
+"21 440 LINE",
+"21 391 LINE"
+);
+}
+);
+width = 435;
+}
+);
+unicode = 0192;
+},
+{
+glyphname = at;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"493 -152 OFFCURVE",
+"575 -119 OFFCURVE",
+"660 -32 CURVE",
+"642 -7 LINE",
+"562 -101 OFFCURVE",
+"469 -122 OFFCURVE",
+"395 -122 CURVE SMOOTH",
+"208 -122 OFFCURVE",
+"103 11 OFFCURVE",
+"103 199 CURVE SMOOTH",
+"103 437 OFFCURVE",
+"270 600 OFFCURVE",
+"474 600 CURVE SMOOTH",
+"629 600 OFFCURVE",
+"752 506 OFFCURVE",
+"752 331 CURVE SMOOTH",
+"752 190 OFFCURVE",
+"672 94 OFFCURVE",
+"605 94 CURVE SMOOTH",
+"588 94 OFFCURVE",
+"579 100 OFFCURVE",
+"579 114 CURVE SMOOTH",
+"579 118 OFFCURVE",
+"580 124 OFFCURVE",
+"582 131 CURVE SMOOTH",
+"656 443 LINE",
+"548 443 LINE",
+"485 189 LINE SMOOTH",
+"474 144 OFFCURVE",
+"471 127 OFFCURVE",
+"471 112 CURVE SMOOTH",
+"471 65 OFFCURVE",
+"500 44 OFFCURVE",
+"552 44 CURVE SMOOTH",
+"681 44 OFFCURVE",
+"785 175 OFFCURVE",
+"785 335 CURVE SMOOTH",
+"785 501 OFFCURVE",
+"674 630 OFFCURVE",
+"477 630 CURVE SMOOTH",
+"261 630 OFFCURVE",
+"70 474 OFFCURVE",
+"70 199 CURVE SMOOTH",
+"70 -40 OFFCURVE",
+"214 -152 OFFCURVE",
+"395 -152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"408 44 OFFCURVE",
+"445 82 OFFCURVE",
+"464 115 CURVE",
+"471 115 LINE",
+"499 237 LINE",
+"472 118 OFFCURVE",
+"408 80 OFFCURVE",
+"371 80 CURVE SMOOTH",
+"346 80 OFFCURVE",
+"335 97 OFFCURVE",
+"335 148 CURVE SMOOTH",
+"335 273 OFFCURVE",
+"401 420 OFFCURVE",
+"465 420 CURVE SMOOTH",
+"498 420 OFFCURVE",
+"518 382 OFFCURVE",
+"518 341 CURVE SMOOTH",
+"518 329 OFFCURVE",
+"516 322 OFFCURVE",
+"516 309 CURVE",
+"536 390 LINE",
+"530 390 LINE",
+"512 435 OFFCURVE",
+"491 454 OFFCURVE",
+"449 454 CURVE SMOOTH",
+"344 454 OFFCURVE",
+"225 336 OFFCURVE",
+"225 194 CURVE SMOOTH",
+"225 90 OFFCURVE",
+"288 44 OFFCURVE",
+"351 44 CURVE SMOOTH"
+);
+}
+);
+width = 835;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"681 44 OFFCURVE",
+"785 175 OFFCURVE",
+"785 335 CURVE SMOOTH",
+"785 501 OFFCURVE",
+"674 630 OFFCURVE",
+"477 630 CURVE SMOOTH",
+"261 630 OFFCURVE",
+"70 474 OFFCURVE",
+"70 199 CURVE SMOOTH",
+"70 -40 OFFCURVE",
+"214 -152 OFFCURVE",
+"395 -152 CURVE SMOOTH",
+"493 -152 OFFCURVE",
+"575 -119 OFFCURVE",
+"660 -32 CURVE",
+"642 -7 LINE",
+"562 -101 OFFCURVE",
+"469 -122 OFFCURVE",
+"395 -122 CURVE SMOOTH",
+"208 -122 OFFCURVE",
+"103 11 OFFCURVE",
+"103 199 CURVE SMOOTH",
+"103 437 OFFCURVE",
+"270 600 OFFCURVE",
+"474 600 CURVE SMOOTH",
+"629 600 OFFCURVE",
+"752 506 OFFCURVE",
+"752 331 CURVE SMOOTH",
+"752 190 OFFCURVE",
+"672 94 OFFCURVE",
+"605 94 CURVE SMOOTH",
+"588 94 OFFCURVE",
+"579 100 OFFCURVE",
+"579 114 CURVE SMOOTH",
+"579 118 OFFCURVE",
+"580 124 OFFCURVE",
+"582 131 CURVE SMOOTH",
+"656 443 LINE",
+"548 443 LINE",
+"485 189 LINE SMOOTH",
+"474 144 OFFCURVE",
+"471 127 OFFCURVE",
+"471 112 CURVE SMOOTH",
+"471 65 OFFCURVE",
+"500 44 OFFCURVE",
+"552 44 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 390 LINE",
+"512 435 OFFCURVE",
+"491 454 OFFCURVE",
+"449 454 CURVE SMOOTH",
+"344 454 OFFCURVE",
+"225 336 OFFCURVE",
+"225 194 CURVE SMOOTH",
+"225 90 OFFCURVE",
+"288 44 OFFCURVE",
+"351 44 CURVE SMOOTH",
+"408 44 OFFCURVE",
+"445 82 OFFCURVE",
+"464 115 CURVE",
+"471 115 LINE",
+"499 237 LINE SMOOTH",
+"472 118 OFFCURVE",
+"408 80 OFFCURVE",
+"371 80 CURVE SMOOTH",
+"346 80 OFFCURVE",
+"335 97 OFFCURVE",
+"335 148 CURVE SMOOTH",
+"335 273 OFFCURVE",
+"401 420 OFFCURVE",
+"465 420 CURVE SMOOTH",
+"498 420 OFFCURVE",
+"518 382 OFFCURVE",
+"518 341 CURVE SMOOTH",
+"518 329 OFFCURVE",
+"516 322 OFFCURVE",
+"516 309 CURVE",
+"536 390 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"479 -152 OFFCURVE",
+"561 -119 OFFCURVE",
+"646 -32 CURVE",
+"623 3 LINE",
+"545 -91 OFFCURVE",
+"454 -112 OFFCURVE",
+"381 -112 CURVE SMOOTH",
+"200 -112 OFFCURVE",
+"99 17 OFFCURVE",
+"99 199 CURVE SMOOTH",
+"99 431 OFFCURVE",
+"261 590 OFFCURVE",
+"460 590 CURVE SMOOTH",
+"609 590 OFFCURVE",
+"728 501 OFFCURVE",
+"728 327 CURVE SMOOTH",
+"728 196 OFFCURVE",
+"660 104 OFFCURVE",
+"601 104 CURVE SMOOTH",
+"586 104 OFFCURVE",
+"577 110 OFFCURVE",
+"577 124 CURVE SMOOTH",
+"577 129 OFFCURVE",
+"578 134 OFFCURVE",
+"580 141 CURVE SMOOTH",
+"652 443 LINE",
+"524 443 LINE",
+"461 189 LINE SMOOTH",
+"450 144 OFFCURVE",
+"447 127 OFFCURVE",
+"447 113 CURVE SMOOTH",
+"447 65 OFFCURVE",
+"481 44 OFFCURVE",
+"535 44 CURVE SMOOTH",
+"669 44 OFFCURVE",
+"771 176 OFFCURVE",
+"771 335 CURVE SMOOTH",
+"771 501 OFFCURVE",
+"660 630 OFFCURVE",
+"463 630 CURVE SMOOTH",
+"247 630 OFFCURVE",
+"56 474 OFFCURVE",
+"56 199 CURVE SMOOTH",
+"56 -40 OFFCURVE",
+"200 -152 OFFCURVE",
+"381 -152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 44 OFFCURVE",
+"423 79 OFFCURVE",
+"440 110 CURVE",
+"447 110 LINE",
+"475 237 LINE",
+"451 130 OFFCURVE",
+"395 90 OFFCURVE",
+"357 90 CURVE SMOOTH",
+"333 90 OFFCURVE",
+"321 105 OFFCURVE",
+"321 158 CURVE SMOOTH",
+"321 275 OFFCURVE",
+"381 410 OFFCURVE",
+"443 410 CURVE SMOOTH",
+"474 410 OFFCURVE",
+"494 376 OFFCURVE",
+"494 341 CURVE SMOOTH",
+"494 329 OFFCURVE",
+"492 322 OFFCURVE",
+"492 309 CURVE",
+"513 395 LINE",
+"507 395 LINE",
+"489 436 OFFCURVE",
+"468 454 OFFCURVE",
+"425 454 CURVE SMOOTH",
+"317 454 OFFCURVE",
+"196 335 OFFCURVE",
+"196 195 CURVE SMOOTH",
+"196 90 OFFCURVE",
+"264 44 OFFCURVE",
+"328 44 CURVE SMOOTH"
+);
+}
+);
+width = 835;
+}
+);
+unicode = 0040;
+},
+{
+glyphname = ampersand;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"530 455 LINE",
+"791 455 LINE",
+"791 480 LINE",
+"530 480 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 0 LINE",
+"766 0 LINE",
+"766 25 LINE",
+"535 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 0 LINE",
+"689 0 LINE",
+"393 465 LINE",
+"239 465 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"272 448 LINE",
+"394 463 LINE",
+"325 562 LINE SMOOTH",
+"303 594 OFFCURVE",
+"284 624 OFFCURVE",
+"284 659 CURVE SMOOTH",
+"284 703 OFFCURVE",
+"315 739 OFFCURVE",
+"371 739 CURVE SMOOTH",
+"426 739 OFFCURVE",
+"456 703 OFFCURVE",
+"456 638 CURVE SMOOTH",
+"456 561 OFFCURVE",
+"414 498 OFFCURVE",
+"354 491 CURVE",
+"382 466 LINE",
+"526 516 OFFCURVE",
+"559 587 OFFCURVE",
+"559 638 CURVE SMOOTH",
+"559 716 OFFCURVE",
+"484 769 OFFCURVE",
+"375 769 CURVE SMOOTH",
+"245 769 OFFCURVE",
+"180 694 OFFCURVE",
+"180 608 CURVE SMOOTH",
+"180 545 OFFCURVE",
+"215 506 OFFCURVE",
+"239 465 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 457 LINE",
+"135 401 OFFCURVE",
+"20 316 OFFCURVE",
+"20 189 CURVE SMOOTH",
+"20 76 OFFCURVE",
+"110 -13 OFFCURVE",
+"271 -13 CURVE SMOOTH",
+"358 -13 OFFCURVE",
+"434 13 OFFCURVE",
+"515 100 CURVE",
+"493 122 LINE",
+"429 58 OFFCURVE",
+"382 36 OFFCURVE",
+"335 36 CURVE SMOOTH",
+"236 36 OFFCURVE",
+"155 134 OFFCURVE",
+"155 260 CURVE SMOOTH",
+"155 335 OFFCURVE",
+"184 395 OFFCURVE",
+"284 430 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 160 LINE",
+"634 232 OFFCURVE",
+"683 365 OFFCURVE",
+"683 464 CURVE",
+"649 464 LINE",
+"649 371 OFFCURVE",
+"614 255 OFFCURVE",
+"556 188 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"689 0 LINE",
+"326 556 LINE SMOOTH",
+"305 589 OFFCURVE",
+"284 622 OFFCURVE",
+"284 657 CURVE SMOOTH",
+"284 701 OFFCURVE",
+"315 737 OFFCURVE",
+"371 737 CURVE SMOOTH",
+"426 737 OFFCURVE",
+"456 701 OFFCURVE",
+"456 636 CURVE SMOOTH",
+"456 559 OFFCURVE",
+"414 498 OFFCURVE",
+"354 491 CURVE",
+"382 466 LINE",
+"526 516 OFFCURVE",
+"559 585 OFFCURVE",
+"559 636 CURVE SMOOTH",
+"559 714 OFFCURVE",
+"484 767 OFFCURVE",
+"375 767 CURVE SMOOTH",
+"245 767 OFFCURVE",
+"180 692 OFFCURVE",
+"180 606 CURVE SMOOTH",
+"180 543 OFFCURVE",
+"213 505 OFFCURVE",
+"239 465 CURVE SMOOTH",
+"535 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"358 -13 OFFCURVE",
+"434 13 OFFCURVE",
+"515 100 CURVE",
+"493 122 LINE",
+"429 58 OFFCURVE",
+"382 36 OFFCURVE",
+"335 36 CURVE SMOOTH",
+"236 36 OFFCURVE",
+"155 134 OFFCURVE",
+"155 260 CURVE SMOOTH",
+"155 335 OFFCURVE",
+"184 395 OFFCURVE",
+"284 430 CURVE",
+"263 457 LINE",
+"135 401 OFFCURVE",
+"20 316 OFFCURVE",
+"20 189 CURVE SMOOTH",
+"20 76 OFFCURVE",
+"110 -13 OFFCURVE",
+"271 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"766 0 LINE",
+"766 25 LINE",
+"575 25 LINE",
+"575 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 232 OFFCURVE",
+"683 365 OFFCURVE",
+"683 464 CURVE",
+"649 464 LINE",
+"649 371 OFFCURVE",
+"614 255 OFFCURVE",
+"556 188 CURVE",
+"579 160 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 455 LINE",
+"791 480 LINE",
+"530 480 LINE",
+"530 455 LINE"
+);
+}
+);
+width = 800;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"567 455 LINE",
+"828 455 LINE",
+"828 480 LINE",
+"567 480 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 0 LINE",
+"822 0 LINE",
+"822 30 LINE",
+"561 30 LINE",
+"735 0 LINE",
+"439 465 LINE",
+"245 465 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 463 LINE",
+"371 562 LINE SMOOTH",
+"349 593 OFFCURVE",
+"330 620 OFFCURVE",
+"330 656 CURVE SMOOTH",
+"330 694 OFFCURVE",
+"351 728 OFFCURVE",
+"409 728 CURVE SMOOTH",
+"469 728 OFFCURVE",
+"497 692 OFFCURVE",
+"497 629 CURVE SMOOTH",
+"497 551 OFFCURVE",
+"453 488 OFFCURVE",
+"390 481 CURVE",
+"418 456 LINE",
+"586 508 OFFCURVE",
+"625 579 OFFCURVE",
+"625 631 CURVE SMOOTH",
+"625 710 OFFCURVE",
+"536 763 OFFCURVE",
+"414 763 CURVE SMOOTH",
+"277 763 OFFCURVE",
+"196 696 OFFCURVE",
+"196 598 CURVE SMOOTH",
+"196 544 OFFCURVE",
+"220 499 OFFCURVE",
+"245 465 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 437 LINE",
+"134 382 OFFCURVE",
+"20 306 OFFCURVE",
+"20 185 CURVE SMOOTH",
+"20 78 OFFCURVE",
+"109 -13 OFFCURVE",
+"272 -13 CURVE SMOOTH",
+"358 -13 OFFCURVE",
+"434 12 OFFCURVE",
+"515 95 CURVE",
+"493 122 LINE",
+"439 72 OFFCURVE",
+"399 56 OFFCURVE",
+"363 56 CURVE SMOOTH",
+"263 56 OFFCURVE",
+"180 182 OFFCURVE",
+"180 292 CURVE SMOOTH",
+"180 350 OFFCURVE",
+"203 381 OFFCURVE",
+"294 405 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 160 LINE",
+"654 232 OFFCURVE",
+"723 365 OFFCURVE",
+"723 464 CURVE",
+"684 464 LINE",
+"684 371 OFFCURVE",
+"633 255 OFFCURVE",
+"551 188 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"735 0 LINE",
+"377 554 LINE SMOOTH",
+"356 587 OFFCURVE",
+"330 623 OFFCURVE",
+"330 656 CURVE SMOOTH",
+"330 694 OFFCURVE",
+"351 728 OFFCURVE",
+"409 728 CURVE SMOOTH",
+"469 728 OFFCURVE",
+"497 692 OFFCURVE",
+"497 629 CURVE SMOOTH",
+"497 551 OFFCURVE",
+"453 488 OFFCURVE",
+"390 481 CURVE",
+"418 456 LINE",
+"586 508 OFFCURVE",
+"625 579 OFFCURVE",
+"625 631 CURVE SMOOTH",
+"625 710 OFFCURVE",
+"536 763 OFFCURVE",
+"414 763 CURVE SMOOTH",
+"277 763 OFFCURVE",
+"196 696 OFFCURVE",
+"196 598 CURVE SMOOTH",
+"196 544 OFFCURVE",
+"220 499 OFFCURVE",
+"245 465 CURVE",
+"541 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"358 -13 OFFCURVE",
+"434 12 OFFCURVE",
+"515 95 CURVE",
+"493 122 LINE",
+"439 72 OFFCURVE",
+"399 56 OFFCURVE",
+"363 56 CURVE SMOOTH",
+"263 56 OFFCURVE",
+"180 182 OFFCURVE",
+"180 292 CURVE SMOOTH",
+"180 350 OFFCURVE",
+"203 381 OFFCURVE",
+"294 405 CURVE",
+"273 437 LINE",
+"134 382 OFFCURVE",
+"20 306 OFFCURVE",
+"20 185 CURVE SMOOTH",
+"20 78 OFFCURVE",
+"109 -13 OFFCURVE",
+"272 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"822 0 LINE",
+"822 30 LINE",
+"575 30 LINE",
+"575 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"654 232 OFFCURVE",
+"723 365 OFFCURVE",
+"723 464 CURVE",
+"684 464 LINE",
+"684 371 OFFCURVE",
+"633 255 OFFCURVE",
+"551 188 CURVE",
+"579 160 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"828 455 LINE",
+"828 480 LINE",
+"567 480 LINE",
+"567 455 LINE"
+);
+}
+);
+width = 836;
+}
+);
+unicode = 0026;
+},
+{
+glyphname = paragraph;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"126 15 LINE",
+"260 15 LINE",
+"260 754 LINE",
+"126 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 526 LINE",
+"415 526 LINE",
+"415 418 OFFCURVE",
+"381 388 OFFCURVE",
+"257 388 CURVE",
+"257 363 LINE",
+"381 363 OFFCURVE",
+"412 328 OFFCURVE",
+"415 216 CURVE",
+"450 216 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"8 729 LINE",
+"416 729 LINE SMOOTH",
+"515 729 OFFCURVE",
+"572 646 OFFCURVE",
+"574 549 CURVE",
+"609 549 LINE",
+"609 754 LINE",
+"8 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"8 0 LINE",
+"639 0 LINE",
+"639 235 LINE",
+"604 235 LINE",
+"602 123 OFFCURVE",
+"545 25 OFFCURVE",
+"446 25 CURVE SMOOTH",
+"8 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"311 -123 LINE",
+"311 731 LINE",
+"422 731 LINE",
+"422 -123 LINE",
+"472 -123 LINE",
+"472 731 LINE",
+"617 731 LINE",
+"617 754 LINE",
+"261 754 LINE SMOOTH",
+"140 754 OFFCURVE",
+"29 660 OFFCURVE",
+"29 535 CURVE SMOOTH",
+"29 418 OFFCURVE",
+"111 319 OFFCURVE",
+"261 309 CURVE",
+"261 -123 LINE"
+);
+}
+);
+width = 626;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"334 -157 LINE",
+"334 680 LINE",
+"431 680 LINE",
+"431 -157 LINE",
+"513 -157 LINE",
+"513 680 LINE",
+"608 680 LINE",
+"608 754 LINE",
+"252 754 LINE SMOOTH",
+"131 754 OFFCURVE",
+"20 660 OFFCURVE",
+"20 535 CURVE SMOOTH",
+"20 418 OFFCURVE",
+"102 319 OFFCURVE",
+"252 309 CURVE",
+"252 -157 LINE"
+);
+}
+);
+width = 633;
+}
+);
+unicode = 00B6;
+},
+{
+glyphname = section;
+lastChange = "2016-08-19 17:07:39 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"407 130 OFFCURVE",
+"459 182 OFFCURVE",
+"459 263 CURVE SMOOTH",
+"459 463 OFFCURVE",
+"144 530 OFFCURVE",
+"144 658 CURVE SMOOTH",
+"144 704 OFFCURVE",
+"184 736 OFFCURVE",
+"256 736 CURVE SMOOTH",
+"305 736 OFFCURVE",
+"339 716 OFFCURVE",
+"339 702 CURVE SMOOTH",
+"339 686 OFFCURVE",
+"300 672 OFFCURVE",
+"300 637 CURVE SMOOTH",
+"300 614 OFFCURVE",
+"317 587 OFFCURVE",
+"354 587 CURVE SMOOTH",
+"385 587 OFFCURVE",
+"412 607 OFFCURVE",
+"412 653 CURVE SMOOTH",
+"412 716 OFFCURVE",
+"349 766 OFFCURVE",
+"254 766 CURVE SMOOTH",
+"145 766 OFFCURVE",
+"94 700 OFFCURVE",
+"94 613 CURVE SMOOTH",
+"94 403 OFFCURVE",
+"393 331 OFFCURVE",
+"393 220 CURVE SMOOTH",
+"393 179 OFFCURVE",
+"352 155 OFFCURVE",
+"303 155 CURVE",
+"307 130 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"350 -123 OFFCURVE",
+"405 -56 OFFCURVE",
+"405 32 CURVE SMOOTH",
+"405 238 OFFCURVE",
+"106 312 OFFCURVE",
+"106 423 CURVE SMOOTH",
+"106 464 OFFCURVE",
+"147 488 OFFCURVE",
+"196 488 CURVE",
+"192 513 LINE",
+"92 513 OFFCURVE",
+"40 461 OFFCURVE",
+"40 380 CURVE SMOOTH",
+"40 182 OFFCURVE",
+"355 79 OFFCURVE",
+"355 -26 CURVE SMOOTH",
+"355 -67 OFFCURVE",
+"306 -93 OFFCURVE",
+"239 -93 CURVE SMOOTH",
+"178 -93 OFFCURVE",
+"150 -71 OFFCURVE",
+"150 -55 CURVE SMOOTH",
+"150 -36 OFFCURVE",
+"189 -24 OFFCURVE",
+"189 11 CURVE SMOOTH",
+"189 33 OFFCURVE",
+"172 61 OFFCURVE",
+"135 61 CURVE SMOOTH",
+"104 61 OFFCURVE",
+"77 42 OFFCURVE",
+"77 -2 CURVE SMOOTH",
+"77 -69 OFFCURVE",
+"139 -123 OFFCURVE",
+"239 -123 CURVE SMOOTH"
+);
+}
+);
+width = 499;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"414 118 OFFCURVE",
+"469 180 OFFCURVE",
+"469 266 CURVE SMOOTH",
+"469 468 OFFCURVE",
+"164 520 OFFCURVE",
+"164 648 CURVE SMOOTH",
+"164 689 OFFCURVE",
+"196 719 OFFCURVE",
+"258 719 CURVE SMOOTH",
+"305 719 OFFCURVE",
+"339 702 OFFCURVE",
+"339 689 CURVE SMOOTH",
+"339 675 OFFCURVE",
+"300 660 OFFCURVE",
+"300 625 CURVE SMOOTH",
+"300 602 OFFCURVE",
+"317 575 OFFCURVE",
+"353 575 CURVE SMOOTH",
+"385 575 OFFCURVE",
+"412 596 OFFCURVE",
+"412 639 CURVE SMOOTH",
+"412 704 OFFCURVE",
+"352 754 OFFCURVE",
+"250 754 CURVE SMOOTH",
+"133 754 OFFCURVE",
+"74 688 OFFCURVE",
+"74 602 CURVE SMOOTH",
+"74 409 OFFCURVE",
+"373 322 OFFCURVE",
+"373 206 CURVE SMOOTH",
+"373 168 OFFCURVE",
+"341 143 OFFCURVE",
+"303 143 CURVE",
+"307 118 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 -161 OFFCURVE",
+"425 -92 OFFCURVE",
+"425 -3 CURVE SMOOTH",
+"425 189 OFFCURVE",
+"126 275 OFFCURVE",
+"126 392 CURVE SMOOTH",
+"126 430 OFFCURVE",
+"157 455 OFFCURVE",
+"196 455 CURVE",
+"192 480 LINE",
+"85 480 OFFCURVE",
+"30 417 OFFCURVE",
+"30 332 CURVE SMOOTH",
+"30 132 OFFCURVE",
+"335 45 OFFCURVE",
+"335 -60 CURVE SMOOTH",
+"335 -96 OFFCURVE",
+"300 -126 OFFCURVE",
+"235 -126 CURVE SMOOTH",
+"180 -126 OFFCURVE",
+"150 -104 OFFCURVE",
+"150 -88 CURVE SMOOTH",
+"150 -69 OFFCURVE",
+"189 -57 OFFCURVE",
+"189 -22 CURVE SMOOTH",
+"189 0 OFFCURVE",
+"172 28 OFFCURVE",
+"135 28 CURVE SMOOTH",
+"104 28 OFFCURVE",
+"77 10 OFFCURVE",
+"77 -36 CURVE SMOOTH",
+"77 -105 OFFCURVE",
+"138 -161 OFFCURVE",
+"244 -161 CURVE SMOOTH"
+);
+}
+);
+width = 499;
+}
+);
+unicode = 00A7;
+},
+{
+glyphname = copyright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"622 -10 OFFCURVE",
+"793 158 OFFCURVE",
+"793 370 CURVE SMOOTH",
+"793 586 OFFCURVE",
+"625 754 OFFCURVE",
+"414 754 CURVE SMOOTH",
+"205 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 370 CURVE SMOOTH",
+"40 165 OFFCURVE",
+"207 -10 OFFCURVE",
+"413 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"464 152 OFFCURVE",
+"508 164 OFFCURVE",
+"543 187 CURVE",
+"563 160 LINE",
+"578 160 LINE",
+"578 285 LINE",
+"558 285 LINE",
+"543 224 OFFCURVE",
+"506 175 OFFCURVE",
+"419 175 CURVE SMOOTH",
+"339 175 OFFCURVE",
+"299 215 OFFCURVE",
+"299 374 CURVE SMOOTH",
+"299 551 OFFCURVE",
+"351 587 OFFCURVE",
+"420 587 CURVE SMOOTH",
+"503 587 OFFCURVE",
+"539 534 OFFCURVE",
+"553 471 CURVE",
+"572 471 LINE",
+"572 604 LINE",
+"558 604 LINE",
+"535 575 LINE",
+"500 600 OFFCURVE",
+"464 609 OFFCURVE",
+"421 609 CURVE SMOOTH",
+"288 609 OFFCURVE",
+"190 503 OFFCURVE",
+"190 384 CURVE SMOOTH",
+"190 262 OFFCURVE",
+"289 152 OFFCURVE",
+"419 152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"233 29 OFFCURVE",
+"79 182 OFFCURVE",
+"79 371 CURVE SMOOTH",
+"79 557 OFFCURVE",
+"230 715 OFFCURVE",
+"414 715 CURVE SMOOTH",
+"602 715 OFFCURVE",
+"754 562 OFFCURVE",
+"754 371 CURVE SMOOTH",
+"754 188 OFFCURVE",
+"604 29 OFFCURVE",
+"413 29 CURVE SMOOTH"
+);
+}
+);
+width = 833;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"622 -10 OFFCURVE",
+"793 158 OFFCURVE",
+"793 372 CURVE SMOOTH",
+"793 585 OFFCURVE",
+"624 754 OFFCURVE",
+"416 754 CURVE SMOOTH",
+"205 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 372 CURVE SMOOTH",
+"40 165 OFFCURVE",
+"205 -10 OFFCURVE",
+"416 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 152 OFFCURVE",
+"511 164 OFFCURVE",
+"543 187 CURVE",
+"558 160 LINE",
+"578 160 LINE",
+"578 285 LINE",
+"553 285 LINE",
+"540 230 OFFCURVE",
+"506 185 OFFCURVE",
+"431 185 CURVE SMOOTH",
+"362 185 OFFCURVE",
+"329 223 OFFCURVE",
+"329 372 CURVE SMOOTH",
+"329 545 OFFCURVE",
+"373 577 OFFCURVE",
+"431 577 CURVE SMOOTH",
+"503 577 OFFCURVE",
+"536 529 OFFCURVE",
+"548 471 CURVE",
+"572 471 LINE",
+"572 604 LINE",
+"553 604 LINE",
+"535 575 LINE",
+"503 600 OFFCURVE",
+"470 609 OFFCURVE",
+"430 609 CURVE SMOOTH",
+"292 609 OFFCURVE",
+"190 503 OFFCURVE",
+"190 383 CURVE SMOOTH",
+"190 262 OFFCURVE",
+"294 152 OFFCURVE",
+"427 152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"237 39 OFFCURVE",
+"89 188 OFFCURVE",
+"89 371 CURVE SMOOTH",
+"89 552 OFFCURVE",
+"234 705 OFFCURVE",
+"416 705 CURVE SMOOTH",
+"596 705 OFFCURVE",
+"744 554 OFFCURVE",
+"744 373 CURVE SMOOTH",
+"744 193 OFFCURVE",
+"598 39 OFFCURVE",
+"416 39 CURVE SMOOTH"
+);
+}
+);
+width = 833;
+}
+);
+unicode = 00A9;
+},
+{
+glyphname = registered;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"475 -10 OFFCURVE",
+"646 158 OFFCURVE",
+"646 372 CURVE SMOOTH",
+"646 585 OFFCURVE",
+"477 754 OFFCURVE",
+"269 754 CURVE SMOOTH",
+"58 754 OFFCURVE",
+"-107 579 OFFCURVE",
+"-107 372 CURVE SMOOTH",
+"-107 165 OFFCURVE",
+"58 -10 OFFCURVE",
+"269 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"455 715 OFFCURVE",
+"607 560 OFFCURVE",
+"607 373 CURVE SMOOTH",
+"607 188 OFFCURVE",
+"457 29 OFFCURVE",
+"269 29 CURVE SMOOTH",
+"85 29 OFFCURVE",
+"-68 182 OFFCURVE",
+"-68 370 CURVE SMOOTH",
+"-68 557 OFFCURVE",
+"82 715 OFFCURVE",
+"269 715 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"120 170 LINE",
+"214 170 LINE",
+"214 602 LINE",
+"120 602 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"244 387 LINE SMOOTH",
+"364 387 OFFCURVE",
+"434 434 OFFCURVE",
+"434 501 CURVE SMOOTH",
+"434 565 OFFCURVE",
+"372 602 OFFCURVE",
+"297 602 CURVE SMOOTH",
+"71 602 LINE",
+"71 580 LINE",
+"268 580 LINE SMOOTH",
+"317 580 OFFCURVE",
+"338 568 OFFCURVE",
+"338 501 CURVE SMOOTH",
+"338 422 OFFCURVE",
+"309 405 OFFCURVE",
+"244 405 CURVE SMOOTH",
+"195 405 LINE",
+"195 387 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 161 LINE",
+"290 161 LINE",
+"290 183 LINE",
+"71 183 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 161 LINE",
+"479 183 LINE",
+"457 183 LINE SMOOTH",
+"426 183 OFFCURVE",
+"416 196 OFFCURVE",
+"416 245 CURVE SMOOTH",
+"416 276 LINE SMOOTH",
+"416 331 OFFCURVE",
+"364 379 OFFCURVE",
+"315 390 CURVE",
+"315 394 LINE",
+"293 394 LINE",
+"249 387 LINE",
+"282 387 OFFCURVE",
+"307 358 OFFCURVE",
+"309 297 CURVE SMOOTH",
+"311 250 LINE SMOOTH",
+"313 196 OFFCURVE",
+"361 161 OFFCURVE",
+"424 161 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"393 323 OFFCURVE",
+"497 425 OFFCURVE",
+"497 555 CURVE SMOOTH",
+"497 684 OFFCURVE",
+"394 787 OFFCURVE",
+"269 787 CURVE SMOOTH",
+"140 787 OFFCURVE",
+"40 681 OFFCURVE",
+"40 555 CURVE SMOOTH",
+"40 430 OFFCURVE",
+"140 323 OFFCURVE",
+"269 323 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 427 LINE",
+"282 445 LINE",
+"148 445 LINE",
+"148 427 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 433 LINE",
+"245 695 LINE",
+"178 695 LINE",
+"178 433 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 357 OFFCURVE",
+"74 446 OFFCURVE",
+"74 554 CURVE SMOOTH",
+"74 663 OFFCURVE",
+"161 754 OFFCURVE",
+"269 754 CURVE SMOOTH",
+"376 754 OFFCURVE",
+"464 664 OFFCURVE",
+"464 555 CURVE SMOOTH",
+"464 448 OFFCURVE",
+"377 357 OFFCURVE",
+"269 357 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"396 427 LINE",
+"396 445 LINE",
+"383 445 LINE SMOOTH",
+"371 445 OFFCURVE",
+"367 453 OFFCURVE",
+"367 483 CURVE SMOOTH",
+"367 497 LINE SMOOTH",
+"367 530 OFFCURVE",
+"341 561 OFFCURVE",
+"317 568 CURVE",
+"317 574 LINE",
+"293 569 LINE",
+"266 565 LINE",
+"280 565 OFFCURVE",
+"291 546 OFFCURVE",
+"293 509 CURVE SMOOTH",
+"293 481 LINE SMOOTH",
+"295 448 OFFCURVE",
+"325 427 OFFCURVE",
+"363 427 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"264 565 LINE SMOOTH",
+"330 565 OFFCURVE",
+"369 593 OFFCURVE",
+"369 633 CURVE SMOOTH",
+"369 672 OFFCURVE",
+"331 695 OFFCURVE",
+"286 695 CURVE SMOOTH",
+"148 695 LINE",
+"148 676 LINE",
+"268 676 LINE SMOOTH",
+"290 676 OFFCURVE",
+"301 669 OFFCURVE",
+"301 633 CURVE SMOOTH",
+"301 590 OFFCURVE",
+"289 580 OFFCURVE",
+"264 580 CURVE SMOOTH",
+"234 580 LINE",
+"234 565 LINE"
+);
+}
+);
+width = 537;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"622 -10 OFFCURVE",
+"793 158 OFFCURVE",
+"793 372 CURVE SMOOTH",
+"793 585 OFFCURVE",
+"624 754 OFFCURVE",
+"416 754 CURVE SMOOTH",
+"205 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 372 CURVE SMOOTH",
+"40 165 OFFCURVE",
+"205 -10 OFFCURVE",
+"416 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"596 705 OFFCURVE",
+"744 555 OFFCURVE",
+"744 373 CURVE SMOOTH",
+"744 193 OFFCURVE",
+"598 39 OFFCURVE",
+"416 39 CURVE SMOOTH",
+"237 39 OFFCURVE",
+"89 188 OFFCURVE",
+"89 370 CURVE SMOOTH",
+"89 552 OFFCURVE",
+"235 705 OFFCURVE",
+"416 705 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"257 170 LINE",
+"371 170 LINE",
+"371 602 LINE",
+"257 602 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 377 LINE SMOOTH",
+"517 377 OFFCURVE",
+"591 428 OFFCURVE",
+"591 501 CURVE SMOOTH",
+"591 565 OFFCURVE",
+"524 602 OFFCURVE",
+"444 602 CURVE SMOOTH",
+"218 602 LINE",
+"218 570 LINE",
+"415 570 LINE SMOOTH",
+"457 570 OFFCURVE",
+"475 550 OFFCURVE",
+"475 501 CURVE SMOOTH",
+"475 422 OFFCURVE",
+"449 405 OFFCURVE",
+"391 405 CURVE SMOOTH",
+"342 405 LINE",
+"342 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 161 LINE",
+"437 161 LINE",
+"437 193 LINE",
+"218 193 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"636 161 LINE",
+"636 183 LINE",
+"614 183 LINE SMOOTH",
+"583 183 OFFCURVE",
+"573 196 OFFCURVE",
+"573 245 CURVE SMOOTH",
+"573 276 LINE SMOOTH",
+"573 326 OFFCURVE",
+"516 370 OFFCURVE",
+"462 380 CURVE",
+"462 384 LINE",
+"440 384 LINE",
+"396 377 LINE",
+"423 377 OFFCURVE",
+"444 351 OFFCURVE",
+"446 297 CURVE SMOOTH",
+"448 250 LINE SMOOTH",
+"450 196 OFFCURVE",
+"502 161 OFFCURVE",
+"571 161 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"393 323 OFFCURVE",
+"497 425 OFFCURVE",
+"497 555 CURVE SMOOTH",
+"497 684 OFFCURVE",
+"394 787 OFFCURVE",
+"269 787 CURVE SMOOTH",
+"140 787 OFFCURVE",
+"40 681 OFFCURVE",
+"40 555 CURVE SMOOTH",
+"40 430 OFFCURVE",
+"140 323 OFFCURVE",
+"269 323 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 427 LINE",
+"282 445 LINE",
+"148 445 LINE",
+"148 427 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 433 LINE",
+"245 695 LINE",
+"168 695 LINE",
+"168 433 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 357 OFFCURVE",
+"74 446 OFFCURVE",
+"74 554 CURVE SMOOTH",
+"74 663 OFFCURVE",
+"161 754 OFFCURVE",
+"269 754 CURVE SMOOTH",
+"376 754 OFFCURVE",
+"464 664 OFFCURVE",
+"464 555 CURVE SMOOTH",
+"464 448 OFFCURVE",
+"377 357 OFFCURVE",
+"269 357 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"406 427 LINE",
+"406 445 LINE",
+"393 445 LINE SMOOTH",
+"381 445 OFFCURVE",
+"377 453 OFFCURVE",
+"377 483 CURVE SMOOTH",
+"377 497 LINE SMOOTH",
+"377 530 OFFCURVE",
+"346 561 OFFCURVE",
+"317 568 CURVE",
+"317 574 LINE",
+"293 569 LINE",
+"266 565 LINE",
+"280 565 OFFCURVE",
+"291 546 OFFCURVE",
+"293 509 CURVE",
+"293 481 LINE",
+"295 448 OFFCURVE",
+"330 427 OFFCURVE",
+"373 427 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"264 565 LINE SMOOTH",
+"336 565 OFFCURVE",
+"379 593 OFFCURVE",
+"379 633 CURVE SMOOTH",
+"379 672 OFFCURVE",
+"336 695 OFFCURVE",
+"286 695 CURVE SMOOTH",
+"148 695 LINE",
+"148 676 LINE",
+"268 676 LINE SMOOTH",
+"290 676 OFFCURVE",
+"301 669 OFFCURVE",
+"301 633 CURVE SMOOTH",
+"301 590 OFFCURVE",
+"289 580 OFFCURVE",
+"264 580 CURVE SMOOTH",
+"234 580 LINE",
+"234 565 LINE"
+);
+}
+);
+width = 537;
+}
+);
+unicode = 00AE;
+},
+{
+glyphname = trademark;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"591 376 LINE",
+"693 710 LINE",
+"697 710 LINE",
+"697 403 LINE",
+"642 403 LINE",
+"642 380 LINE",
+"818 380 LINE",
+"818 403 LINE",
+"783 403 LINE",
+"783 732 LINE",
+"818 732 LINE",
+"818 754 LINE",
+"688 754 LINE",
+"607 494 LINE",
+"603 494 LINE",
+"526 754 LINE",
+"372 754 LINE",
+"372 732 LINE",
+"416 732 LINE",
+"416 403 LINE",
+"372 403 LINE",
+"372 380 LINE",
+"500 380 LINE",
+"500 403 LINE",
+"445 403 LINE",
+"445 710 LINE",
+"449 710 LINE",
+"554 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"297 380 LINE",
+"297 403 LINE",
+"233 403 LINE",
+"233 732 LINE",
+"243 732 LINE SMOOTH",
+"292 732 OFFCURVE",
+"320 691 OFFCURVE",
+"321 633 CURVE",
+"348 633 LINE",
+"348 754 LINE",
+"27 754 LINE",
+"27 633 LINE",
+"54 633 LINE",
+"55 689 OFFCURVE",
+"82 732 OFFCURVE",
+"129 732 CURVE SMOOTH",
+"146 732 LINE",
+"146 403 LINE",
+"82 403 LINE",
+"82 380 LINE"
+);
+}
+);
+width = 845;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"601 376 LINE",
+"693 677 LINE",
+"697 677 LINE",
+"697 408 LINE",
+"642 408 LINE",
+"642 380 LINE",
+"828 380 LINE",
+"828 408 LINE",
+"793 408 LINE",
+"793 727 LINE",
+"828 727 LINE",
+"828 754 LINE",
+"688 754 LINE",
+"607 494 LINE",
+"603 494 LINE",
+"526 754 LINE",
+"372 754 LINE",
+"372 727 LINE",
+"406 727 LINE",
+"406 408 LINE",
+"372 408 LINE",
+"372 380 LINE",
+"500 380 LINE",
+"500 408 LINE",
+"445 408 LINE",
+"445 679 LINE",
+"449 679 LINE",
+"544 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"297 380 LINE",
+"297 408 LINE",
+"243 408 LINE",
+"243 727 LINE",
+"247 727 LINE SMOOTH",
+"291 727 OFFCURVE",
+"315 689 OFFCURVE",
+"316 633 CURVE",
+"348 633 LINE",
+"348 754 LINE",
+"27 754 LINE",
+"27 633 LINE",
+"59 633 LINE",
+"60 689 OFFCURVE",
+"85 725 OFFCURVE",
+"129 727 CURVE SMOOTH",
+"136 727 LINE",
+"136 408 LINE",
+"82 408 LINE",
+"82 380 LINE"
+);
+}
+);
+width = 845;
+}
+);
+unicode = 2122;
+},
+{
+glyphname = degree;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"280 459 OFFCURVE",
+"348 515 OFFCURVE",
+"348 608 CURVE SMOOTH",
+"348 693 OFFCURVE",
+"290 763 OFFCURVE",
+"200 763 CURVE SMOOTH",
+"118 763 OFFCURVE",
+"50 705 OFFCURVE",
+"50 610 CURVE SMOOTH",
+"50 515 OFFCURVE",
+"118 459 OFFCURVE",
+"199 459 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 503 OFFCURVE",
+"103 549 OFFCURVE",
+"103 612 CURVE SMOOTH",
+"103 675 OFFCURVE",
+"140 718 OFFCURVE",
+"201 718 CURVE SMOOTH",
+"264 718 OFFCURVE",
+"296 671 OFFCURVE",
+"296 611 CURVE SMOOTH",
+"296 547 OFFCURVE",
+"260 503 OFFCURVE",
+"201 503 CURVE SMOOTH"
+);
+}
+);
+width = 363;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"263 459 OFFCURVE",
+"331 515 OFFCURVE",
+"331 608 CURVE SMOOTH",
+"331 693 OFFCURVE",
+"273 763 OFFCURVE",
+"183 763 CURVE SMOOTH",
+"101 763 OFFCURVE",
+"33 705 OFFCURVE",
+"33 610 CURVE SMOOTH",
+"33 515 OFFCURVE",
+"101 459 OFFCURVE",
+"182 459 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 513 OFFCURVE",
+"96 555 OFFCURVE",
+"96 612 CURVE SMOOTH",
+"96 669 OFFCURVE",
+"129 708 OFFCURVE",
+"184 708 CURVE SMOOTH",
+"240 708 OFFCURVE",
+"269 665 OFFCURVE",
+"269 611 CURVE SMOOTH",
+"269 553 OFFCURVE",
+"237 513 OFFCURVE",
+"184 513 CURVE SMOOTH"
+);
+}
+);
+width = 363;
+}
+);
+unicode = 00B0;
+},
+{
+glyphname = bar;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"213 -123 LINE",
+"213 788 LINE",
+"154 788 LINE",
+"154 -123 LINE"
+);
+}
+);
+width = 367;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"223 -123 LINE",
+"223 788 LINE",
+"144 788 LINE",
+"144 -123 LINE"
+);
+}
+);
+width = 367;
+}
+);
+unicode = 007C;
+},
+{
+glyphname = brokenbar;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"154 788 LINE",
+"154 -123 LINE",
+"213 -123 LINE",
+"213 788 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"213 417 LINE",
+"213 787 LINE",
+"154 787 LINE",
+"154 417 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"213 -123 LINE",
+"213 247 LINE",
+"154 247 LINE",
+"154 -123 LINE"
+);
+}
+);
+width = 367;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"144 788 LINE",
+"144 -123 LINE",
+"223 -123 LINE",
+"223 788 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"223 377 LINE",
+"223 787 LINE",
+"144 787 LINE",
+"144 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"223 -122 LINE",
+"223 279 LINE",
+"144 279 LINE",
+"144 -122 LINE"
+);
+}
+);
+width = 367;
+}
+);
+unicode = 00A6;
+},
+{
+glyphname = dagger;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"281 -123 LINE",
+"281 10 OFFCURVE",
+"296 192 OFFCURVE",
+"334 268 CURVE",
+"293 334 OFFCURVE",
+"283 395 OFFCURVE",
+"283 472 CURVE",
+"388 468 OFFCURVE",
+"418 438 OFFCURVE",
+"462 438 CURVE SMOOTH",
+"502 438 OFFCURVE",
+"521 453 OFFCURVE",
+"521 484 CURVE SMOOTH",
+"521 517 OFFCURVE",
+"499 532 OFFCURVE",
+"460 532 CURVE SMOOTH",
+"418 532 OFFCURVE",
+"387 502 OFFCURVE",
+"283 496 CURVE",
+"289 620 OFFCURVE",
+"317 657 OFFCURVE",
+"317 705 CURVE SMOOTH",
+"317 744 OFFCURVE",
+"302 766 OFFCURVE",
+"269 766 CURVE SMOOTH",
+"238 766 OFFCURVE",
+"223 747 OFFCURVE",
+"223 707 CURVE SMOOTH",
+"223 657 OFFCURVE",
+"252 621 OFFCURVE",
+"257 496 CURVE",
+"153 502 OFFCURVE",
+"122 532 OFFCURVE",
+"80 532 CURVE SMOOTH",
+"41 532 OFFCURVE",
+"19 517 OFFCURVE",
+"19 484 CURVE SMOOTH",
+"19 453 OFFCURVE",
+"38 438 OFFCURVE",
+"78 438 CURVE SMOOTH",
+"122 438 OFFCURVE",
+"152 468 OFFCURVE",
+"257 472 CURVE",
+"257 395 OFFCURVE",
+"247 334 OFFCURVE",
+"206 268 CURVE",
+"244 192 OFFCURVE",
+"259 10 OFFCURVE",
+"259 -123 CURVE"
+);
+}
+);
+width = 541;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"286 -290 LINE",
+"286 -92 OFFCURVE",
+"303 147 OFFCURVE",
+"344 255 CURVE",
+"303 319 OFFCURVE",
+"293 389 OFFCURVE",
+"293 464 CURVE",
+"370 459 OFFCURVE",
+"405 420 OFFCURVE",
+"458 420 CURVE SMOOTH",
+"496 420 OFFCURVE",
+"521 440 OFFCURVE",
+"521 481 CURVE SMOOTH",
+"521 524 OFFCURVE",
+"492 544 OFFCURVE",
+"455 544 CURVE SMOOTH",
+"405 544 OFFCURVE",
+"369 506 OFFCURVE",
+"293 498 CURVE",
+"301 593 OFFCURVE",
+"337 638 OFFCURVE",
+"337 692 CURVE SMOOTH",
+"337 733 OFFCURVE",
+"316 763 OFFCURVE",
+"269 763 CURVE SMOOTH",
+"224 763 OFFCURVE",
+"203 736 OFFCURVE",
+"203 694 CURVE SMOOTH",
+"203 637 OFFCURVE",
+"241 594 OFFCURVE",
+"247 498 CURVE",
+"171 506 OFFCURVE",
+"135 544 OFFCURVE",
+"85 544 CURVE SMOOTH",
+"48 544 OFFCURVE",
+"19 524 OFFCURVE",
+"19 481 CURVE SMOOTH",
+"19 440 OFFCURVE",
+"44 420 OFFCURVE",
+"82 420 CURVE SMOOTH",
+"135 420 OFFCURVE",
+"170 459 OFFCURVE",
+"247 464 CURVE",
+"247 389 OFFCURVE",
+"237 319 OFFCURVE",
+"196 255 CURVE",
+"237 147 OFFCURVE",
+"254 -92 OFFCURVE",
+"254 -290 CURVE"
+);
+}
+);
+width = 541;
+}
+);
+unicode = 2020;
+},
+{
+glyphname = literSign;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"340 -11 OFFCURVE",
+"402 41 OFFCURVE",
+"445 123 CURVE",
+"425 136 LINE",
+"393 84 OFFCURVE",
+"359 38 OFFCURVE",
+"302 38 CURVE SMOOTH",
+"244 38 OFFCURVE",
+"221 87 OFFCURVE",
+"221 216 CURVE SMOOTH",
+"221 331 LINE",
+"318 424 OFFCURVE",
+"375 511 OFFCURVE",
+"375 623 CURVE SMOOTH",
+"375 710 OFFCURVE",
+"341 772 OFFCURVE",
+"268 772 CURVE SMOOTH",
+"176 772 OFFCURVE",
+"94 672 OFFCURVE",
+"94 447 CURVE SMOOTH",
+"94 293 LINE",
+"21 240 LINE",
+"35 217 LINE",
+"94 256 LINE",
+"94 186 LINE SMOOTH",
+"94 65 OFFCURVE",
+"140 -11 OFFCURVE",
+"249 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 503 LINE SMOOTH",
+"221 710 OFFCURVE",
+"238 742 OFFCURVE",
+"274 742 CURVE SMOOTH",
+"304 742 OFFCURVE",
+"333 719 OFFCURVE",
+"333 629 CURVE SMOOTH",
+"333 527 OFFCURVE",
+"296 457 OFFCURVE",
+"221 390 CURVE"
+);
+}
+);
+width = 465;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"365 -12 OFFCURVE",
+"428 34 OFFCURVE",
+"485 135 CURVE",
+"457 161 LINE",
+"419 106 OFFCURVE",
+"386 78 OFFCURVE",
+"337 78 CURVE SMOOTH",
+"270 78 OFFCURVE",
+"247 129 OFFCURVE",
+"247 257 CURVE SMOOTH",
+"247 334 LINE",
+"353 427 OFFCURVE",
+"414 509 OFFCURVE",
+"414 623 CURVE SMOOTH",
+"414 710 OFFCURVE",
+"379 779 OFFCURVE",
+"286 779 CURVE SMOOTH",
+"172 779 OFFCURVE",
+"97 675 OFFCURVE",
+"97 498 CURVE SMOOTH",
+"97 302 LINE",
+"19 251 LINE",
+"35 213 LINE",
+"97 250 LINE",
+"97 193 LINE SMOOTH",
+"97 67 OFFCURVE",
+"156 -12 OFFCURVE",
+"275 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"247 505 LINE SMOOTH",
+"247 683 OFFCURVE",
+"252 736 OFFCURVE",
+"297 736 CURVE SMOOTH",
+"340 736 OFFCURVE",
+"358 686 OFFCURVE",
+"358 624 CURVE SMOOTH",
+"358 524 OFFCURVE",
+"312 452 OFFCURVE",
+"247 400 CURVE"
+);
+}
+);
+width = 504;
+}
+);
+unicode = 2113;
+},
+{
+glyphname = daggerdbl;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"302 -123 OFFCURVE",
+"317 -102 OFFCURVE",
+"317 -62 CURVE SMOOTH",
+"317 -21 OFFCURVE",
+"289 11 OFFCURVE",
+"283 117 CURVE",
+"387 111 OFFCURVE",
+"418 81 OFFCURVE",
+"460 81 CURVE SMOOTH",
+"499 81 OFFCURVE",
+"521 96 OFFCURVE",
+"521 129 CURVE SMOOTH",
+"521 159 OFFCURVE",
+"502 175 OFFCURVE",
+"462 175 CURVE SMOOTH",
+"418 175 OFFCURVE",
+"388 145 OFFCURVE",
+"283 141 CURVE",
+"283 206 OFFCURVE",
+"293 266 OFFCURVE",
+"334 322 CURVE",
+"293 378 OFFCURVE",
+"283 437 OFFCURVE",
+"283 502 CURVE",
+"388 498 OFFCURVE",
+"418 468 OFFCURVE",
+"462 468 CURVE SMOOTH",
+"502 468 OFFCURVE",
+"521 483 OFFCURVE",
+"521 514 CURVE SMOOTH",
+"521 547 OFFCURVE",
+"499 562 OFFCURVE",
+"460 562 CURVE SMOOTH",
+"418 562 OFFCURVE",
+"387 532 OFFCURVE",
+"283 526 CURVE",
+"289 632 OFFCURVE",
+"317 663 OFFCURVE",
+"317 705 CURVE SMOOTH",
+"317 744 OFFCURVE",
+"302 766 OFFCURVE",
+"269 766 CURVE SMOOTH",
+"238 766 OFFCURVE",
+"223 747 OFFCURVE",
+"223 707 CURVE SMOOTH",
+"223 663 OFFCURVE",
+"252 633 OFFCURVE",
+"257 526 CURVE",
+"153 532 OFFCURVE",
+"122 562 OFFCURVE",
+"80 562 CURVE SMOOTH",
+"41 562 OFFCURVE",
+"19 547 OFFCURVE",
+"19 514 CURVE SMOOTH",
+"19 483 OFFCURVE",
+"38 468 OFFCURVE",
+"78 468 CURVE SMOOTH",
+"122 468 OFFCURVE",
+"152 498 OFFCURVE",
+"257 502 CURVE",
+"257 437 OFFCURVE",
+"247 378 OFFCURVE",
+"206 322 CURVE",
+"247 266 OFFCURVE",
+"257 206 OFFCURVE",
+"257 141 CURVE",
+"152 141 OFFCURVE",
+"122 175 OFFCURVE",
+"78 175 CURVE SMOOTH",
+"38 175 OFFCURVE",
+"19 160 OFFCURVE",
+"19 129 CURVE SMOOTH",
+"19 96 OFFCURVE",
+"41 81 OFFCURVE",
+"80 81 CURVE SMOOTH",
+"122 81 OFFCURVE",
+"153 108 OFFCURVE",
+"257 117 CURVE",
+"252 10 OFFCURVE",
+"223 -20 OFFCURVE",
+"223 -64 CURVE SMOOTH",
+"223 -104 OFFCURVE",
+"238 -123 OFFCURVE",
+"269 -123 CURVE SMOOTH"
+);
+}
+);
+width = 541;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"316 -290 OFFCURVE",
+"337 -260 OFFCURVE",
+"337 -219 CURVE SMOOTH",
+"337 -165 OFFCURVE",
+"301 -120 OFFCURVE",
+"293 -25 CURVE",
+"369 -33 OFFCURVE",
+"405 -71 OFFCURVE",
+"455 -71 CURVE SMOOTH",
+"492 -71 OFFCURVE",
+"521 -51 OFFCURVE",
+"521 -8 CURVE SMOOTH",
+"521 33 OFFCURVE",
+"496 53 OFFCURVE",
+"458 53 CURVE SMOOTH",
+"405 53 OFFCURVE",
+"370 14 OFFCURVE",
+"293 9 CURVE",
+"293 88 OFFCURVE",
+"303 169 OFFCURVE",
+"344 236 CURVE",
+"303 303 OFFCURVE",
+"293 385 OFFCURVE",
+"293 464 CURVE",
+"370 459 OFFCURVE",
+"405 420 OFFCURVE",
+"458 420 CURVE SMOOTH",
+"496 420 OFFCURVE",
+"521 440 OFFCURVE",
+"521 481 CURVE SMOOTH",
+"521 524 OFFCURVE",
+"492 544 OFFCURVE",
+"455 544 CURVE SMOOTH",
+"405 544 OFFCURVE",
+"369 506 OFFCURVE",
+"293 498 CURVE",
+"301 593 OFFCURVE",
+"337 638 OFFCURVE",
+"337 692 CURVE SMOOTH",
+"337 733 OFFCURVE",
+"316 763 OFFCURVE",
+"269 763 CURVE SMOOTH",
+"224 763 OFFCURVE",
+"203 736 OFFCURVE",
+"203 694 CURVE SMOOTH",
+"203 637 OFFCURVE",
+"241 594 OFFCURVE",
+"247 498 CURVE",
+"171 506 OFFCURVE",
+"135 544 OFFCURVE",
+"85 544 CURVE SMOOTH",
+"48 544 OFFCURVE",
+"19 524 OFFCURVE",
+"19 481 CURVE SMOOTH",
+"19 440 OFFCURVE",
+"44 420 OFFCURVE",
+"82 420 CURVE SMOOTH",
+"135 420 OFFCURVE",
+"170 459 OFFCURVE",
+"247 464 CURVE",
+"247 385 OFFCURVE",
+"237 303 OFFCURVE",
+"196 236 CURVE",
+"237 169 OFFCURVE",
+"247 88 OFFCURVE",
+"247 9 CURVE",
+"170 14 OFFCURVE",
+"135 53 OFFCURVE",
+"82 53 CURVE SMOOTH",
+"44 53 OFFCURVE",
+"19 33 OFFCURVE",
+"19 -8 CURVE SMOOTH",
+"19 -51 OFFCURVE",
+"48 -71 OFFCURVE",
+"85 -71 CURVE SMOOTH",
+"135 -71 OFFCURVE",
+"171 -33 OFFCURVE",
+"247 -25 CURVE",
+"241 -121 OFFCURVE",
+"203 -164 OFFCURVE",
+"203 -221 CURVE SMOOTH",
+"203 -263 OFFCURVE",
+"224 -290 OFFCURVE",
+"269 -290 CURVE SMOOTH"
+);
+}
+);
+width = 541;
+}
+);
+unicode = 2021;
+},
+{
+glyphname = estimated;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"581 -12 OFFCURVE",
+"701 45 OFFCURVE",
+"775 132 CURVE",
+"716 132 LINE",
+"651 57 OFFCURVE",
+"556 9 OFFCURVE",
+"449 9 CURVE SMOOTH",
+"350 9 OFFCURVE",
+"261 52 OFFCURVE",
+"196 119 CURVE SMOOTH",
+"190 125 OFFCURVE",
+"187 133 OFFCURVE",
+"187 142 CURVE SMOOTH",
+"187 345 LINE SMOOTH",
+"187 348 OFFCURVE",
+"189 349 OFFCURVE",
+"192 349 CURVE SMOOTH",
+"862 349 LINE",
+"862 352 OFFCURVE",
+"862 356 OFFCURVE",
+"862 359 CURVE SMOOTH",
+"862 565 OFFCURVE",
+"677 731 OFFCURVE",
+"448 731 CURVE SMOOTH",
+"220 731 OFFCURVE",
+"35 565 OFFCURVE",
+"35 359 CURVE SMOOTH",
+"35 154 OFFCURVE",
+"220 -12 OFFCURVE",
+"448 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 369 OFFCURVE",
+"187 373 OFFCURVE",
+"187 375 CURVE SMOOTH",
+"187 575 LINE SMOOTH",
+"187 585 OFFCURVE",
+"190 594 OFFCURVE",
+"197 600 CURVE",
+"262 666 OFFCURVE",
+"351 709 OFFCURVE",
+"449 709 CURVE SMOOTH",
+"547 709 OFFCURVE",
+"635 667 OFFCURVE",
+"700 604 CURVE SMOOTH",
+"707 597 OFFCURVE",
+"710 588 OFFCURVE",
+"710 579 CURVE SMOOTH",
+"710 375 LINE SMOOTH",
+"710 373 OFFCURVE",
+"709 369 OFFCURVE",
+"706 369 CURVE SMOOTH",
+"192 369 LINE SMOOTH"
+);
+}
+);
+width = 898;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"581 -12 OFFCURVE",
+"701 45 OFFCURVE",
+"775 132 CURVE",
+"716 132 LINE",
+"651 57 OFFCURVE",
+"556 9 OFFCURVE",
+"449 9 CURVE SMOOTH",
+"350 9 OFFCURVE",
+"261 52 OFFCURVE",
+"196 119 CURVE SMOOTH",
+"190 125 OFFCURVE",
+"187 133 OFFCURVE",
+"187 142 CURVE SMOOTH",
+"187 345 LINE SMOOTH",
+"187 348 OFFCURVE",
+"189 349 OFFCURVE",
+"192 349 CURVE SMOOTH",
+"862 349 LINE",
+"862 352 OFFCURVE",
+"862 356 OFFCURVE",
+"862 359 CURVE SMOOTH",
+"862 565 OFFCURVE",
+"677 731 OFFCURVE",
+"448 731 CURVE SMOOTH",
+"220 731 OFFCURVE",
+"35 565 OFFCURVE",
+"35 359 CURVE SMOOTH",
+"35 154 OFFCURVE",
+"220 -12 OFFCURVE",
+"448 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 369 OFFCURVE",
+"187 373 OFFCURVE",
+"187 375 CURVE SMOOTH",
+"187 575 LINE SMOOTH",
+"187 585 OFFCURVE",
+"190 594 OFFCURVE",
+"197 600 CURVE",
+"262 666 OFFCURVE",
+"351 709 OFFCURVE",
+"449 709 CURVE SMOOTH",
+"547 709 OFFCURVE",
+"635 667 OFFCURVE",
+"700 604 CURVE SMOOTH",
+"707 597 OFFCURVE",
+"710 588 OFFCURVE",
+"710 579 CURVE SMOOTH",
+"710 375 LINE SMOOTH",
+"710 373 OFFCURVE",
+"709 369 OFFCURVE",
+"706 369 CURVE SMOOTH",
+"192 369 LINE SMOOTH"
+);
+}
+);
+width = 898;
+}
+);
+unicode = 212E;
+},
+{
+glyphname = numero;
+lastChange = "2016-08-18 22:15:45 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = ordmasculine;
+transform = "{1, 0, 0, 1, 744, 0}";
+}
+);
+layerId = UUID0;
+width = 1082;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"793 533 OFFCURVE",
+"861 457 OFFCURVE",
+"946 457 CURVE SMOOTH",
+"1032 457 OFFCURVE",
+"1101 533 OFFCURVE",
+"1101 611 CURVE SMOOTH",
+"1101 688 OFFCURVE",
+"1032 764 OFFCURVE",
+"946 764 CURVE SMOOTH",
+"861 764 OFFCURVE",
+"793 688 OFFCURVE",
+"793 611 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"888 712 OFFCURVE",
+"903 735 OFFCURVE",
+"946 735 CURVE SMOOTH",
+"990 735 OFFCURVE",
+"1005 712 OFFCURVE",
+"1005 611 CURVE SMOOTH",
+"1005 509 OFFCURVE",
+"990 487 OFFCURVE",
+"946 487 CURVE SMOOTH",
+"903 487 OFFCURVE",
+"888 509 OFFCURVE",
+"888 611 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 15 LINE",
+"174 15 LINE",
+"174 754 LINE",
+"130 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"284 724 LINE",
+"284 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"632 -13 LINE",
+"676 -13 LINE",
+"676 754 LINE",
+"632 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 724 LINE",
+"776 724 LINE",
+"776 754 LINE",
+"532 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 754 LINE",
+"162 754 LINE",
+"174 641 LINE",
+"178 641 LINE",
+"632 -13 LINE",
+"662 -13 LINE",
+"632 309 LINE",
+"628 309 LINE"
+);
+}
+);
+};
+components = (
+{
+name = N;
+},
+{
+name = ordmasculine;
+transform = "{1, 0, 0, 1, 791, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1129;
+}
+);
+unicode = 2116;
+},
+{
+glyphname = servicemark;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"531 376 LINE",
+"633 710 LINE",
+"637 710 LINE",
+"637 403 LINE",
+"582 403 LINE",
+"582 380 LINE",
+"758 380 LINE",
+"758 403 LINE",
+"723 403 LINE",
+"723 732 LINE",
+"758 732 LINE",
+"758 754 LINE",
+"628 754 LINE",
+"547 494 LINE",
+"543 494 LINE",
+"466 754 LINE",
+"312 754 LINE",
+"312 732 LINE",
+"356 732 LINE",
+"356 403 LINE",
+"312 403 LINE",
+"312 380 LINE",
+"440 380 LINE",
+"440 403 LINE",
+"385 403 LINE",
+"385 710 LINE",
+"389 710 LINE",
+"494 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 371 OFFCURVE",
+"284 419 OFFCURVE",
+"284 497 CURVE SMOOTH",
+"284 569 OFFCURVE",
+"247 606 OFFCURVE",
+"171 624 CURVE SMOOTH",
+"119 636 OFFCURVE",
+"80 644 OFFCURVE",
+"80 682 CURVE SMOOTH",
+"80 714 OFFCURVE",
+"113 738 OFFCURVE",
+"157 738 CURVE SMOOTH",
+"203 738 OFFCURVE",
+"233 712 OFFCURVE",
+"251 656 CURVE",
+"269 656 LINE",
+"269 759 LINE",
+"251 759 LINE",
+"239 737 LINE",
+"215 755 OFFCURVE",
+"188 763 OFFCURVE",
+"158 763 CURVE SMOOTH",
+"98 763 OFFCURVE",
+"46 725 OFFCURVE",
+"46 653 CURVE SMOOTH",
+"46 594 OFFCURVE",
+"79 549 OFFCURVE",
+"155 533 CURVE SMOOTH",
+"214 521 OFFCURVE",
+"251 513 OFFCURVE",
+"251 465 CURVE SMOOTH",
+"251 429 OFFCURVE",
+"220 397 OFFCURVE",
+"164 397 CURVE SMOOTH",
+"99 397 OFFCURVE",
+"69 444 OFFCURVE",
+"58 484 CURVE",
+"40 484 LINE",
+"40 378 LINE",
+"57 378 LINE",
+"77 403 LINE",
+"101 381 OFFCURVE",
+"128 371 OFFCURVE",
+"163 371 CURVE SMOOTH"
+);
+}
+);
+width = 785;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"541 376 LINE",
+"633 677 LINE",
+"637 677 LINE",
+"637 408 LINE",
+"582 408 LINE",
+"582 380 LINE",
+"768 380 LINE",
+"768 408 LINE",
+"733 408 LINE",
+"733 727 LINE",
+"768 727 LINE",
+"768 754 LINE",
+"628 754 LINE",
+"547 494 LINE",
+"543 494 LINE",
+"466 754 LINE",
+"312 754 LINE",
+"312 727 LINE",
+"346 727 LINE",
+"346 408 LINE",
+"312 408 LINE",
+"312 380 LINE",
+"440 380 LINE",
+"440 408 LINE",
+"385 408 LINE",
+"385 679 LINE",
+"389 679 LINE",
+"484 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 371 OFFCURVE",
+"284 419 OFFCURVE",
+"284 497 CURVE SMOOTH",
+"284 572 OFFCURVE",
+"247 610 OFFCURVE",
+"171 629 CURVE SMOOTH",
+"96 648 OFFCURVE",
+"85 660 OFFCURVE",
+"85 687 CURVE SMOOTH",
+"85 713 OFFCURVE",
+"116 733 OFFCURVE",
+"157 733 CURVE SMOOTH",
+"203 733 OFFCURVE",
+"233 709 OFFCURVE",
+"251 656 CURVE",
+"269 656 LINE",
+"269 759 LINE",
+"251 759 LINE",
+"239 737 LINE",
+"215 755 OFFCURVE",
+"188 763 OFFCURVE",
+"158 763 CURVE SMOOTH",
+"98 763 OFFCURVE",
+"46 725 OFFCURVE",
+"46 653 CURVE SMOOTH",
+"46 592 OFFCURVE",
+"79 545 OFFCURVE",
+"155 528 CURVE SMOOTH",
+"233 511 OFFCURVE",
+"246 493 OFFCURVE",
+"246 460 CURVE SMOOTH",
+"246 430 OFFCURVE",
+"217 402 OFFCURVE",
+"164 402 CURVE SMOOTH",
+"99 402 OFFCURVE",
+"69 446 OFFCURVE",
+"58 484 CURVE",
+"40 484 LINE",
+"40 378 LINE",
+"57 378 LINE",
+"77 403 LINE",
+"101 381 OFFCURVE",
+"128 371 OFFCURVE",
+"163 371 CURVE SMOOTH"
+);
+}
+);
+width = 785;
+}
+);
+unicode = 2120;
+},
+{
+glyphname = cent;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"307 576 OFFCURVE",
+"329 566 OFFCURVE",
+"329 544 CURVE SMOOTH",
+"329 520 OFFCURVE",
+"305 516 OFFCURVE",
+"305 482 CURVE SMOOTH",
+"305 445 OFFCURVE",
+"335 426 OFFCURVE",
+"367 426 CURVE SMOOTH",
+"402 426 OFFCURVE",
+"427 450 OFFCURVE",
+"427 489 CURVE SMOOTH",
+"427 556 OFFCURVE",
+"355 603 OFFCURVE",
+"267 603 CURVE SMOOTH",
+"128 603 OFFCURVE",
+"27 487 OFFCURVE",
+"27 370 CURVE SMOOTH",
+"27 251 OFFCURVE",
+"132 136 OFFCURVE",
+"259 136 CURVE SMOOTH",
+"355 136 OFFCURVE",
+"419 201 OFFCURVE",
+"445 297 CURVE",
+"417 297 LINE",
+"381 202 OFFCURVE",
+"335 166 OFFCURVE",
+"262 166 CURVE SMOOTH",
+"185 166 OFFCURVE",
+"157 206 OFFCURVE",
+"157 368 CURVE SMOOTH",
+"157 539 OFFCURVE",
+"188 576 OFFCURVE",
+"266 576 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 6 LINE",
+"267 6 LINE",
+"267 734 LINE",
+"238 734 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"355 136 OFFCURVE",
+"419 201 OFFCURVE",
+"445 297 CURVE",
+"417 297 LINE",
+"381 202 OFFCURVE",
+"335 166 OFFCURVE",
+"262 166 CURVE SMOOTH",
+"185 166 OFFCURVE",
+"157 206 OFFCURVE",
+"157 368 CURVE SMOOTH",
+"157 539 OFFCURVE",
+"188 576 OFFCURVE",
+"266 576 CURVE SMOOTH",
+"307 576 OFFCURVE",
+"329 566 OFFCURVE",
+"329 544 CURVE SMOOTH",
+"329 520 OFFCURVE",
+"305 516 OFFCURVE",
+"305 482 CURVE SMOOTH",
+"305 445 OFFCURVE",
+"335 426 OFFCURVE",
+"367 426 CURVE SMOOTH",
+"402 426 OFFCURVE",
+"427 450 OFFCURVE",
+"427 489 CURVE SMOOTH",
+"427 556 OFFCURVE",
+"355 603 OFFCURVE",
+"267 603 CURVE SMOOTH",
+"128 603 OFFCURVE",
+"27 487 OFFCURVE",
+"27 370 CURVE SMOOTH",
+"27 251 OFFCURVE",
+"132 136 OFFCURVE",
+"259 136 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 6 LINE",
+"267 734 LINE",
+"238 734 LINE",
+"238 6 LINE"
+);
+}
+);
+width = 478;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"270 6 LINE",
+"299 6 LINE",
+"299 734 LINE",
+"270 734 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 570 OFFCURVE",
+"357 562 OFFCURVE",
+"357 546 CURVE SMOOTH",
+"357 525 OFFCURVE",
+"328 512 OFFCURVE",
+"328 471 CURVE SMOOTH",
+"328 430 OFFCURVE",
+"355 405 OFFCURVE",
+"395 405 CURVE SMOOTH",
+"437 405 OFFCURVE",
+"469 433 OFFCURVE",
+"469 479 CURVE SMOOTH",
+"469 551 OFFCURVE",
+"388 602 OFFCURVE",
+"293 602 CURVE SMOOTH",
+"149 602 OFFCURVE",
+"45 486 OFFCURVE",
+"45 370 CURVE SMOOTH",
+"45 250 OFFCURVE",
+"155 135 OFFCURVE",
+"292 135 CURVE SMOOTH",
+"395 135 OFFCURVE",
+"463 200 OFFCURVE",
+"490 296 CURVE",
+"457 296 LINE",
+"420 205 OFFCURVE",
+"372 170 OFFCURVE",
+"300 170 CURVE SMOOTH",
+"224 170 OFFCURVE",
+"200 209 OFFCURVE",
+"200 363 CURVE SMOOTH",
+"200 536 OFFCURVE",
+"230 570 OFFCURVE",
+"299 570 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"395 135 OFFCURVE",
+"463 200 OFFCURVE",
+"490 296 CURVE",
+"457 296 LINE",
+"420 205 OFFCURVE",
+"372 170 OFFCURVE",
+"300 170 CURVE SMOOTH",
+"224 170 OFFCURVE",
+"200 209 OFFCURVE",
+"200 363 CURVE SMOOTH",
+"200 536 OFFCURVE",
+"230 570 OFFCURVE",
+"299 570 CURVE SMOOTH",
+"339 570 OFFCURVE",
+"357 562 OFFCURVE",
+"357 546 CURVE SMOOTH",
+"357 525 OFFCURVE",
+"328 512 OFFCURVE",
+"328 471 CURVE SMOOTH",
+"328 430 OFFCURVE",
+"355 405 OFFCURVE",
+"395 405 CURVE SMOOTH",
+"437 405 OFFCURVE",
+"469 433 OFFCURVE",
+"469 479 CURVE SMOOTH",
+"469 551 OFFCURVE",
+"388 602 OFFCURVE",
+"293 602 CURVE SMOOTH",
+"149 602 OFFCURVE",
+"45 486 OFFCURVE",
+"45 370 CURVE SMOOTH",
+"45 250 OFFCURVE",
+"155 135 OFFCURVE",
+"292 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"299 6 LINE",
+"299 734 LINE",
+"270 734 LINE",
+"270 6 LINE"
+);
+}
+);
+width = 520;
+}
+);
+unicode = 00A2;
+},
+{
+glyphname = colonsign;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"355 136 OFFCURVE",
+"419 201 OFFCURVE",
+"445 297 CURVE",
+"417 297 LINE",
+"381 202 OFFCURVE",
+"335 166 OFFCURVE",
+"262 166 CURVE SMOOTH",
+"185 166 OFFCURVE",
+"157 206 OFFCURVE",
+"157 368 CURVE SMOOTH",
+"157 529 OFFCURVE",
+"188 576 OFFCURVE",
+"266 576 CURVE SMOOTH",
+"347 576 OFFCURVE",
+"383 515 OFFCURVE",
+"394 445 CURVE",
+"419 445 LINE",
+"419 603 LINE",
+"407 603 LINE",
+"380 571 LINE",
+"342 594 OFFCURVE",
+"319 603 OFFCURVE",
+"267 603 CURVE SMOOTH",
+"128 603 OFFCURVE",
+"27 487 OFFCURVE",
+"27 370 CURVE SMOOTH",
+"27 251 OFFCURVE",
+"132 136 OFFCURVE",
+"259 136 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 23 LINE",
+"320 733 LINE",
+"288 733 LINE",
+"130 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"236 23 LINE",
+"394 733 LINE",
+"362 733 LINE",
+"204 23 LINE"
+);
+}
+);
+width = 478;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"387 137 OFFCURVE",
+"444 201 OFFCURVE",
+"470 298 CURVE",
+"437 298 LINE",
+"404 209 OFFCURVE",
+"366 172 OFFCURVE",
+"297 172 CURVE SMOOTH",
+"224 172 OFFCURVE",
+"200 214 OFFCURVE",
+"200 364 CURVE SMOOTH",
+"200 525 OFFCURVE",
+"228 572 OFFCURVE",
+"300 572 CURVE SMOOTH",
+"393 572 OFFCURVE",
+"422 492 OFFCURVE",
+"422 440 CURVE",
+"458 440 LINE",
+"458 603 LINE",
+"441 603 LINE",
+"419 568 LINE",
+"387 591 OFFCURVE",
+"342 604 OFFCURVE",
+"293 604 CURVE SMOOTH",
+"149 604 OFFCURVE",
+"45 488 OFFCURVE",
+"45 372 CURVE SMOOTH",
+"45 252 OFFCURVE",
+"157 137 OFFCURVE",
+"289 137 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 23 LINE",
+"339 733 LINE",
+"307 733 LINE",
+"149 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 23 LINE",
+"413 733 LINE",
+"381 733 LINE",
+"223 23 LINE"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 20A1;
+},
+{
+glyphname = currency;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"464 135 OFFCURVE",
+"569 240 OFFCURVE",
+"569 368 CURVE SMOOTH",
+"569 496 OFFCURVE",
+"464 602 OFFCURVE",
+"334 602 CURVE SMOOTH",
+"204 602 OFFCURVE",
+"100 496 OFFCURVE",
+"100 368 CURVE SMOOTH",
+"100 240 OFFCURVE",
+"204 135 OFFCURVE",
+"334 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"211 235 LINE",
+"194 262 LINE",
+"100 152 LINE",
+"122 135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"212 500 LINE",
+"122 601 LINE",
+"100 584 LINE",
+"194 474 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 200 OFFCURVE",
+"165 275 OFFCURVE",
+"165 368 CURVE SMOOTH",
+"165 461 OFFCURVE",
+"240 537 OFFCURVE",
+"334 537 CURVE SMOOTH",
+"428 537 OFFCURVE",
+"504 461 OFFCURVE",
+"504 368 CURVE SMOOTH",
+"504 275 OFFCURVE",
+"428 200 OFFCURVE",
+"334 200 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 152 LINE",
+"475 262 LINE",
+"458 235 LINE",
+"547 135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 584 LINE",
+"547 601 LINE",
+"457 500 LINE",
+"475 474 LINE"
+);
+}
+);
+width = 669;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"464 135 OFFCURVE",
+"569 240 OFFCURVE",
+"569 368 CURVE SMOOTH",
+"569 496 OFFCURVE",
+"464 602 OFFCURVE",
+"334 602 CURVE SMOOTH",
+"204 602 OFFCURVE",
+"100 496 OFFCURVE",
+"100 368 CURVE SMOOTH",
+"100 240 OFFCURVE",
+"204 135 OFFCURVE",
+"334 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"231 225 LINE",
+"184 282 LINE",
+"90 172 LINE",
+"142 125 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"232 510 LINE",
+"142 611 LINE",
+"90 564 LINE",
+"184 454 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"248 215 OFFCURVE",
+"180 283 OFFCURVE",
+"180 368 CURVE SMOOTH",
+"180 453 OFFCURVE",
+"248 522 OFFCURVE",
+"334 522 CURVE SMOOTH",
+"420 522 OFFCURVE",
+"489 453 OFFCURVE",
+"489 368 CURVE SMOOTH",
+"489 283 OFFCURVE",
+"420 215 OFFCURVE",
+"334 215 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 172 LINE",
+"485 282 LINE",
+"438 225 LINE",
+"527 125 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 564 LINE",
+"527 611 LINE",
+"437 510 LINE",
+"485 454 LINE"
+);
+}
+);
+width = 669;
+}
+);
+unicode = 00A4;
+},
+{
+glyphname = dollar;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"405 -13 OFFCURVE",
+"499 82 OFFCURVE",
+"499 217 CURVE SMOOTH",
+"499 352 OFFCURVE",
+"405 390 OFFCURVE",
+"285 429 CURVE SMOOTH",
+"135 477 OFFCURVE",
+"110 502 OFFCURVE",
+"110 566 CURVE SMOOTH",
+"110 663 OFFCURVE",
+"189 703 OFFCURVE",
+"283 703 CURVE SMOOTH",
+"366 703 OFFCURVE",
+"416 672 OFFCURVE",
+"416 642 CURVE SMOOTH",
+"416 610 OFFCURVE",
+"362 620 OFFCURVE",
+"362 570 CURVE SMOOTH",
+"362 535 OFFCURVE",
+"389 522 OFFCURVE",
+"414 522 CURVE SMOOTH",
+"449 522 OFFCURVE",
+"473 549 OFFCURVE",
+"473 595 CURVE SMOOTH",
+"473 675 OFFCURVE",
+"400 733 OFFCURVE",
+"285 733 CURVE SMOOTH",
+"158 733 OFFCURVE",
+"48 663 OFFCURVE",
+"48 521 CURVE SMOOTH",
+"48 397 OFFCURVE",
+"133 347 OFFCURVE",
+"253 316 CURVE SMOOTH",
+"375 285 OFFCURVE",
+"440 267 OFFCURVE",
+"440 175 CURVE SMOOTH",
+"440 79 OFFCURVE",
+"368 17 OFFCURVE",
+"245 17 CURVE SMOOTH",
+"148 17 OFFCURVE",
+"90 56 OFFCURVE",
+"90 82 CURVE SMOOTH",
+"90 110 OFFCURVE",
+"157 103 OFFCURVE",
+"157 162 CURVE SMOOTH",
+"157 195 OFFCURVE",
+"135 216 OFFCURVE",
+"97 216 CURVE SMOOTH",
+"49 216 OFFCURVE",
+"23 181 OFFCURVE",
+"23 135 CURVE SMOOTH",
+"23 50 OFFCURVE",
+"112 -13 OFFCURVE",
+"243 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 -113 LINE",
+"222 801 LINE",
+"193 801 LINE",
+"193 -113 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"334 -113 LINE",
+"334 801 LINE",
+"305 801 LINE",
+"305 -113 LINE"
+);
+}
+);
+width = 556;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"363 774 OFFCURVE",
+"363 774 OFFCURVE",
+"363 757 CURVE SMOOTH",
+"363 732 OFFCURVE",
+"363 732 OFFCURVE",
+"320 732 CURVE SMOOTH",
+"301 732 OFFCURVE",
+"281 730 OFFCURVE",
+"276 730 CURVE SMOOTH",
+"259 729 OFFCURVE",
+"258 730 OFFCURVE",
+"259 754 CURVE",
+"261 772 OFFCURVE",
+"261 774 OFFCURVE",
+"256 779 CURVE SMOOTH",
+"251 786 OFFCURVE",
+"241 786 OFFCURVE",
+"234 779 CURVE SMOOTH",
+"228 774 OFFCURVE",
+"228 772 OFFCURVE",
+"230 752 CURVE SMOOTH",
+"233 724 OFFCURVE",
+"230 720 OFFCURVE",
+"217 716 CURVE SMOOTH",
+"211 715 OFFCURVE",
+"202 712 OFFCURVE",
+"193 706 CURVE SMOOTH",
+"186 703 OFFCURVE",
+"178 699 OFFCURVE",
+"178 699 CURVE",
+"177 699 OFFCURVE",
+"168 695 OFFCURVE",
+"157 687 CURVE SMOOTH",
+"137 676 OFFCURVE",
+"101 644 OFFCURVE",
+"100 637 CURVE",
+"100 635 OFFCURVE",
+"97 630 OFFCURVE",
+"92 625 CURVE SMOOTH",
+"87 620 OFFCURVE",
+"83 613 OFFCURVE",
+"81 610 CURVE",
+"80 606 OFFCURVE",
+"75 597 OFFCURVE",
+"72 589 CURVE",
+"59 571 OFFCURVE",
+"51 525 OFFCURVE",
+"56 509 CURVE",
+"56 503 OFFCURVE",
+"58 496 OFFCURVE",
+"58 489 CURVE SMOOTH",
+"58 481 OFFCURVE",
+"59 470 OFFCURVE",
+"66 442 CURVE SMOOTH",
+"72 424 OFFCURVE",
+"82 405 OFFCURVE",
+"106 382 CURVE SMOOTH",
+"129 357 OFFCURVE",
+"142 349 OFFCURVE",
+"163 337 CURVE SMOOTH",
+"177 329 OFFCURVE",
+"208 317 OFFCURVE",
+"222 314 CURVE",
+"225 312 OFFCURVE",
+"228 310 OFFCURVE",
+"230 305 CURVE",
+"230 300 OFFCURVE",
+"230 298 OFFCURVE",
+"230 290 CURVE SMOOTH",
+"230 284 OFFCURVE",
+"228 266 OFFCURVE",
+"228 249 CURVE SMOOTH",
+"227 230 OFFCURVE",
+"227 176 OFFCURVE",
+"227 129 CURVE",
+"225 80 OFFCURVE",
+"224 38 OFFCURVE",
+"224 35 CURVE",
+"222 30 OFFCURVE",
+"220 27 OFFCURVE",
+"217 27 CURVE SMOOTH",
+"210 26 OFFCURVE",
+"185 30 OFFCURVE",
+"177 36 CURVE SMOOTH",
+"174 38 OFFCURVE",
+"169 38 OFFCURVE",
+"168 38 CURVE SMOOTH",
+"163 38 OFFCURVE",
+"127 58 OFFCURVE",
+"117 68 CURVE",
+"104 78 OFFCURVE",
+"100 89 OFFCURVE",
+"106 95 CURVE",
+"106 100 OFFCURVE",
+"118 105 OFFCURVE",
+"131 109 CURVE SMOOTH",
+"156 115 OFFCURVE",
+"175 129 OFFCURVE",
+"186 153 CURVE SMOOTH",
+"191 165 OFFCURVE",
+"193 168 OFFCURVE",
+"193 182 CURVE SMOOTH",
+"193 204 OFFCURVE",
+"188 217 OFFCURVE",
+"174 230 CURVE SMOOTH",
+"161 244 OFFCURVE",
+"151 250 OFFCURVE",
+"135 255 CURVE SMOOTH",
+"120 259 OFFCURVE",
+"123 259 OFFCURVE",
+"101 258 CURVE",
+"68 255 OFFCURVE",
+"34 224 OFFCURVE",
+"24 187 CURVE SMOOTH",
+"21 171 OFFCURVE",
+"24 136 OFFCURVE",
+"29 119 CURVE SMOOTH",
+"33 112 OFFCURVE",
+"36 105 OFFCURVE",
+"38 103 CURVE SMOOTH",
+"39 102 OFFCURVE",
+"42 95 OFFCURVE",
+"46 86 CURVE SMOOTH",
+"51 78 OFFCURVE",
+"56 72 OFFCURVE",
+"58 72 CURVE",
+"58 70 OFFCURVE",
+"66 63 OFFCURVE",
+"75 56 CURVE SMOOTH",
+"96 36 OFFCURVE",
+"107 29 OFFCURVE",
+"144 16 CURVE SMOOTH",
+"170 5 OFFCURVE",
+"182 2 OFFCURVE",
+"203 1 CURVE SMOOTH",
+"225 -1 OFFCURVE",
+"225 -5 OFFCURVE",
+"225 -24 CURVE",
+"227 -30 OFFCURVE",
+"227 -42 OFFCURVE",
+"227 -49 CURVE",
+"225 -55 OFFCURVE",
+"225 -72 OFFCURVE",
+"224 -84 CURVE",
+"224 -108 LINE",
+"228 -115 LINE SMOOTH",
+"233 -120 OFFCURVE",
+"236 -120 OFFCURVE",
+"242 -120 CURVE SMOOTH",
+"247 -120 OFFCURVE",
+"253 -118 OFFCURVE",
+"254 -117 CURVE SMOOTH",
+"258 -113 OFFCURVE",
+"258 -106 OFFCURVE",
+"256 -55 CURVE",
+"256 -24 OFFCURVE",
+"256 -10 OFFCURVE",
+"256 -8 CURVE SMOOTH",
+"256 -7 OFFCURVE",
+"262 -5 OFFCURVE",
+"283 -5 CURVE SMOOTH",
+"296 -5 OFFCURVE",
+"318 -5 OFFCURVE",
+"329 -3 CURVE SMOOTH",
+"355 -1 OFFCURVE",
+"355 -3 OFFCURVE",
+"360 -20 CURVE",
+"360 -29 OFFCURVE",
+"360 -32 OFFCURVE",
+"360 -57 CURVE",
+"355 -92 OFFCURVE",
+"355 -108 OFFCURVE",
+"361 -115 CURVE SMOOTH",
+"366 -123 OFFCURVE",
+"384 -122 OFFCURVE",
+"389 -109 CURVE",
+"389 -106 OFFCURVE",
+"389 -98 OFFCURVE",
+"389 -89 CURVE SMOOTH",
+"386 -42 OFFCURVE",
+"388 -5 OFFCURVE",
+"391 2 CURVE",
+"391 4 OFFCURVE",
+"401 7 OFFCURVE",
+"410 9 CURVE SMOOTH",
+"426 13 OFFCURVE",
+"462 29 OFFCURVE",
+"471 35 CURVE SMOOTH",
+"474 36 OFFCURVE",
+"476 38 OFFCURVE",
+"478 38 CURVE SMOOTH",
+"479 38 OFFCURVE",
+"484 43 OFFCURVE",
+"491 46 CURVE",
+"496 52 OFFCURVE",
+"503 56 OFFCURVE",
+"503 56 CURVE",
+"503 56 OFFCURVE",
+"531 83 OFFCURVE",
+"541 97 CURVE",
+"555 112 OFFCURVE",
+"562 119 OFFCURVE",
+"569 140 CURVE",
+"578 163 OFFCURVE",
+"583 176 OFFCURVE",
+"588 212 CURVE",
+"588 238 OFFCURVE",
+"588 239 OFFCURVE",
+"588 255 CURVE",
+"583 276 OFFCURVE",
+"574 303 OFFCURVE",
+"566 320 CURVE SMOOTH",
+"560 331 OFFCURVE",
+"552 339 OFFCURVE",
+"532 359 CURVE SMOOTH",
+"510 382 OFFCURVE",
+"504 388 OFFCURVE",
+"493 393 CURVE SMOOTH",
+"484 396 OFFCURVE",
+"476 400 OFFCURVE",
+"473 403 CURVE SMOOTH",
+"471 405 OFFCURVE",
+"464 408 OFFCURVE",
+"459 410 CURVE SMOOTH",
+"454 411 OFFCURVE",
+"444 415 OFFCURVE",
+"436 419 CURVE SMOOTH",
+"428 422 OFFCURVE",
+"415 425 OFFCURVE",
+"408 427 CURVE SMOOTH",
+"388 432 OFFCURVE",
+"388 432 OFFCURVE",
+"389 458 CURVE SMOOTH",
+"389 469 OFFCURVE",
+"389 504 OFFCURVE",
+"391 537 CURVE",
+"393 670 OFFCURVE",
+"393 686 OFFCURVE",
+"403 689 CURVE",
+"403 693 OFFCURVE",
+"416 690 OFFCURVE",
+"428 684 CURVE",
+"441 681 OFFCURVE",
+"454 676 OFFCURVE",
+"454 674 CURVE",
+"456 672 OFFCURVE",
+"461 669 OFFCURVE",
+"464 667 CURVE SMOOTH",
+"474 662 OFFCURVE",
+"482 645 OFFCURVE",
+"479 633 CURVE",
+"479 630 OFFCURVE",
+"473 627 OFFCURVE",
+"456 619 CURVE SMOOTH",
+"425 603 OFFCURVE",
+"415 591 OFFCURVE",
+"410 564 CURVE",
+"404 542 OFFCURVE",
+"410 527 OFFCURVE",
+"430 509 CURVE SMOOTH",
+"447 492 OFFCURVE",
+"463 486 OFFCURVE",
+"490 487 CURVE",
+"512 489 OFFCURVE",
+"530 500 OFFCURVE",
+"546 523 CURVE SMOOTH",
+"557 540 OFFCURVE",
+"560 577 OFFCURVE",
+"554 608 CURVE",
+"550 620 OFFCURVE",
+"547 627 OFFCURVE",
+"538 640 CURVE SMOOTH",
+"525 659 OFFCURVE",
+"501 682 OFFCURVE",
+"491 689 CURVE",
+"488 690 OFFCURVE",
+"484 693 OFFCURVE",
+"482 695 CURVE",
+"482 696 OFFCURVE",
+"450 712 OFFCURVE",
+"448 712 CURVE SMOOTH",
+"447 712 OFFCURVE",
+"444 713 OFFCURVE",
+"440 715 CURVE SMOOTH",
+"437 716 OFFCURVE",
+"425 720 OFFCURVE",
+"415 723 CURVE SMOOTH",
+"393 730 OFFCURVE",
+"388 735 OFFCURVE",
+"389 743 CURVE",
+"391 745 OFFCURVE",
+"391 754 OFFCURVE",
+"393 762 CURVE",
+"393 779 OFFCURVE",
+"391 783 OFFCURVE",
+"380 784 CURVE",
+"374 786 OFFCURVE",
+"372 784 OFFCURVE",
+"368 779 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 695 OFFCURVE",
+"361 681 OFFCURVE",
+"361 564 CURVE SMOOTH",
+"361 445 OFFCURVE",
+"361 447 OFFCURVE",
+"349 445 CURVE",
+"340 445 OFFCURVE",
+"261 464 OFFCURVE",
+"259 469 CURVE SMOOTH",
+"258 470 OFFCURVE",
+"256 496 OFFCURVE",
+"256 503 CURVE SMOOTH",
+"256 504 OFFCURVE",
+"256 547 OFFCURVE",
+"258 596 CURVE",
+"258 669 OFFCURVE",
+"259 686 OFFCURVE",
+"261 689 CURVE SMOOTH",
+"266 698 OFFCURVE",
+"285 701 OFFCURVE",
+"327 701 CURVE SMOOTH",
+"347 701 OFFCURVE",
+"354 701 OFFCURVE",
+"354 698 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"227 674 OFFCURVE",
+"227 652 OFFCURVE",
+"227 608 CURVE SMOOTH",
+"227 572 OFFCURVE",
+"227 535 OFFCURVE",
+"227 527 CURVE SMOOTH",
+"228 509 OFFCURVE",
+"225 481 OFFCURVE",
+"222 478 CURVE SMOOTH",
+"219 476 OFFCURVE",
+"207 478 OFFCURVE",
+"194 483 CURVE",
+"190 486 OFFCURVE",
+"182 489 OFFCURVE",
+"177 492 CURVE SMOOTH",
+"160 498 OFFCURVE",
+"141 513 OFFCURVE",
+"132 529 CURVE SMOOTH",
+"127 538 OFFCURVE",
+"120 559 OFFCURVE",
+"118 571 CURVE",
+"118 591 OFFCURVE",
+"118 616 OFFCURVE",
+"141 633 CURVE",
+"151 645 OFFCURVE",
+"178 664 OFFCURVE",
+"186 669 CURVE",
+"190 670 OFFCURVE",
+"200 674 OFFCURVE",
+"202 678 CURVE",
+"202 682 OFFCURVE",
+"202 682 OFFCURVE",
+"225 676 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"325 288 OFFCURVE",
+"331 286 OFFCURVE",
+"344 281 CURVE",
+"364 275 OFFCURVE",
+"364 273 OFFCURVE",
+"361 238 CURVE",
+"361 224 OFFCURVE",
+"360 195 OFFCURVE",
+"360 174 CURVE SMOOTH",
+"361 33 OFFCURVE",
+"361 30 OFFCURVE",
+"352 27 CURVE SMOOTH",
+"347 26 OFFCURVE",
+"313 21 OFFCURVE",
+"300 21 CURVE SMOOTH",
+"292 21 OFFCURVE",
+"279 21 OFFCURVE",
+"273 22 CURVE SMOOTH",
+"254 24 OFFCURVE",
+"254 24 OFFCURVE",
+"254 86 CURVE SMOOTH",
+"254 115 OFFCURVE",
+"256 157 OFFCURVE",
+"256 183 CURVE SMOOTH",
+"256 239 OFFCURVE",
+"256 293 OFFCURVE",
+"256 297 CURVE SMOOTH",
+"256 300 OFFCURVE",
+"259 300 OFFCURVE",
+"290 295 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 246 OFFCURVE",
+"462 241 OFFCURVE",
+"478 229 CURVE SMOOTH",
+"496 216 OFFCURVE",
+"496 207 OFFCURVE",
+"504 195 CURVE",
+"510 185 OFFCURVE",
+"513 163 OFFCURVE",
+"513 149 CURVE SMOOTH",
+"513 132 OFFCURVE",
+"504 109 OFFCURVE",
+"488 89 CURVE",
+"474 70 OFFCURVE",
+"423 41 OFFCURVE",
+"402 39 CURVE",
+"393 39 OFFCURVE",
+"393 39 OFFCURVE",
+"389 44 CURVE",
+"388 49 OFFCURVE",
+"389 255 OFFCURVE",
+"391 261 CURVE",
+"394 266 OFFCURVE",
+"403 264 OFFCURVE",
+"427 256 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"483 -10 OFFCURVE",
+"586 89 OFFCURVE",
+"586 226 CURVE SMOOTH",
+"586 375 OFFCURVE",
+"463 412 OFFCURVE",
+"314 453 CURVE SMOOTH",
+"162 495 OFFCURVE",
+"118 513 OFFCURVE",
+"118 575 CURVE SMOOTH",
+"118 663 OFFCURVE",
+"207 697 OFFCURVE",
+"314 697 CURVE SMOOTH",
+"415 697 OFFCURVE",
+"479 667 OFFCURVE",
+"479 639 CURVE SMOOTH",
+"479 610 OFFCURVE",
+"413 609 OFFCURVE",
+"413 547 CURVE SMOOTH",
+"413 502 OFFCURVE",
+"448 485 OFFCURVE",
+"482 485 CURVE SMOOTH",
+"528 485 OFFCURVE",
+"559 517 OFFCURVE",
+"559 570 CURVE SMOOTH",
+"559 664 OFFCURVE",
+"462 733 OFFCURVE",
+"318 733 CURVE SMOOTH",
+"173 733 OFFCURVE",
+"49 664 OFFCURVE",
+"49 517 CURVE SMOOTH",
+"49 372 OFFCURVE",
+"170 322 OFFCURVE",
+"281 294 CURVE SMOOTH",
+"388 267 OFFCURVE",
+"514 254 OFFCURVE",
+"514 156 CURVE SMOOTH",
+"514 80 OFFCURVE",
+"437 26 OFFCURVE",
+"298 26 CURVE SMOOTH",
+"181 26 OFFCURVE",
+"107 64 OFFCURVE",
+"107 90 CURVE SMOOTH",
+"107 118 OFFCURVE",
+"191 104 OFFCURVE",
+"191 181 CURVE SMOOTH",
+"191 227 OFFCURVE",
+"160 257 OFFCURVE",
+"114 257 CURVE SMOOTH",
+"56 257 OFFCURVE",
+"23 211 OFFCURVE",
+"23 157 CURVE SMOOTH",
+"23 57 OFFCURVE",
+"138 -10 OFFCURVE",
+"294 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"269 -113 LINE",
+"269 804 LINE",
+"229 804 LINE",
+"229 -113 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 -113 LINE",
+"391 804 LINE",
+"351 804 LINE",
+"351 -113 LINE"
+);
+}
+);
+width = 594;
+}
+);
+unicode = 0024;
+},
+{
+glyphname = euro;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"415 -13 OFFCURVE",
+"461 14 OFFCURVE",
+"481 40 CURVE",
+"521 0 LINE",
+"546 0 LINE",
+"546 179 LINE",
+"512 179 LINE",
+"497 86 OFFCURVE",
+"448 17 OFFCURVE",
+"356 17 CURVE SMOOTH",
+"271 17 OFFCURVE",
+"252 165 OFFCURVE",
+"251 279 CURVE",
+"485 279 LINE",
+"485 325 LINE",
+"251 325 LINE",
+"251 407 LINE",
+"485 407 LINE",
+"485 451 LINE",
+"251 451 LINE",
+"251 614 OFFCURVE",
+"288 703 OFFCURVE",
+"369 703 CURVE SMOOTH",
+"449 703 OFFCURVE",
+"497 633 OFFCURVE",
+"512 540 CURVE",
+"546 540 LINE",
+"546 733 LINE",
+"521 733 LINE",
+"483 679 LINE",
+"464 703 OFFCURVE",
+"421 734 OFFCURVE",
+"357 734 CURVE SMOOTH",
+"214 734 OFFCURVE",
+"135 587 OFFCURVE",
+"110 451 CURVE",
+"26 451 LINE",
+"26 407 LINE",
+"102 407 LINE",
+"101 392 OFFCURVE",
+"101 375 OFFCURVE",
+"101 360 CURVE SMOOTH",
+"101 325 LINE",
+"26 325 LINE",
+"26 279 LINE",
+"108 279 LINE",
+"130 139 OFFCURVE",
+"209 -13 OFFCURVE",
+"357 -13 CURVE SMOOTH"
+);
+}
+);
+width = 581;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"466 -13 OFFCURVE",
+"517 14 OFFCURVE",
+"541 40 CURVE",
+"581 0 LINE",
+"606 0 LINE",
+"606 179 LINE",
+"572 179 LINE",
+"556 95 OFFCURVE",
+"503 22 OFFCURVE",
+"423 22 CURVE SMOOTH",
+"310 22 OFFCURVE",
+"292 169 OFFCURVE",
+"291 279 CURVE",
+"525 279 LINE",
+"525 330 LINE",
+"291 330 LINE",
+"291 402 LINE",
+"525 402 LINE",
+"525 451 LINE",
+"291 451 LINE",
+"291 605 OFFCURVE",
+"328 698 OFFCURVE",
+"422 698 CURVE SMOOTH",
+"506 698 OFFCURVE",
+"555 625 OFFCURVE",
+"572 540 CURVE",
+"606 540 LINE",
+"606 733 LINE",
+"581 733 LINE",
+"543 679 LINE",
+"520 703 OFFCURVE",
+"472 734 OFFCURVE",
+"396 734 CURVE SMOOTH",
+"229 734 OFFCURVE",
+"138 584 OFFCURVE",
+"110 451 CURVE",
+"26 451 LINE",
+"26 402 LINE",
+"102 402 LINE",
+"101 389 OFFCURVE",
+"101 373 OFFCURVE",
+"101 360 CURVE SMOOTH",
+"101 330 LINE",
+"26 330 LINE",
+"26 279 LINE",
+"108 279 LINE",
+"134 139 OFFCURVE",
+"226 -13 OFFCURVE",
+"395 -13 CURVE SMOOTH"
+);
+}
+);
+width = 651;
+}
+);
+unicode = 20AC;
+},
+{
+glyphname = franc;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"372 0 LINE",
+"372 25 LINE",
+"262 25 LINE",
+"262 155 LINE",
+"372 155 LINE",
+"372 199 LINE",
+"262 199 LINE",
+"262 383 LINE",
+"383 382 OFFCURVE",
+"414 347 OFFCURVE",
+"417 236 CURVE",
+"452 236 LINE",
+"452 546 LINE",
+"417 546 LINE",
+"417 439 OFFCURVE",
+"383 408 OFFCURVE",
+"262 408 CURVE",
+"262 729 LINE",
+"428 729 LINE SMOOTH",
+"527 729 OFFCURVE",
+"584 626 OFFCURVE",
+"586 509 CURVE",
+"621 509 LINE",
+"621 754 LINE",
+"10 754 LINE",
+"10 729 LINE",
+"128 729 LINE",
+"128 199 LINE",
+"10 199 LINE",
+"10 155 LINE",
+"128 155 LINE",
+"128 25 LINE",
+"10 25 LINE",
+"10 0 LINE"
+);
+}
+);
+width = 642;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"401 0 LINE",
+"401 30 LINE",
+"273 30 LINE",
+"273 150 LINE",
+"402 150 LINE",
+"402 199 LINE",
+"273 199 LINE",
+"273 365 LINE",
+"402 364 OFFCURVE",
+"450 320 OFFCURVE",
+"452 225 CURVE",
+"492 225 LINE",
+"492 525 LINE",
+"452 525 LINE",
+"450 437 OFFCURVE",
+"402 396 OFFCURVE",
+"273 395 CURVE",
+"273 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 639 OFFCURVE",
+"606 539 CURVE",
+"646 539 LINE",
+"646 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 199 LINE",
+"20 199 LINE",
+"20 150 LINE",
+"115 150 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+}
+);
+width = 702;
+}
+);
+unicode = 20A3;
+},
+{
+glyphname = lira;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"157 -20 OFFCURVE",
+"206 15 OFFCURVE",
+"226 54 CURVE",
+"295 -7 OFFCURVE",
+"335 -20 OFFCURVE",
+"379 -20 CURVE SMOOTH",
+"512 -20 OFFCURVE",
+"531 101 OFFCURVE",
+"531 204 CURVE",
+"507 204 LINE",
+"503 113 OFFCURVE",
+"451 79 OFFCURVE",
+"377 79 CURVE SMOOTH",
+"335 79 OFFCURVE",
+"289 90 OFFCURVE",
+"250 111 CURVE",
+"274 167 OFFCURVE",
+"286 225 OFFCURVE",
+"286 286 CURVE SMOOTH",
+"286 398 OFFCURVE",
+"246 485 OFFCURVE",
+"246 571 CURVE SMOOTH",
+"246 649 OFFCURVE",
+"279 703 OFFCURVE",
+"363 703 CURVE SMOOTH",
+"432 703 OFFCURVE",
+"464 666 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 612 OFFCURVE",
+"406 616 OFFCURVE",
+"406 568 CURVE SMOOTH",
+"406 540 OFFCURVE",
+"425 519 OFFCURVE",
+"458 519 CURVE SMOOTH",
+"501 519 OFFCURVE",
+"521 553 OFFCURVE",
+"521 596 CURVE SMOOTH",
+"521 679 OFFCURVE",
+"447 733 OFFCURVE",
+"350 733 CURVE SMOOTH",
+"206 733 OFFCURVE",
+"134 615 OFFCURVE",
+"134 470 CURVE SMOOTH",
+"134 330 OFFCURVE",
+"201 242 OFFCURVE",
+"201 154 CURVE",
+"201 145 OFFCURVE",
+"201 135 OFFCURVE",
+"199 126 CURVE",
+"172 135 OFFCURVE",
+"143 144 OFFCURVE",
+"114 144 CURVE SMOOTH",
+"64 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 60 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"49 -20 OFFCURVE",
+"102 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"75 10 OFFCURVE",
+"53 28 OFFCURVE",
+"53 58 CURVE SMOOTH",
+"53 91 OFFCURVE",
+"80 110 OFFCURVE",
+"109 110 CURVE SMOOTH",
+"134 110 OFFCURVE",
+"172 96 OFFCURVE",
+"191 78 CURVE",
+"178 47 OFFCURVE",
+"140 10 OFFCURVE",
+"102 10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 276 LINE",
+"415 320 LINE",
+"41 320 LINE",
+"41 276 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 396 LINE",
+"415 440 LINE",
+"41 440 LINE",
+"41 396 LINE"
+);
+}
+);
+width = 559;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"53 91 OFFCURVE",
+"80 110 OFFCURVE",
+"109 110 CURVE SMOOTH",
+"134 110 OFFCURVE",
+"172 96 OFFCURVE",
+"191 78 CURVE",
+"178 47 OFFCURVE",
+"140 10 OFFCURVE",
+"102 10 CURVE SMOOTH",
+"75 10 OFFCURVE",
+"53 28 OFFCURVE",
+"53 58 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 145 OFFCURVE",
+"201 135 OFFCURVE",
+"199 126 CURVE",
+"172 135 OFFCURVE",
+"143 144 OFFCURVE",
+"114 144 CURVE SMOOTH",
+"64 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 60 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"49 -20 OFFCURVE",
+"102 -20 CURVE SMOOTH",
+"157 -20 OFFCURVE",
+"206 15 OFFCURVE",
+"226 54 CURVE",
+"295 -7 OFFCURVE",
+"335 -20 OFFCURVE",
+"379 -20 CURVE SMOOTH",
+"512 -20 OFFCURVE",
+"531 101 OFFCURVE",
+"531 204 CURVE",
+"507 204 LINE",
+"503 113 OFFCURVE",
+"451 79 OFFCURVE",
+"377 79 CURVE SMOOTH",
+"335 79 OFFCURVE",
+"289 90 OFFCURVE",
+"250 111 CURVE",
+"274 167 OFFCURVE",
+"286 225 OFFCURVE",
+"286 286 CURVE SMOOTH",
+"286 398 OFFCURVE",
+"246 485 OFFCURVE",
+"246 571 CURVE SMOOTH",
+"246 649 OFFCURVE",
+"279 703 OFFCURVE",
+"363 703 CURVE SMOOTH",
+"432 703 OFFCURVE",
+"464 666 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 612 OFFCURVE",
+"406 616 OFFCURVE",
+"406 568 CURVE SMOOTH",
+"406 540 OFFCURVE",
+"425 519 OFFCURVE",
+"458 519 CURVE SMOOTH",
+"501 519 OFFCURVE",
+"521 553 OFFCURVE",
+"521 596 CURVE SMOOTH",
+"521 679 OFFCURVE",
+"447 733 OFFCURVE",
+"350 733 CURVE SMOOTH",
+"206 733 OFFCURVE",
+"134 615 OFFCURVE",
+"134 470 CURVE SMOOTH",
+"134 330 OFFCURVE",
+"201 242 OFFCURVE",
+"201 154 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"41 396 LINE",
+"415 396 LINE",
+"415 440 LINE",
+"41 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"41 276 LINE",
+"415 276 LINE",
+"415 320 LINE",
+"41 320 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"165 -20 OFFCURVE",
+"224 17 OFFCURVE",
+"246 54 CURVE",
+"301 -3 OFFCURVE",
+"342 -20 OFFCURVE",
+"386 -20 CURVE SMOOTH",
+"508 -20 OFFCURVE",
+"546 113 OFFCURVE",
+"546 204 CURVE",
+"507 204 LINE",
+"502 122 OFFCURVE",
+"447 99 OFFCURVE",
+"374 99 CURVE SMOOTH",
+"343 99 OFFCURVE",
+"303 103 OFFCURVE",
+"270 111 CURVE",
+"294 167 OFFCURVE",
+"306 225 OFFCURVE",
+"306 286 CURVE SMOOTH",
+"306 397 OFFCURVE",
+"266 486 OFFCURVE",
+"266 569 CURVE SMOOTH",
+"266 644 OFFCURVE",
+"298 698 OFFCURVE",
+"373 698 CURVE SMOOTH",
+"429 698 OFFCURVE",
+"464 667 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 611 OFFCURVE",
+"406 614 OFFCURVE",
+"406 563 CURVE SMOOTH",
+"406 532 OFFCURVE",
+"427 509 OFFCURVE",
+"463 509 CURVE SMOOTH",
+"510 509 OFFCURVE",
+"531 548 OFFCURVE",
+"531 593 CURVE SMOOTH",
+"531 681 OFFCURVE",
+"453 733 OFFCURVE",
+"349 733 CURVE SMOOTH",
+"192 733 OFFCURVE",
+"114 614 OFFCURVE",
+"114 471 CURVE SMOOTH",
+"114 333 OFFCURVE",
+"186 248 OFFCURVE",
+"186 164 CURVE SMOOTH",
+"186 155 OFFCURVE",
+"186 145 OFFCURVE",
+"184 136 CURVE",
+"159 139 OFFCURVE",
+"137 144 OFFCURVE",
+"115 144 CURVE SMOOTH",
+"63 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 59 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"48 -20 OFFCURVE",
+"104 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 15 OFFCURVE",
+"58 31 OFFCURVE",
+"58 58 CURVE SMOOTH",
+"58 86 OFFCURVE",
+"79 105 OFFCURVE",
+"110 105 CURVE SMOOTH",
+"129 105 OFFCURVE",
+"160 98 OFFCURVE",
+"176 88 CURVE",
+"165 55 OFFCURVE",
+"135 15 OFFCURVE",
+"101 15 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 271 LINE",
+"435 320 LINE",
+"41 320 LINE",
+"41 271 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 395 LINE",
+"435 444 LINE",
+"41 444 LINE",
+"41 395 LINE"
+);
+}
+);
+width = 559;
+}
+);
+unicode = 20A4;
+},
+{
+glyphname = liraTurkish;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 0 LINE SMOOTH",
+"452 0 OFFCURVE",
+"556 86 OFFCURVE",
+"556 222 CURVE SMOOTH",
+"556 298 OFFCURVE",
+"523 339 OFFCURVE",
+"470 339 CURVE SMOOTH",
+"434 339 OFFCURVE",
+"412 321 OFFCURVE",
+"412 291 CURVE SMOOTH",
+"412 267 OFFCURVE",
+"426 249 OFFCURVE",
+"454 249 CURVE SMOOTH",
+"495 249 OFFCURVE",
+"486 286 OFFCURVE",
+"505 286 CURVE SMOOTH",
+"519 286 OFFCURVE",
+"528 264 OFFCURVE",
+"528 223 CURVE SMOOTH",
+"528 96 OFFCURVE",
+"442 25 OFFCURVE",
+"269 25 CURVE SMOOTH",
+"20 25 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"272 15 LINE",
+"272 754 LINE",
+"138 754 LINE",
+"138 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 427 LINE",
+"470 474 LINE",
+"35 318 LINE",
+"35 271 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 555 LINE",
+"470 602 LINE",
+"35 446 LINE",
+"35 399 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"393 729 LINE",
+"393 754 LINE",
+"20 754 LINE",
+"20 729 LINE"
+);
+}
+);
+width = 570;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"266 0 LINE SMOOTH",
+"452 0 OFFCURVE",
+"556 82 OFFCURVE",
+"556 212 CURVE SMOOTH",
+"556 294 OFFCURVE",
+"520 339 OFFCURVE",
+"463 339 CURVE SMOOTH",
+"421 339 OFFCURVE",
+"395 317 OFFCURVE",
+"395 281 CURVE SMOOTH",
+"395 251 OFFCURVE",
+"410 229 OFFCURVE",
+"442 229 CURVE SMOOTH",
+"487 229 OFFCURVE",
+"477 276 OFFCURVE",
+"498 276 CURVE SMOOTH",
+"512 276 OFFCURVE",
+"521 253 OFFCURVE",
+"521 213 CURVE SMOOTH",
+"521 98 OFFCURVE",
+"437 35 OFFCURVE",
+"269 35 CURVE SMOOTH",
+"20 35 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 20 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 20 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 422 LINE",
+"470 474 LINE",
+"35 318 LINE",
+"35 266 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 555 LINE",
+"470 607 LINE",
+"35 451 LINE",
+"35 399 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"393 724 LINE",
+"393 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 576;
+}
+);
+unicode = 20BA;
+},
+{
+glyphname = naira;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"722 512 LINE",
+"722 556 LINE",
+"20 556 LINE",
+"20 512 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"722 386 LINE",
+"722 430 LINE",
+"20 430 LINE",
+"20 386 LINE"
+);
+}
+);
+width = 744;
+},
+{
+components = (
+{
+name = N;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"772 380 LINE",
+"772 429 LINE",
+"20 429 LINE",
+"20 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"772 511 LINE",
+"772 559 LINE",
+"20 559 LINE",
+"20 511 LINE"
+);
+}
+);
+width = 743;
+}
+);
+unicode = 20A6;
+},
+{
+glyphname = rupeeIndian;
+lastChange = "2016-08-19 17:07:29 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"133 367 LINE SMOOTH",
+"337 367 OFFCURVE",
+"458 446 OFFCURVE",
+"458 562 CURVE SMOOTH",
+"458 671 OFFCURVE",
+"317 734 OFFCURVE",
+"133 734 CURVE SMOOTH",
+"47 734 LINE",
+"47 690 LINE",
+"183 690 LINE SMOOTH",
+"274 690 OFFCURVE",
+"303 651 OFFCURVE",
+"303 565 CURVE SMOOTH",
+"303 427 OFFCURVE",
+"253 397 OFFCURVE",
+"133 397 CURVE SMOOTH",
+"50 397 LINE",
+"50 367 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 0 LINE",
+"535 25 LINE",
+"497 25 LINE SMOOTH",
+"446 25 OFFCURVE",
+"428 52 OFFCURVE",
+"428 144 CURVE SMOOTH",
+"428 176 LINE SMOOTH",
+"428 271 OFFCURVE",
+"339 354 OFFCURVE",
+"254 374 CURVE",
+"254 378 LINE",
+"217 378 LINE",
+"141 367 LINE",
+"219 367 OFFCURVE",
+"275 317 OFFCURVE",
+"279 212 CURVE SMOOTH",
+"282 153 LINE SMOOTH",
+"287 60 OFFCURVE",
+"361 0 OFFCURVE",
+"458 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 564 LINE",
+"569 608 LINE",
+"47 608 LINE",
+"47 564 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 690 LINE",
+"569 734 LINE",
+"47 734 LINE",
+"47 690 LINE"
+);
+}
+);
+width = 570;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"133 380 LINE SMOOTH",
+"360 380 OFFCURVE",
+"493 455 OFFCURVE",
+"493 562 CURVE SMOOTH",
+"493 671 OFFCURVE",
+"340 734 OFFCURVE",
+"133 734 CURVE SMOOTH",
+"47 734 LINE",
+"47 690 LINE",
+"183 690 LINE SMOOTH",
+"274 690 OFFCURVE",
+"303 651 OFFCURVE",
+"303 565 CURVE SMOOTH",
+"303 446 OFFCURVE",
+"253 420 OFFCURVE",
+"133 420 CURVE SMOOTH",
+"50 420 LINE",
+"50 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 0 LINE",
+"574 32 LINE",
+"532 32 LINE SMOOTH",
+"484 32 OFFCURVE",
+"466 59 OFFCURVE",
+"466 144 CURVE SMOOTH",
+"466 196 LINE SMOOTH",
+"466 275 OFFCURVE",
+"390 365 OFFCURVE",
+"289 391 CURVE",
+"289 395 LINE",
+"217 391 LINE",
+"141 380 LINE",
+"214 380 OFFCURVE",
+"269 341 OFFCURVE",
+"273 246 CURVE SMOOTH",
+"277 153 LINE SMOOTH",
+"282 60 OFFCURVE",
+"364 0 OFFCURVE",
+"453 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 559 LINE",
+"604 608 LINE",
+"47 608 LINE",
+"47 559 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 685 LINE",
+"604 734 LINE",
+"47 734 LINE",
+"47 685 LINE"
+);
+}
+);
+width = 604;
+}
+);
+unicode = 20B9;
+},
+{
+glyphname = sterling;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"157 -20 OFFCURVE",
+"206 15 OFFCURVE",
+"226 54 CURVE",
+"295 -7 OFFCURVE",
+"335 -20 OFFCURVE",
+"379 -20 CURVE SMOOTH",
+"512 -20 OFFCURVE",
+"531 101 OFFCURVE",
+"531 204 CURVE",
+"507 204 LINE",
+"503 113 OFFCURVE",
+"451 79 OFFCURVE",
+"377 79 CURVE SMOOTH",
+"335 79 OFFCURVE",
+"289 90 OFFCURVE",
+"250 111 CURVE",
+"274 167 OFFCURVE",
+"286 225 OFFCURVE",
+"286 286 CURVE SMOOTH",
+"286 398 OFFCURVE",
+"246 485 OFFCURVE",
+"246 571 CURVE SMOOTH",
+"246 649 OFFCURVE",
+"279 703 OFFCURVE",
+"363 703 CURVE SMOOTH",
+"432 703 OFFCURVE",
+"464 666 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 612 OFFCURVE",
+"406 616 OFFCURVE",
+"406 568 CURVE SMOOTH",
+"406 540 OFFCURVE",
+"425 519 OFFCURVE",
+"458 519 CURVE SMOOTH",
+"501 519 OFFCURVE",
+"521 553 OFFCURVE",
+"521 596 CURVE SMOOTH",
+"521 679 OFFCURVE",
+"447 733 OFFCURVE",
+"350 733 CURVE SMOOTH",
+"206 733 OFFCURVE",
+"134 615 OFFCURVE",
+"134 470 CURVE SMOOTH",
+"134 330 OFFCURVE",
+"201 242 OFFCURVE",
+"201 154 CURVE",
+"201 145 OFFCURVE",
+"201 135 OFFCURVE",
+"199 126 CURVE",
+"172 135 OFFCURVE",
+"143 144 OFFCURVE",
+"114 144 CURVE SMOOTH",
+"64 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 60 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"49 -20 OFFCURVE",
+"102 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"75 10 OFFCURVE",
+"53 28 OFFCURVE",
+"53 58 CURVE SMOOTH",
+"53 91 OFFCURVE",
+"80 110 OFFCURVE",
+"109 110 CURVE SMOOTH",
+"134 110 OFFCURVE",
+"172 96 OFFCURVE",
+"191 78 CURVE",
+"178 47 OFFCURVE",
+"140 10 OFFCURVE",
+"102 10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 355 LINE",
+"415 399 LINE",
+"41 399 LINE",
+"41 355 LINE"
+);
+}
+);
+width = 559;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"165 -20 OFFCURVE",
+"224 17 OFFCURVE",
+"246 54 CURVE",
+"301 -3 OFFCURVE",
+"342 -20 OFFCURVE",
+"386 -20 CURVE SMOOTH",
+"508 -20 OFFCURVE",
+"546 113 OFFCURVE",
+"546 204 CURVE",
+"507 204 LINE",
+"502 122 OFFCURVE",
+"447 99 OFFCURVE",
+"374 99 CURVE SMOOTH",
+"343 99 OFFCURVE",
+"303 103 OFFCURVE",
+"270 111 CURVE",
+"294 167 OFFCURVE",
+"306 225 OFFCURVE",
+"306 286 CURVE SMOOTH",
+"306 397 OFFCURVE",
+"266 486 OFFCURVE",
+"266 569 CURVE SMOOTH",
+"266 644 OFFCURVE",
+"298 698 OFFCURVE",
+"373 698 CURVE SMOOTH",
+"429 698 OFFCURVE",
+"464 667 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 611 OFFCURVE",
+"406 614 OFFCURVE",
+"406 563 CURVE SMOOTH",
+"406 532 OFFCURVE",
+"427 509 OFFCURVE",
+"463 509 CURVE SMOOTH",
+"510 509 OFFCURVE",
+"531 548 OFFCURVE",
+"531 593 CURVE SMOOTH",
+"531 681 OFFCURVE",
+"453 733 OFFCURVE",
+"349 733 CURVE SMOOTH",
+"192 733 OFFCURVE",
+"114 614 OFFCURVE",
+"114 471 CURVE SMOOTH",
+"114 333 OFFCURVE",
+"186 248 OFFCURVE",
+"186 164 CURVE",
+"186 155 OFFCURVE",
+"186 145 OFFCURVE",
+"184 136 CURVE",
+"159 139 OFFCURVE",
+"137 144 OFFCURVE",
+"115 144 CURVE SMOOTH",
+"63 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 59 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"48 -20 OFFCURVE",
+"104 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 15 OFFCURVE",
+"58 31 OFFCURVE",
+"58 58 CURVE SMOOTH",
+"58 86 OFFCURVE",
+"79 105 OFFCURVE",
+"110 105 CURVE SMOOTH",
+"129 105 OFFCURVE",
+"160 98 OFFCURVE",
+"176 88 CURVE",
+"165 55 OFFCURVE",
+"135 15 OFFCURVE",
+"101 15 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 355 LINE",
+"435 404 LINE",
+"41 404 LINE",
+"41 355 LINE"
+);
+}
+);
+width = 559;
+}
+);
+unicode = 00A3;
+},
+{
+glyphname = won;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"958 502 LINE",
+"958 546 LINE",
+"40 546 LINE",
+"40 502 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"958 376 LINE",
+"958 420 LINE",
+"40 420 LINE",
+"40 376 LINE"
+);
+}
+);
+width = 907;
+},
+{
+components = (
+{
+name = W;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"978 497 LINE",
+"978 546 LINE",
+"20 546 LINE",
+"20 497 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"978 371 LINE",
+"978 420 LINE",
+"20 420 LINE",
+"20 371 LINE"
+);
+}
+);
+width = 998;
+}
+);
+unicode = 20A9;
+},
+{
+glyphname = yen;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"577 0 LINE",
+"577 25 LINE",
+"457 25 LINE",
+"457 362 LINE",
+"654 729 LINE",
+"750 729 LINE",
+"750 754 LINE",
+"485 754 LINE",
+"485 729 LINE",
+"621 729 LINE",
+"442 402 LINE",
+"438 402 LINE",
+"249 729 LINE",
+"357 729 LINE",
+"357 754 LINE",
+"10 754 LINE",
+"10 729 LINE",
+"99 729 LINE",
+"323 343 LINE",
+"323 25 LINE",
+"203 25 LINE",
+"203 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 208 LINE",
+"633 252 LINE",
+"141 252 LINE",
+"141 208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 334 LINE",
+"633 378 LINE",
+"141 378 LINE",
+"141 334 LINE"
+);
+}
+);
+width = 760;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"593 0 LINE",
+"593 30 LINE",
+"475 30 LINE",
+"475 342 LINE",
+"667 724 LINE",
+"756 724 LINE",
+"756 754 LINE",
+"521 754 LINE",
+"521 724 LINE",
+"629 724 LINE",
+"467 403 LINE",
+"463 403 LINE",
+"276 724 LINE",
+"362 724 LINE",
+"362 754 LINE",
+"10 754 LINE",
+"10 724 LINE",
+"78 724 LINE",
+"317 329 LINE",
+"317 30 LINE",
+"202 30 LINE",
+"202 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 203 LINE",
+"633 252 LINE",
+"141 252 LINE",
+"141 203 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 329 LINE",
+"633 378 LINE",
+"141 378 LINE",
+"141 329 LINE"
+);
+}
+);
+width = 766;
+}
+);
+unicode = 00A5;
+},
+{
+glyphname = bulletoperator;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"123 177 OFFCURVE",
+"156 210 OFFCURVE",
+"156 250 CURVE SMOOTH",
+"156 290 OFFCURVE",
+"123 323 OFFCURVE",
+"83 323 CURVE SMOOTH",
+"43 323 OFFCURVE",
+"10 290 OFFCURVE",
+"10 250 CURVE SMOOTH",
+"10 210 OFFCURVE",
+"43 177 OFFCURVE",
+"83 177 CURVE SMOOTH"
+);
+}
+);
+width = 166;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"185 167 OFFCURVE",
+"224 206 OFFCURVE",
+"224 254 CURVE SMOOTH",
+"224 302 OFFCURVE",
+"185 341 OFFCURVE",
+"137 341 CURVE SMOOTH",
+"89 341 OFFCURVE",
+"50 302 OFFCURVE",
+"50 254 CURVE SMOOTH",
+"50 206 OFFCURVE",
+"89 167 OFFCURVE",
+"137 167 CURVE SMOOTH"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 2219;
+},
+{
+glyphname = divisionslash;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+components = (
+{
+name = fraction;
+}
+);
+layerId = UUID0;
+width = 489;
+},
+{
+components = (
+{
+name = fraction;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 489;
+}
+);
+unicode = 2215;
+},
+{
+glyphname = plus;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 309 LINE",
+"538 309 LINE",
+"538 377 LINE",
+"40 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 74 LINE",
+"323 612 LINE",
+"255 612 LINE",
+"255 74 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"311 74 LINE",
+"311 612 LINE",
+"267 612 LINE",
+"267 74 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 321 LINE",
+"538 365 LINE",
+"40 365 LINE",
+"40 321 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 304 LINE",
+"538 304 LINE",
+"538 382 LINE",
+"40 382 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"328 74 LINE",
+"328 612 LINE",
+"250 612 LINE",
+"250 74 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"316 74 LINE",
+"316 612 LINE",
+"262 612 LINE",
+"262 74 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 316 LINE",
+"538 370 LINE",
+"40 370 LINE",
+"40 316 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 002B;
+},
+{
+glyphname = minus;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 309 LINE",
+"538 309 LINE",
+"538 377 LINE",
+"40 377 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"538 321 LINE",
+"538 365 LINE",
+"40 365 LINE",
+"40 321 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 304 LINE",
+"538 304 LINE",
+"538 382 LINE",
+"40 382 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"538 316 LINE",
+"538 370 LINE",
+"40 370 LINE",
+"40 316 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 2212;
+},
+{
+glyphname = multiply;
+lastChange = "2016-10-31 10:01:02 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"60 524 LINE",
+"470 114 LINE",
+"518 162 LINE",
+"108 572 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"108 114 LINE",
+"518 524 LINE",
+"470 572 LINE",
+"60 162 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"510 154 LINE",
+"100 564 LINE",
+"68 532 LINE",
+"478 122 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 534 LINE",
+"478 564 LINE",
+"70 156 LINE",
+"98 124 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 309 LINE",
+"538 309 LINE",
+"538 377 LINE",
+"40 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 74 LINE",
+"323 612 LINE",
+"255 612 LINE",
+"255 74 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"56 517 LINE",
+"466 107 LINE",
+"521 169 LINE",
+"111 579 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"116 112 LINE",
+"526 522 LINE",
+"467 580 LINE",
+"57 170 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"511 164 LINE",
+"101 574 LINE",
+"61 527 LINE",
+"471 117 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 532 LINE",
+"477 575 LINE",
+"67 165 LINE",
+"111 122 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 00D7;
+},
+{
+glyphname = divide;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 309 LINE",
+"538 309 LINE",
+"538 377 LINE",
+"40 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 116 OFFCURVE",
+"254 83 OFFCURVE",
+"294 83 CURVE SMOOTH",
+"334 83 OFFCURVE",
+"367 116 OFFCURVE",
+"367 156 CURVE SMOOTH",
+"367 196 OFFCURVE",
+"334 229 OFFCURVE",
+"294 229 CURVE SMOOTH",
+"254 229 OFFCURVE",
+"221 196 OFFCURVE",
+"221 156 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 490 OFFCURVE",
+"254 457 OFFCURVE",
+"294 457 CURVE SMOOTH",
+"334 457 OFFCURVE",
+"367 490 OFFCURVE",
+"367 530 CURVE SMOOTH",
+"367 570 OFFCURVE",
+"334 603 OFFCURVE",
+"294 603 CURVE SMOOTH",
+"254 603 OFFCURVE",
+"221 570 OFFCURVE",
+"221 530 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"538 321 LINE",
+"538 365 LINE",
+"40 365 LINE",
+"40 321 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"326 97 OFFCURVE",
+"353 124 OFFCURVE",
+"353 156 CURVE SMOOTH",
+"353 188 OFFCURVE",
+"326 215 OFFCURVE",
+"294 215 CURVE SMOOTH",
+"262 215 OFFCURVE",
+"235 188 OFFCURVE",
+"235 156 CURVE SMOOTH",
+"235 124 OFFCURVE",
+"262 97 OFFCURVE",
+"294 97 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"326 471 OFFCURVE",
+"353 498 OFFCURVE",
+"353 530 CURVE SMOOTH",
+"353 563 OFFCURVE",
+"326 589 OFFCURVE",
+"294 589 CURVE SMOOTH",
+"262 589 OFFCURVE",
+"235 563 OFFCURVE",
+"235 530 CURVE SMOOTH",
+"235 498 OFFCURVE",
+"262 471 OFFCURVE",
+"294 471 CURVE SMOOTH"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 304 LINE",
+"538 304 LINE",
+"538 382 LINE",
+"40 382 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 94 OFFCURVE",
+"246 55 OFFCURVE",
+"294 55 CURVE SMOOTH",
+"342 55 OFFCURVE",
+"381 94 OFFCURVE",
+"381 142 CURVE SMOOTH",
+"381 190 OFFCURVE",
+"342 229 OFFCURVE",
+"294 229 CURVE SMOOTH",
+"246 229 OFFCURVE",
+"207 190 OFFCURVE",
+"207 142 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 496 OFFCURVE",
+"246 457 OFFCURVE",
+"294 457 CURVE SMOOTH",
+"342 457 OFFCURVE",
+"381 496 OFFCURVE",
+"381 544 CURVE SMOOTH",
+"381 592 OFFCURVE",
+"342 631 OFFCURVE",
+"294 631 CURVE SMOOTH",
+"246 631 OFFCURVE",
+"207 592 OFFCURVE",
+"207 544 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"538 316 LINE",
+"538 370 LINE",
+"40 370 LINE",
+"40 316 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"336 65 OFFCURVE",
+"371 100 OFFCURVE",
+"371 142 CURVE SMOOTH",
+"371 184 OFFCURVE",
+"336 219 OFFCURVE",
+"294 219 CURVE SMOOTH",
+"252 219 OFFCURVE",
+"217 184 OFFCURVE",
+"217 142 CURVE SMOOTH",
+"217 100 OFFCURVE",
+"252 65 OFFCURVE",
+"294 65 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"336 467 OFFCURVE",
+"371 502 OFFCURVE",
+"371 544 CURVE SMOOTH",
+"371 586 OFFCURVE",
+"336 621 OFFCURVE",
+"294 621 CURVE SMOOTH",
+"252 621 OFFCURVE",
+"217 586 OFFCURVE",
+"217 544 CURVE SMOOTH",
+"217 502 OFFCURVE",
+"252 467 OFFCURVE",
+"294 467 CURVE SMOOTH"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 00F7;
+},
+{
+glyphname = equal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 394 LINE",
+"548 394 LINE",
+"548 462 LINE",
+"50 462 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 225 LINE",
+"548 225 LINE",
+"548 293 LINE",
+"50 293 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"548 402 LINE",
+"548 450 LINE",
+"50 450 LINE",
+"50 402 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 235 LINE",
+"548 283 LINE",
+"50 283 LINE",
+"50 235 LINE"
+);
+}
+);
+width = 598;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 212 LINE",
+"548 212 LINE",
+"548 290 LINE",
+"50 290 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 408 LINE",
+"548 408 LINE",
+"548 486 LINE",
+"50 486 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"548 420 LINE",
+"548 474 LINE",
+"50 474 LINE",
+"50 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 224 LINE",
+"548 278 LINE",
+"50 278 LINE",
+"50 224 LINE"
+);
+}
+);
+width = 598;
+}
+);
+unicode = 003D;
+},
+{
+glyphname = notequal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 393 LINE",
+"548 393 LINE",
+"548 461 LINE",
+"50 461 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 227 LINE",
+"548 227 LINE",
+"548 295 LINE",
+"50 295 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 604 LINE",
+"200 72 LINE",
+"259 72 LINE",
+"408 604 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"247 72 LINE",
+"396 604 LINE",
+"361 604 LINE",
+"212 72 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 239 LINE",
+"548 283 LINE",
+"50 283 LINE",
+"50 239 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 405 LINE",
+"548 449 LINE",
+"50 449 LINE",
+"50 405 LINE"
+);
+}
+);
+width = 598;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 388 LINE",
+"548 388 LINE",
+"548 466 LINE",
+"50 466 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 222 LINE",
+"548 222 LINE",
+"548 300 LINE",
+"50 300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 604 LINE",
+"194 72 LINE",
+"264 72 LINE",
+"413 604 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"252 72 LINE",
+"401 604 LINE",
+"355 604 LINE",
+"206 72 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 234 LINE",
+"548 288 LINE",
+"50 288 LINE",
+"50 234 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 400 LINE",
+"548 454 LINE",
+"50 454 LINE",
+"50 400 LINE"
+);
+}
+);
+width = 598;
+}
+);
+unicode = 2260;
+},
+{
+glyphname = greater;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"528 385 LINE",
+"60 619 LINE",
+"60 541 LINE",
+"528 307 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 385 LINE",
+"60 151 LINE",
+"60 70 LINE",
+"528 304 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"528 316 LINE",
+"528 373 LINE",
+"60 139 LINE",
+"60 82 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 373 LINE",
+"60 607 LINE",
+"60 553 LINE",
+"528 319 LINE"
+);
+}
+);
+width = 588;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"528 390 LINE",
+"60 624 LINE",
+"60 536 LINE",
+"528 302 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 390 LINE",
+"60 156 LINE",
+"60 65 LINE",
+"528 299 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"528 311 LINE",
+"528 378 LINE",
+"60 144 LINE",
+"60 77 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 378 LINE",
+"60 612 LINE",
+"60 548 LINE",
+"528 314 LINE"
+);
+}
+);
+width = 588;
+}
+);
+unicode = 003E;
+},
+{
+glyphname = less;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"60 307 LINE",
+"528 541 LINE",
+"528 619 LINE",
+"60 385 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 304 LINE",
+"528 70 LINE",
+"528 151 LINE",
+"60 385 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"528 139 LINE",
+"60 373 LINE",
+"60 316 LINE",
+"528 82 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 553 LINE",
+"528 607 LINE",
+"60 373 LINE",
+"60 319 LINE"
+);
+}
+);
+width = 588;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"60 302 LINE",
+"528 536 LINE",
+"528 624 LINE",
+"60 390 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 299 LINE",
+"528 65 LINE",
+"528 156 LINE",
+"60 390 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"528 144 LINE",
+"60 378 LINE",
+"60 311 LINE",
+"528 77 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 548 LINE",
+"528 612 LINE",
+"60 378 LINE",
+"60 314 LINE"
+);
+}
+);
+width = 588;
+}
+);
+unicode = 003C;
+},
+{
+glyphname = greaterequal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"538 99 LINE",
+"40 99 LINE",
+"40 31 LINE",
+"538 31 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 476 LINE",
+"50 710 LINE",
+"50 632 LINE",
+"518 398 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 476 LINE",
+"50 242 LINE",
+"50 161 LINE",
+"518 395 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"518 408 LINE",
+"518 465 LINE",
+"50 699 LINE",
+"50 645 LINE",
+"464 438 LINE",
+"50 231 LINE",
+"50 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 43 LINE",
+"538 87 LINE",
+"40 87 LINE",
+"40 43 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"518 481 LINE",
+"50 247 LINE",
+"50 156 LINE",
+"518 390 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 481 LINE",
+"50 715 LINE",
+"50 627 LINE",
+"518 393 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 104 LINE",
+"40 104 LINE",
+"40 26 LINE",
+"538 26 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"518 402 LINE",
+"518 469 LINE",
+"50 703 LINE",
+"50 639 LINE",
+"454 437 LINE",
+"50 235 LINE",
+"50 168 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 38 LINE",
+"538 92 LINE",
+"40 92 LINE",
+"40 38 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 2265;
+},
+{
+glyphname = lessequal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 31 LINE",
+"538 31 LINE",
+"538 99 LINE",
+"40 99 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 398 LINE",
+"528 632 LINE",
+"528 710 LINE",
+"60 476 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 395 LINE",
+"528 161 LINE",
+"528 242 LINE",
+"60 476 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"528 231 LINE",
+"60 465 LINE",
+"60 408 LINE",
+"528 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 43 LINE",
+"538 87 LINE",
+"40 87 LINE",
+"40 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 645 LINE",
+"528 699 LINE",
+"60 465 LINE",
+"60 411 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 26 LINE",
+"538 26 LINE",
+"538 104 LINE",
+"40 104 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 393 LINE",
+"528 627 LINE",
+"528 715 LINE",
+"60 481 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 390 LINE",
+"528 156 LINE",
+"528 247 LINE",
+"60 481 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"528 235 LINE",
+"60 469 LINE",
+"60 402 LINE",
+"528 168 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 38 LINE",
+"538 92 LINE",
+"40 92 LINE",
+"40 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 639 LINE",
+"528 703 LINE",
+"60 469 LINE",
+"60 405 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 2264;
+},
+{
+glyphname = plusminus;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 399 LINE",
+"538 399 LINE",
+"538 467 LINE",
+"40 467 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 164 LINE",
+"323 702 LINE",
+"255 702 LINE",
+"255 164 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"40 31 LINE",
+"538 31 LINE",
+"538 99 LINE",
+"40 99 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"311 164 LINE",
+"311 702 LINE",
+"267 702 LINE",
+"267 164 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 43 LINE",
+"538 87 LINE",
+"40 87 LINE",
+"40 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 411 LINE",
+"538 455 LINE",
+"40 455 LINE",
+"40 411 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 394 LINE",
+"538 394 LINE",
+"538 472 LINE",
+"40 472 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"328 164 LINE",
+"328 702 LINE",
+"250 702 LINE",
+"250 164 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"40 26 LINE",
+"538 26 LINE",
+"538 104 LINE",
+"40 104 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"316 164 LINE",
+"316 702 LINE",
+"262 702 LINE",
+"262 164 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 38 LINE",
+"538 92 LINE",
+"40 92 LINE",
+"40 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 406 LINE",
+"538 460 LINE",
+"40 460 LINE",
+"40 406 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 00B1;
+},
+{
+glyphname = approxequal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"489 493 LINE",
+"462 462 OFFCURVE",
+"439 435 OFFCURVE",
+"389 435 CURVE SMOOTH",
+"322 435 OFFCURVE",
+"256 496 OFFCURVE",
+"180 496 CURVE SMOOTH",
+"113 496 OFFCURVE",
+"76 449 OFFCURVE",
+"45 401 CURVE",
+"95 359 LINE",
+"117 393 OFFCURVE",
+"137 424 OFFCURVE",
+"182 424 CURVE SMOOTH",
+"252 424 OFFCURVE",
+"318 363 OFFCURVE",
+"393 363 CURVE SMOOTH",
+"465 363 OFFCURVE",
+"505 407 OFFCURVE",
+"540 453 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 326 LINE",
+"462 295 OFFCURVE",
+"439 268 OFFCURVE",
+"389 268 CURVE SMOOTH",
+"322 268 OFFCURVE",
+"256 329 OFFCURVE",
+"180 329 CURVE SMOOTH",
+"113 329 OFFCURVE",
+"76 282 OFFCURVE",
+"45 234 CURVE",
+"95 192 LINE",
+"117 226 OFFCURVE",
+"137 257 OFFCURVE",
+"182 257 CURVE SMOOTH",
+"252 257 OFFCURVE",
+"318 196 OFFCURVE",
+"393 196 CURVE SMOOTH",
+"465 196 OFFCURVE",
+"505 240 OFFCURVE",
+"540 286 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"111 400 OFFCURVE",
+"137 436 OFFCURVE",
+"182 436 CURVE SMOOTH",
+"252 436 OFFCURVE",
+"318 375 OFFCURVE",
+"393 375 CURVE SMOOTH",
+"465 375 OFFCURVE",
+"499 412 OFFCURVE",
+"534 458 CURVE",
+"496 487 LINE",
+"469 455 OFFCURVE",
+"439 423 OFFCURVE",
+"389 423 CURVE SMOOTH",
+"322 423 OFFCURVE",
+"256 484 OFFCURVE",
+"180 484 CURVE SMOOTH",
+"113 484 OFFCURVE",
+"81 445 OFFCURVE",
+"50 397 CURVE",
+"89 366 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"111 233 OFFCURVE",
+"137 269 OFFCURVE",
+"182 269 CURVE SMOOTH",
+"252 269 OFFCURVE",
+"318 208 OFFCURVE",
+"393 208 CURVE SMOOTH",
+"465 208 OFFCURVE",
+"499 245 OFFCURVE",
+"534 291 CURVE",
+"496 320 LINE",
+"469 288 OFFCURVE",
+"439 256 OFFCURVE",
+"389 256 CURVE SMOOTH",
+"322 256 OFFCURVE",
+"256 317 OFFCURVE",
+"180 317 CURVE SMOOTH",
+"113 317 OFFCURVE",
+"81 278 OFFCURVE",
+"50 230 CURVE",
+"89 199 LINE"
+);
+}
+);
+width = 585;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"489 508 LINE",
+"462 477 OFFCURVE",
+"439 450 OFFCURVE",
+"389 450 CURVE SMOOTH",
+"322 450 OFFCURVE",
+"256 511 OFFCURVE",
+"180 511 CURVE SMOOTH",
+"111 511 OFFCURVE",
+"72 464 OFFCURVE",
+"40 416 CURVE",
+"95 359 LINE",
+"117 393 OFFCURVE",
+"137 424 OFFCURVE",
+"182 424 CURVE SMOOTH",
+"252 424 OFFCURVE",
+"318 363 OFFCURVE",
+"393 363 CURVE SMOOTH",
+"467 363 OFFCURVE",
+"509 407 OFFCURVE",
+"545 453 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 326 LINE",
+"462 295 OFFCURVE",
+"439 268 OFFCURVE",
+"389 268 CURVE SMOOTH",
+"322 268 OFFCURVE",
+"256 329 OFFCURVE",
+"180 329 CURVE SMOOTH",
+"111 329 OFFCURVE",
+"72 282 OFFCURVE",
+"40 234 CURVE",
+"95 182 LINE",
+"117 216 OFFCURVE",
+"137 247 OFFCURVE",
+"182 247 CURVE SMOOTH",
+"252 247 OFFCURVE",
+"318 186 OFFCURVE",
+"393 186 CURVE SMOOTH",
+"467 186 OFFCURVE",
+"509 230 OFFCURVE",
+"545 276 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"112 399 OFFCURVE",
+"137 436 OFFCURVE",
+"182 436 CURVE SMOOTH",
+"252 436 OFFCURVE",
+"318 375 OFFCURVE",
+"393 375 CURVE SMOOTH",
+"467 375 OFFCURVE",
+"509 419 OFFCURVE",
+"539 458 CURVE",
+"495 503 LINE",
+"462 464 OFFCURVE",
+"439 438 OFFCURVE",
+"389 438 CURVE SMOOTH",
+"322 438 OFFCURVE",
+"256 499 OFFCURVE",
+"180 499 CURVE SMOOTH",
+"111 499 OFFCURVE",
+"72 452 OFFCURVE",
+"44 410 CURVE",
+"90 365 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"112 219 OFFCURVE",
+"137 256 OFFCURVE",
+"182 256 CURVE SMOOTH",
+"252 256 OFFCURVE",
+"318 195 OFFCURVE",
+"393 195 CURVE SMOOTH",
+"467 195 OFFCURVE",
+"509 239 OFFCURVE",
+"539 278 CURVE",
+"495 323 LINE",
+"462 284 OFFCURVE",
+"439 258 OFFCURVE",
+"389 258 CURVE SMOOTH",
+"322 258 OFFCURVE",
+"256 319 OFFCURVE",
+"180 319 CURVE SMOOTH",
+"111 319 OFFCURVE",
+"72 272 OFFCURVE",
+"44 230 CURVE",
+"90 185 LINE"
+);
+}
+);
+width = 585;
+}
+);
+unicode = 2248;
+},
+{
+glyphname = asciitilde;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"75 260 OFFCURVE",
+"97 291 OFFCURVE",
+"147 291 CURVE SMOOTH",
+"211 291 OFFCURVE",
+"271 230 OFFCURVE",
+"338 230 CURVE SMOOTH",
+"400 230 OFFCURVE",
+"433 274 OFFCURVE",
+"465 320 CURVE",
+"424 345 LINE",
+"400 309 OFFCURVE",
+"379 282 OFFCURVE",
+"334 282 CURVE SMOOTH",
+"273 282 OFFCURVE",
+"213 343 OFFCURVE",
+"145 343 CURVE SMOOTH",
+"78 343 OFFCURVE",
+"41 296 OFFCURVE",
+"10 248 CURVE",
+"50 221 LINE"
+);
+}
+);
+width = 475;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"75 250 OFFCURVE",
+"97 281 OFFCURVE",
+"147 281 CURVE SMOOTH",
+"211 281 OFFCURVE",
+"271 220 OFFCURVE",
+"338 220 CURVE SMOOTH",
+"405 220 OFFCURVE",
+"440 264 OFFCURVE",
+"475 310 CURVE",
+"424 355 LINE",
+"400 319 OFFCURVE",
+"379 292 OFFCURVE",
+"334 292 CURVE SMOOTH",
+"273 292 OFFCURVE",
+"213 353 OFFCURVE",
+"145 353 CURVE SMOOTH",
+"73 353 OFFCURVE",
+"33 306 OFFCURVE",
+"0 258 CURVE",
+"50 211 LINE"
+);
+}
+);
+width = 475;
+}
+);
+unicode = 007E;
+},
+{
+glyphname = logicalnot;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 270 LINE",
+"518 270 LINE",
+"518 338 LINE",
+"20 338 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"411 307 LINE",
+"411 43 LINE",
+"518 43 LINE",
+"518 307 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"518 282 LINE",
+"518 326 LINE",
+"20 326 LINE",
+"20 282 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 72 LINE",
+"518 307 LINE",
+"441 307 LINE",
+"441 72 LINE"
+);
+}
+);
+width = 538;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 265 LINE",
+"518 265 LINE",
+"518 338 LINE",
+"20 338 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"401 307 LINE",
+"401 43 LINE",
+"518 43 LINE",
+"518 307 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"518 277 LINE",
+"518 326 LINE",
+"20 326 LINE",
+"20 277 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 55 LINE",
+"518 307 LINE",
+"425 307 LINE",
+"425 55 LINE"
+);
+}
+);
+width = 538;
+}
+);
+unicode = 00AC;
+},
+{
+glyphname = asciicircum;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"64 173 LINE",
+"249 581 LINE",
+"437 173 LINE",
+"491 173 LINE",
+"274 645 LINE",
+"225 645 LINE",
+"10 173 LINE"
+);
+}
+);
+width = 501;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"84 173 LINE",
+"249 541 LINE",
+"417 173 LINE",
+"491 173 LINE",
+"274 645 LINE",
+"225 645 LINE",
+"10 173 LINE"
+);
+}
+);
+width = 501;
+}
+);
+unicode = 005E;
+},
+{
+glyphname = infinity;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 117 OFFCURVE",
+"346 168 OFFCURVE",
+"396 231 CURVE",
+"462 141 OFFCURVE",
+"520 117 OFFCURVE",
+"573 117 CURVE SMOOTH",
+"661 117 OFFCURVE",
+"742 183 OFFCURVE",
+"742 296 CURVE SMOOTH",
+"742 401 OFFCURVE",
+"672 468 OFFCURVE",
+"581 468 CURVE SMOOTH",
+"489 468 OFFCURVE",
+"435 401 OFFCURVE",
+"400 357 CURVE",
+"348 425 OFFCURVE",
+"293 468 OFFCURVE",
+"218 468 CURVE SMOOTH",
+"121 468 OFFCURVE",
+"47 396 OFFCURVE",
+"47 291 CURVE SMOOTH",
+"47 186 OFFCURVE",
+"122 117 OFFCURVE",
+"212 117 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"154 172 OFFCURVE",
+"104 223 OFFCURVE",
+"104 293 CURVE SMOOTH",
+"104 355 OFFCURVE",
+"143 414 OFFCURVE",
+"216 414 CURVE SMOOTH",
+"290 414 OFFCURVE",
+"331 354 OFFCURVE",
+"374 287 CURVE",
+"306 198 OFFCURVE",
+"266 172 OFFCURVE",
+"219 172 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 172 OFFCURVE",
+"481 210 OFFCURVE",
+"418 294 CURVE",
+"474 374 OFFCURVE",
+"517 414 OFFCURVE",
+"573 414 CURVE SMOOTH",
+"641 414 OFFCURVE",
+"684 358 OFFCURVE",
+"684 294 CURVE SMOOTH",
+"684 238 OFFCURVE",
+"651 172 OFFCURVE",
+"577 172 CURVE SMOOTH"
+);
+}
+);
+width = 789;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"300 106 OFFCURVE",
+"354 153 OFFCURVE",
+"407 221 CURVE",
+"475 125 OFFCURVE",
+"536 106 OFFCURVE",
+"592 106 CURVE SMOOTH",
+"680 106 OFFCURVE",
+"766 175 OFFCURVE",
+"766 297 CURVE SMOOTH",
+"766 406 OFFCURVE",
+"689 477 OFFCURVE",
+"597 477 CURVE SMOOTH",
+"523 477 OFFCURVE",
+"478 443 OFFCURVE",
+"412 366 CURVE",
+"359 437 OFFCURVE",
+"304 477 OFFCURVE",
+"227 477 CURVE SMOOTH",
+"125 477 OFFCURVE",
+"47 401 OFFCURVE",
+"47 290 CURVE SMOOTH",
+"47 178 OFFCURVE",
+"129 106 OFFCURVE",
+"217 106 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"170 183 OFFCURVE",
+"126 232 OFFCURVE",
+"126 289 CURVE SMOOTH",
+"126 357 OFFCURVE",
+"166 401 OFFCURVE",
+"226 401 CURVE SMOOTH",
+"282 401 OFFCURVE",
+"310 374 OFFCURVE",
+"370 286 CURVE",
+"330 234 OFFCURVE",
+"287 183 OFFCURVE",
+"229 183 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 183 OFFCURVE",
+"509 207 OFFCURVE",
+"446 294 CURVE",
+"511 376 OFFCURVE",
+"544 401 OFFCURVE",
+"588 401 CURVE SMOOTH",
+"649 401 OFFCURVE",
+"687 352 OFFCURVE",
+"687 289 CURVE SMOOTH",
+"687 244 OFFCURVE",
+"653 183 OFFCURVE",
+"594 183 CURVE SMOOTH"
+);
+}
+);
+width = 814;
+}
+);
+unicode = 221E;
+},
+{
+glyphname = integral;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"173 -202 OFFCURVE",
+"276 -138 OFFCURVE",
+"276 159 CURVE SMOOTH",
+"276 261 OFFCURVE",
+"264 560 OFFCURVE",
+"264 658 CURVE SMOOTH",
+"264 802 OFFCURVE",
+"290 841 OFFCURVE",
+"336 841 CURVE SMOOTH",
+"357 841 OFFCURVE",
+"373 833 OFFCURVE",
+"373 815 CURVE SMOOTH",
+"373 801 OFFCURVE",
+"363 793 OFFCURVE",
+"363 772 CURVE SMOOTH",
+"363 744 OFFCURVE",
+"382 719 OFFCURVE",
+"419 719 CURVE SMOOTH",
+"453 719 OFFCURVE",
+"467 741 OFFCURVE",
+"467 771 CURVE SMOOTH",
+"467 833 OFFCURVE",
+"408 866 OFFCURVE",
+"339 866 CURVE SMOOTH",
+"229 866 OFFCURVE",
+"134 782 OFFCURVE",
+"134 545 CURVE SMOOTH",
+"134 414 OFFCURVE",
+"163 111 OFFCURVE",
+"163 -37 CURVE SMOOTH",
+"163 -139 OFFCURVE",
+"149 -177 OFFCURVE",
+"106 -177 CURVE SMOOTH",
+"78 -177 OFFCURVE",
+"77 -161 OFFCURVE",
+"75 -128 CURVE SMOOTH",
+"73 -96 OFFCURVE",
+"63 -71 OFFCURVE",
+"28 -71 CURVE SMOOTH",
+"-4 -71 OFFCURVE",
+"-20 -91 OFFCURVE",
+"-20 -120 CURVE SMOOTH",
+"-20 -176 OFFCURVE",
+"42 -202 OFFCURVE",
+"93 -202 CURVE SMOOTH"
+);
+}
+);
+width = 446;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"179 -202 OFFCURVE",
+"291 -140 OFFCURVE",
+"291 161 CURVE SMOOTH",
+"291 259 OFFCURVE",
+"279 560 OFFCURVE",
+"279 659 CURVE SMOOTH",
+"279 793 OFFCURVE",
+"301 831 OFFCURVE",
+"341 831 CURVE SMOOTH",
+"359 831 OFFCURVE",
+"373 823 OFFCURVE",
+"373 806 CURVE SMOOTH",
+"373 788 OFFCURVE",
+"358 781 OFFCURVE",
+"358 757 CURVE SMOOTH",
+"358 729 OFFCURVE",
+"377 704 OFFCURVE",
+"415 704 CURVE SMOOTH",
+"452 704 OFFCURVE",
+"467 728 OFFCURVE",
+"467 762 CURVE SMOOTH",
+"467 830 OFFCURVE",
+"409 866 OFFCURVE",
+"335 866 CURVE SMOOTH",
+"222 866 OFFCURVE",
+"119 782 OFFCURVE",
+"119 543 CURVE SMOOTH",
+"119 416 OFFCURVE",
+"148 112 OFFCURVE",
+"148 -39 CURVE SMOOTH",
+"148 -132 OFFCURVE",
+"137 -167 OFFCURVE",
+"105 -167 CURVE SMOOTH",
+"83 -167 OFFCURVE",
+"82 -151 OFFCURVE",
+"80 -118 CURVE SMOOTH",
+"78 -86 OFFCURVE",
+"67 -61 OFFCURVE",
+"28 -61 CURVE SMOOTH",
+"-11 -61 OFFCURVE",
+"-30 -86 OFFCURVE",
+"-30 -118 CURVE SMOOTH",
+"-30 -177 OFFCURVE",
+"37 -202 OFFCURVE",
+"92 -202 CURVE SMOOTH"
+);
+}
+);
+width = 446;
+}
+);
+unicode = 222B;
+},
+{
+glyphname = Ohm;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"332 0 LINE",
+"342 23 LINE",
+"254 156 OFFCURVE",
+"219 257 OFFCURVE",
+"219 412 CURVE SMOOTH",
+"219 636 OFFCURVE",
+"292 702 OFFCURVE",
+"377 702 CURVE SMOOTH",
+"468 702 OFFCURVE",
+"542 625 OFFCURVE",
+"542 408 CURVE SMOOTH",
+"542 267 OFFCURVE",
+"511 160 OFFCURVE",
+"418 23 CURVE",
+"427 0 LINE",
+"698 0 LINE",
+"727 174 LINE",
+"704 174 LINE",
+"683 109 OFFCURVE",
+"669 95 OFFCURVE",
+"627 95 CURVE SMOOTH",
+"505 95 LINE",
+"604 187 OFFCURVE",
+"691 269 OFFCURVE",
+"691 421 CURVE SMOOTH",
+"691 607 OFFCURVE",
+"562 733 OFFCURVE",
+"384 733 CURVE SMOOTH",
+"205 733 OFFCURVE",
+"69 606 OFFCURVE",
+"69 412 CURVE SMOOTH",
+"69 249 OFFCURVE",
+"165 165 OFFCURVE",
+"248 96 CURVE",
+"141 96 LINE SMOOTH",
+"97 96 OFFCURVE",
+"81 112 OFFCURVE",
+"59 174 CURVE",
+"35 174 LINE",
+"60 0 LINE"
+);
+}
+);
+width = 762;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"353 0 LINE",
+"363 26 LINE",
+"314 132 OFFCURVE",
+"251 268 OFFCURVE",
+"251 399 CURVE SMOOTH",
+"251 626 OFFCURVE",
+"311 694 OFFCURVE",
+"403 694 CURVE SMOOTH",
+"494 694 OFFCURVE",
+"560 615 OFFCURVE",
+"560 402 CURVE SMOOTH",
+"560 267 OFFCURVE",
+"488 123 OFFCURVE",
+"446 26 CURVE",
+"456 0 LINE",
+"744 0 LINE",
+"776 189 LINE",
+"735 189 LINE",
+"712 127 OFFCURVE",
+"697 116 OFFCURVE",
+"653 116 CURVE SMOOTH",
+"540 116 LINE",
+"632 188 OFFCURVE",
+"739 274 OFFCURVE",
+"739 414 CURVE SMOOTH",
+"739 612 OFFCURVE",
+"603 733 OFFCURVE",
+"407 733 CURVE SMOOTH",
+"214 733 OFFCURVE",
+"71 609 OFFCURVE",
+"71 408 CURVE SMOOTH",
+"71 253 OFFCURVE",
+"183 171 OFFCURVE",
+"262 116 CURVE",
+"164 116 LINE SMOOTH",
+"115 116 OFFCURVE",
+"99 128 OFFCURVE",
+"75 189 CURVE",
+"36 189 LINE",
+"63 0 LINE"
+);
+}
+);
+width = 812;
+}
+);
+unicode = 2126;
+},
+{
+glyphname = increment;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"645 0 LINE",
+"645 37 LINE",
+"363 729 LINE",
+"306 715 LINE",
+"35 37 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 570 LINE",
+"482 37 LINE",
+"71 37 LINE"
+);
+}
+);
+width = 680;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"689 0 LINE",
+"689 43 LINE",
+"392 733 LINE",
+"322 716 LINE",
+"37 43 LINE",
+"37 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 527 LINE",
+"495 73 LINE",
+"119 73 LINE"
+);
+}
+);
+width = 727;
+}
+);
+unicode = 2206;
+},
+{
+glyphname = product;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 -79 LINE",
+"321 -54 LINE",
+"241 -54 LINE",
+"241 709 LINE",
+"470 709 LINE",
+"470 -54 LINE",
+"390 -54 LINE",
+"390 -79 LINE",
+"694 -79 LINE",
+"694 -54 LINE",
+"604 -54 LINE",
+"604 709 LINE",
+"694 709 LINE",
+"694 734 LINE",
+"17 734 LINE",
+"17 709 LINE",
+"107 709 LINE",
+"107 -54 LINE",
+"17 -54 LINE",
+"17 -79 LINE"
+);
+}
+);
+width = 711;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"773 730 LINE",
+"25 730 LINE",
+"25 691 LINE",
+"121 684 OFFCURVE",
+"129 674 OFFCURVE",
+"129 584 CURVE SMOOTH",
+"129 65 LINE SMOOTH",
+"129 -27 OFFCURVE",
+"120 -40 OFFCURVE",
+"29 -47 CURVE",
+"29 -86 LINE",
+"363 -86 LINE",
+"363 -47 LINE",
+"291 -40 OFFCURVE",
+"290 -28 OFFCURVE",
+"290 65 CURVE SMOOTH",
+"290 644 LINE SMOOTH",
+"290 677 OFFCURVE",
+"294 681 OFFCURVE",
+"328 681 CURVE SMOOTH",
+"470 681 LINE SMOOTH",
+"505 681 OFFCURVE",
+"511 677 OFFCURVE",
+"511 641 CURVE SMOOTH",
+"511 65 LINE SMOOTH",
+"511 -33 OFFCURVE",
+"507 -40 OFFCURVE",
+"431 -47 CURVE",
+"431 -86 LINE",
+"772 -86 LINE",
+"772 -47 LINE",
+"680 -39 OFFCURVE",
+"672 -29 OFFCURVE",
+"672 65 CURVE SMOOTH",
+"672 584 LINE SMOOTH",
+"672 672 OFFCURVE",
+"679 684 OFFCURVE",
+"773 691 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"361 -86 LINE",
+"361 -56 LINE",
+"288 -56 LINE",
+"288 703 LINE",
+"512 703 LINE",
+"512 -56 LINE",
+"439 -56 LINE",
+"439 -86 LINE",
+"769 -86 LINE",
+"769 -56 LINE",
+"670 -56 LINE",
+"670 703 LINE",
+"769 703 LINE",
+"769 733 LINE",
+"31 733 LINE",
+"31 703 LINE",
+"130 703 LINE",
+"130 -56 LINE",
+"31 -56 LINE",
+"31 -86 LINE"
+);
+}
+);
+width = 802;
+}
+);
+unicode = 220F;
+},
+{
+glyphname = summation;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"511 -87 LINE",
+"558 141 LINE",
+"532 148 LINE",
+"487 31 OFFCURVE",
+"473 25 OFFCURVE",
+"380 25 CURVE SMOOTH",
+"135 25 LINE",
+"367 370 LINE",
+"192 701 LINE",
+"380 701 LINE SMOOTH",
+"450 701 OFFCURVE",
+"479 660 OFFCURVE",
+"500 542 CURVE",
+"531 550 LINE",
+"519 733 LINE",
+"32 733 LINE",
+"32 709 LINE",
+"255 278 LINE",
+"28 -53 LINE",
+"28 -87 LINE"
+);
+}
+);
+width = 833;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"552 -96 LINE",
+"606 149 LINE",
+"560 149 LINE",
+"515 43 OFFCURVE",
+"502 34 OFFCURVE",
+"403 34 CURVE SMOOTH",
+"154 34 LINE",
+"394 370 LINE",
+"223 684 LINE",
+"366 684 LINE SMOOTH",
+"458 684 OFFCURVE",
+"489 659 OFFCURVE",
+"522 534 CURVE",
+"565 534 LINE",
+"551 730 LINE",
+"33 730 LINE",
+"33 690 LINE",
+"261 264 LINE",
+"28 -56 LINE",
+"28 -96 LINE"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 2211;
+},
+{
+glyphname = radical;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"377 -172 LINE",
+"558 915 LINE",
+"529 915 LINE",
+"382 56 LINE",
+"378 56 LINE",
+"237 440 LINE",
+"34 440 LINE",
+"34 415 LINE",
+"128 415 LINE",
+"363 -175 LINE"
+);
+}
+);
+width = 594;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"415 -175 LINE",
+"612 914 LINE",
+"551 914 LINE",
+"405 81 LINE",
+"401 81 LINE",
+"265 440 LINE",
+"39 440 LINE",
+"39 405 LINE",
+"137 405 LINE",
+"376 -183 LINE"
+);
+}
+);
+width = 617;
+}
+);
+unicode = 221A;
+},
+{
+glyphname = micro;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"541 25 LINE",
+"352 25 LINE",
+"352 0 LINE",
+"541 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 426 LINE",
+"352 426 LINE",
+"352 16 LINE",
+"462 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 441 LINE",
+"270 441 LINE",
+"270 416 LINE",
+"462 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"179 441 LINE",
+"-9 441 LINE",
+"-9 416 LINE",
+"179 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"69 99 LINE SMOOTH",
+"69 38 OFFCURVE",
+"123 -10 OFFCURVE",
+"200 -10 CURVE SMOOTH",
+"274 -10 OFFCURVE",
+"319 28 OFFCURVE",
+"348 80 CURVE",
+"372 80 LINE",
+"352 230 LINE",
+"352 116 OFFCURVE",
+"296 27 OFFCURVE",
+"235 27 CURVE SMOOTH",
+"200 27 OFFCURVE",
+"179 52 OFFCURVE",
+"179 102 CURVE SMOOTH",
+"179 426 LINE",
+"69 426 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"69 101 LINE",
+"64 -72 OFFCURVE",
+"35 -124 OFFCURVE",
+"35 -190 CURVE SMOOTH",
+"35 -230 OFFCURVE",
+"51 -254 OFFCURVE",
+"86 -254 CURVE SMOOTH",
+"122 -254 OFFCURVE",
+"139 -227 OFFCURVE",
+"139 -188 CURVE SMOOTH",
+"139 -140 OFFCURVE",
+"103 -103 OFFCURVE",
+"95 28 CURVE",
+"99 28 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 -12 OFFCURVE",
+"335 26 OFFCURVE",
+"364 78 CURVE",
+"388 78 LINE",
+"368 228 LINE",
+"368 114 OFFCURVE",
+"312 25 OFFCURVE",
+"251 25 CURVE SMOOTH",
+"216 25 OFFCURVE",
+"195 50 OFFCURVE",
+"195 100 CURVE SMOOTH",
+"195 435 LINE",
+"85 435 LINE",
+"85 97 LINE SMOOTH",
+"85 36 OFFCURVE",
+"139 -12 OFFCURVE",
+"216 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 -254 OFFCURVE",
+"153 -227 OFFCURVE",
+"153 -188 CURVE SMOOTH",
+"153 -140 OFFCURVE",
+"117 -103 OFFCURVE",
+"109 28 CURVE",
+"113 28 LINE",
+"85 101 LINE",
+"80 -72 OFFCURVE",
+"49 -124 OFFCURVE",
+"49 -190 CURVE SMOOTH",
+"49 -230 OFFCURVE",
+"65 -254 OFFCURVE",
+"100 -254 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"368 25 LINE",
+"368 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 425 LINE",
+"195 450 LINE",
+"7 450 LINE",
+"7 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 16 LINE",
+"478 435 LINE",
+"368 435 LINE",
+"368 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 425 LINE",
+"478 450 LINE",
+"286 450 LINE",
+"286 425 LINE"
+);
+}
+);
+width = 570;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE",
+"603 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 425 LINE",
+"386 425 LINE",
+"386 15 LINE",
+"524 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 440 LINE",
+"304 440 LINE",
+"304 410 LINE",
+"524 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 440 LINE",
+"10 440 LINE",
+"10 410 LINE",
+"226 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH",
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 425 LINE",
+"88 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH",
+"153 -277 OFFCURVE",
+"178 -246 OFFCURVE",
+"178 -203 CURVE SMOOTH",
+"178 -152 OFFCURVE",
+"152 -119 OFFCURVE",
+"134 10 CURVE",
+"138 10 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 435 LINE",
+"88 435 LINE",
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"153 -277 OFFCURVE",
+"178 -246 OFFCURVE",
+"178 -203 CURVE SMOOTH",
+"178 -152 OFFCURVE",
+"152 -119 OFFCURVE",
+"134 10 CURVE",
+"138 10 LINE",
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 0 LINE",
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 420 LINE",
+"226 450 LINE",
+"10 450 LINE",
+"10 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 15 LINE",
+"524 435 LINE",
+"386 435 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 420 LINE",
+"524 450 LINE",
+"304 450 LINE",
+"304 420 LINE"
+);
+}
+);
+width = 613;
+}
+);
+unicode = 00B5;
+},
+{
+glyphname = partialdiff;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"404 -11 OFFCURVE",
+"524 129 OFFCURVE",
+"524 391 CURVE SMOOTH",
+"524 657 OFFCURVE",
+"401 779 OFFCURVE",
+"236 779 CURVE SMOOTH",
+"169 779 OFFCURVE",
+"121 759 OFFCURVE",
+"85 738 CURVE",
+"125 668 LINE",
+"166 713 OFFCURVE",
+"210 741 OFFCURVE",
+"267 741 CURVE SMOOTH",
+"362 741 OFFCURVE",
+"421 664 OFFCURVE",
+"421 528 CURVE SMOOTH",
+"421 482 OFFCURVE",
+"414 434 OFFCURVE",
+"407 390 CURVE",
+"379 429 OFFCURVE",
+"337 451 OFFCURVE",
+"280 451 CURVE SMOOTH",
+"133 451 OFFCURVE",
+"43 319 OFFCURVE",
+"43 193 CURVE SMOOTH",
+"43 67 OFFCURVE",
+"123 -11 OFFCURVE",
+"243 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 19 OFFCURVE",
+"170 58 OFFCURVE",
+"170 138 CURVE SMOOTH",
+"170 224 OFFCURVE",
+"196 411 OFFCURVE",
+"308 411 CURVE SMOOTH",
+"359 411 OFFCURVE",
+"386 372 OFFCURVE",
+"397 350 CURVE",
+"385 260 OFFCURVE",
+"371 202 OFFCURVE",
+"346 136 CURVE SMOOTH",
+"314 52 OFFCURVE",
+"289 19 OFFCURVE",
+"243 19 CURVE SMOOTH"
+);
+}
+);
+width = 569;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 -12 OFFCURVE",
+"565 162 OFFCURVE",
+"565 384 CURVE SMOOTH",
+"565 593 OFFCURVE",
+"463 779 OFFCURVE",
+"248 779 CURVE SMOOTH",
+"176 779 OFFCURVE",
+"128 758 OFFCURVE",
+"89 738 CURVE",
+"138 633 LINE",
+"178 678 OFFCURVE",
+"237 709 OFFCURVE",
+"299 709 CURVE SMOOTH",
+"405 709 OFFCURVE",
+"438 620 OFFCURVE",
+"438 519 CURVE SMOOTH",
+"438 476 OFFCURVE",
+"432 442 OFFCURVE",
+"424 397 CURVE",
+"393 437 OFFCURVE",
+"347 455 OFFCURVE",
+"291 455 CURVE SMOOTH",
+"149 455 OFFCURVE",
+"44 339 OFFCURVE",
+"44 197 CURVE SMOOTH",
+"44 69 OFFCURVE",
+"129 -12 OFFCURVE",
+"259 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 31 OFFCURVE",
+"196 63 OFFCURVE",
+"196 136 CURVE SMOOTH",
+"196 210 OFFCURVE",
+"219 399 OFFCURVE",
+"330 399 CURVE SMOOTH",
+"376 399 OFFCURVE",
+"401 366 OFFCURVE",
+"413 343 CURVE",
+"400 257 OFFCURVE",
+"386 199 OFFCURVE",
+"360 138 CURVE SMOOTH",
+"335 79 OFFCURVE",
+"304 31 OFFCURVE",
+"257 31 CURVE SMOOTH"
+);
+}
+);
+width = 616;
+}
+);
+unicode = 2202;
+},
+{
+glyphname = percent;
+lastChange = "2016-08-19 16:58:51 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 206, 0}";
+},
+{
+name = zero.numerator;
+transform = "{1, 0, 0, 1, 23, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 483, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 215, 0}";
+},
+{
+name = zero.numerator;
+transform = "{1, 0, 0, 1, 23, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 483, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 0025;
+},
+{
+glyphname = perthousand;
+lastChange = "2016-08-19 16:59:14 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 205, 0}";
+},
+{
+name = zero.numerator;
+transform = "{1, 0, 0, 1, 23, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 483, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 923, 0}";
+}
+);
+layerId = UUID0;
+width = 1353;
+},
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 211, 0}";
+},
+{
+name = zero.numerator;
+transform = "{1, 0, 0, 1, 23, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 483, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 923, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1353;
+}
+);
+unicode = 2030;
+},
+{
+glyphname = lozenge;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"347 -74 LINE",
+"547 347 LINE",
+"347 771 LINE",
+"251 771 LINE",
+"48 347 LINE",
+"248 -74 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"119 348 LINE",
+"297 717 LINE",
+"301 717 LINE",
+"476 347 LINE",
+"301 -24 LINE",
+"297 -24 LINE"
+);
+}
+);
+width = 595;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"373 -77 LINE",
+"584 347 LINE",
+"374 774 LINE",
+"261 774 LINE",
+"48 347 LINE",
+"258 -77 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 348 LINE",
+"315 700 LINE",
+"319 700 LINE",
+"488 347 LINE",
+"319 -7 LINE",
+"315 -7 LINE"
+);
+}
+);
+width = 633;
+}
+);
+unicode = 25CA;
+},
+{
+glyphname = brevecomb_acutecomb;
+lastChange = "2016-08-22 09:59:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 853}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -30, 198}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 864}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -92, 208}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_gravecomb;
+lastChange = "2016-08-22 10:27:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 848}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 8, 198}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 888}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 49, 159}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_hookabovecomb;
+lastChange = "2016-08-22 10:06:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 868}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 3, 128}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 898}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -4, 153}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_tildecomb;
+lastChange = "2016-08-22 10:27:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 851}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 4, 128}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 861}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, -15, 144}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_acutecomb;
+lastChange = "2016-08-22 10:07:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 857}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -35, 127}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 865}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -94, 139}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_gravecomb;
+lastChange = "2016-08-22 10:07:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 852}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 3, 127}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 889}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 47, 139}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_hookabovecomb;
+lastChange = "2016-08-22 10:06:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 872}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 123, 105}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 899}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 151, 134}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_tildecomb;
+lastChange = "2016-08-22 10:07:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 855}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -1, 127}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 862}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -17, 139}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = dieresiscomb;
+lastChange = "2022-03-23 16:28:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{154, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"285 572 OFFCURVE",
+"310 597 OFFCURVE",
+"310 627 CURVE SMOOTH",
+"310 657 OFFCURVE",
+"285 682 OFFCURVE",
+"255 682 CURVE SMOOTH",
+"225 682 OFFCURVE",
+"200 657 OFFCURVE",
+"200 627 CURVE SMOOTH",
+"200 597 OFFCURVE",
+"225 572 OFFCURVE",
+"255 572 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"95 572 OFFCURVE",
+"120 597 OFFCURVE",
+"120 627 CURVE SMOOTH",
+"120 657 OFFCURVE",
+"95 682 OFFCURVE",
+"65 682 CURVE SMOOTH",
+"35 682 OFFCURVE",
+"10 657 OFFCURVE",
+"10 627 CURVE SMOOTH",
+"10 597 OFFCURVE",
+"35 572 OFFCURVE",
+"65 572 CURVE SMOOTH"
+);
+}
+);
+width = 320;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{162, 452}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"302 561 OFFCURVE",
+"332 591 OFFCURVE",
+"332 627 CURVE SMOOTH",
+"332 663 OFFCURVE",
+"302 693 OFFCURVE",
+"266 693 CURVE SMOOTH",
+"230 693 OFFCURVE",
+"200 663 OFFCURVE",
+"200 627 CURVE SMOOTH",
+"200 591 OFFCURVE",
+"230 561 OFFCURVE",
+"266 561 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"112 561 OFFCURVE",
+"142 591 OFFCURVE",
+"142 627 CURVE SMOOTH",
+"142 663 OFFCURVE",
+"112 693 OFFCURVE",
+"76 693 CURVE SMOOTH",
+"40 693 OFFCURVE",
+"10 663 OFFCURVE",
+"10 627 CURVE SMOOTH",
+"10 591 OFFCURVE",
+"40 561 OFFCURVE",
+"76 561 CURVE SMOOTH"
+);
+}
+);
+width = 342;
+}
+);
+unicode = 0308;
+},
+{
+glyphname = gravecomb;
+lastChange = "2016-08-22 09:45:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{287, 450}";
+},
+{
+name = top;
+position = "{287, 650}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"421 518 LINE",
+"270 614 LINE SMOOTH",
+"223 644 OFFCURVE",
+"211 650 OFFCURVE",
+"197 650 CURVE SMOOTH",
+"169 650 OFFCURVE",
+"153 633 OFFCURVE",
+"153 607 CURVE SMOOTH",
+"153 581 OFFCURVE",
+"170 561 OFFCURVE",
+"203 554 CURVE SMOOTH",
+"378 518 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{249, 450}";
+},
+{
+name = top;
+position = "{249, 680}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"395 543 LINE",
+"234 647 LINE SMOOTH",
+"199 670 OFFCURVE",
+"181 680 OFFCURVE",
+"152 680 CURVE SMOOTH",
+"119 680 OFFCURVE",
+"102 658 OFFCURVE",
+"102 634 CURVE SMOOTH",
+"102 611 OFFCURVE",
+"111 587 OFFCURVE",
+"155 578 CURVE SMOOTH",
+"332 543 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0300;
+},
+{
+glyphname = acutecomb;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{325, 450}";
+},
+{
+name = top;
+position = "{325, 655}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"234 523 LINE",
+"409 559 LINE SMOOTH",
+"442 566 OFFCURVE",
+"459 586 OFFCURVE",
+"459 612 CURVE SMOOTH",
+"459 638 OFFCURVE",
+"443 655 OFFCURVE",
+"415 655 CURVE SMOOTH",
+"401 655 OFFCURVE",
+"389 649 OFFCURVE",
+"342 619 CURVE SMOOTH",
+"191 523 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{390, 450}";
+},
+{
+name = top;
+position = "{390, 656}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"306 519 LINE",
+"483 554 LINE SMOOTH",
+"527 563 OFFCURVE",
+"536 587 OFFCURVE",
+"536 610 CURVE SMOOTH",
+"536 634 OFFCURVE",
+"519 656 OFFCURVE",
+"486 656 CURVE SMOOTH",
+"457 656 OFFCURVE",
+"439 646 OFFCURVE",
+"404 623 CURVE SMOOTH",
+"243 519 LINE"
+);
+}
+);
+width = 600;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0301;
+},
+{
+glyphname = circumflexcomb;
+lastChange = "2016-08-22 10:07:55 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 577}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"181 520 LINE",
+"290 571 LINE",
+"399 520 LINE",
+"442 520 LINE",
+"321 632 LINE",
+"259 632 LINE",
+"138 520 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 589}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"177 523 LINE",
+"296 565 LINE",
+"415 523 LINE",
+"468 523 LINE",
+"327 639 LINE",
+"265 639 LINE",
+"124 523 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0302;
+},
+{
+glyphname = brevecomb;
+lastChange = "2016-08-22 10:16:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 648}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"401 516 OFFCURVE",
+"431 571 OFFCURVE",
+"431 648 CURVE",
+"397 648 LINE",
+"394 604 OFFCURVE",
+"364 584 OFFCURVE",
+"293 584 CURVE SMOOTH",
+"223 584 OFFCURVE",
+"195 602 OFFCURVE",
+"192 648 CURVE",
+"158 648 LINE",
+"158 567 OFFCURVE",
+"192 516 OFFCURVE",
+"295 516 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 658}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"391 521 OFFCURVE",
+"444 581 OFFCURVE",
+"444 658 CURVE",
+"400 658 LINE",
+"397 628 OFFCURVE",
+"347 614 OFFCURVE",
+"296 614 CURVE SMOOTH",
+"246 614 OFFCURVE",
+"198 626 OFFCURVE",
+"195 658 CURVE",
+"151 658 LINE",
+"151 577 OFFCURVE",
+"208 521 OFFCURVE",
+"298 521 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0306;
+},
+{
+glyphname = ringcomb;
+lastChange = "2022-03-23 16:29:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{112, 450}";
+},
+{
+name = top;
+position = "{112, 723}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"168 540 OFFCURVE",
+"214 586 OFFCURVE",
+"214 642 CURVE SMOOTH",
+"214 698 OFFCURVE",
+"167 743 OFFCURVE",
+"112 743 CURVE SMOOTH",
+"57 743 OFFCURVE",
+"10 697 OFFCURVE",
+"10 642 CURVE SMOOTH",
+"10 586 OFFCURVE",
+"57 540 OFFCURVE",
+"112 540 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"82 586 OFFCURVE",
+"57 613 OFFCURVE",
+"57 642 CURVE SMOOTH",
+"57 671 OFFCURVE",
+"83 696 OFFCURVE",
+"112 696 CURVE SMOOTH",
+"141 696 OFFCURVE",
+"167 671 OFFCURVE",
+"167 642 CURVE SMOOTH",
+"167 612 OFFCURVE",
+"142 586 OFFCURVE",
+"112 586 CURVE SMOOTH"
+);
+}
+);
+width = 224;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{112, 450}";
+},
+{
+name = top;
+position = "{112, 723}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"168 540 OFFCURVE",
+"214 586 OFFCURVE",
+"214 642 CURVE SMOOTH",
+"214 698 OFFCURVE",
+"167 743 OFFCURVE",
+"112 743 CURVE SMOOTH",
+"57 743 OFFCURVE",
+"10 697 OFFCURVE",
+"10 642 CURVE SMOOTH",
+"10 586 OFFCURVE",
+"57 540 OFFCURVE",
+"112 540 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 596 OFFCURVE",
+"67 618 OFFCURVE",
+"67 642 CURVE SMOOTH",
+"67 666 OFFCURVE",
+"88 686 OFFCURVE",
+"112 686 CURVE SMOOTH",
+"136 686 OFFCURVE",
+"157 666 OFFCURVE",
+"157 642 CURVE SMOOTH",
+"157 617 OFFCURVE",
+"137 596 OFFCURVE",
+"112 596 CURVE SMOOTH"
+);
+}
+);
+width = 224;
+}
+);
+unicode = 030A;
+},
+{
+glyphname = tildecomb;
+lastChange = "2016-08-22 10:22:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{291, 450}";
+},
+{
+name = top;
+position = "{291, 700}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"148 558 LINE",
+"155 586 OFFCURVE",
+"178 607 OFFCURVE",
+"211 607 CURVE SMOOTH",
+"258 607 OFFCURVE",
+"292 559 OFFCURVE",
+"348 559 CURVE SMOOTH",
+"417 559 OFFCURVE",
+"453 623 OFFCURVE",
+"467 686 CURVE",
+"433 686 LINE",
+"426 665 OFFCURVE",
+"408 635 OFFCURVE",
+"370 635 CURVE SMOOTH",
+"324 635 OFFCURVE",
+"287 683 OFFCURVE",
+"233 683 CURVE SMOOTH",
+"167 683 OFFCURVE",
+"125 620 OFFCURVE",
+"115 558 CURVE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{313, 450}";
+},
+{
+name = top;
+position = "{313, 697}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 560 LINE",
+"159 584 OFFCURVE",
+"190 601 OFFCURVE",
+"233 601 CURVE SMOOTH",
+"280 601 OFFCURVE",
+"314 561 OFFCURVE",
+"370 561 CURVE SMOOTH",
+"451 561 OFFCURVE",
+"493 629 OFFCURVE",
+"509 697 CURVE",
+"475 697 LINE",
+"466 680 OFFCURVE",
+"442 657 OFFCURVE",
+"392 657 CURVE SMOOTH",
+"346 657 OFFCURVE",
+"309 697 OFFCURVE",
+"255 697 CURVE SMOOTH",
+"177 697 OFFCURVE",
+"129 627 OFFCURVE",
+"117 560 CURVE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0303;
+},
+{
+glyphname = hookabovecomb;
+lastChange = "2016-08-22 10:25:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{285, 450}";
+},
+{
+name = top;
+position = "{285, 659}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"312 524 LINE",
+"324 550 OFFCURVE",
+"381 560 OFFCURVE",
+"381 600 CURVE SMOOTH",
+"381 657 OFFCURVE",
+"341 683 OFFCURVE",
+"281 683 CURVE SMOOTH",
+"237 683 OFFCURVE",
+"188 662 OFFCURVE",
+"188 603 CURVE SMOOTH",
+"188 583 OFFCURVE",
+"204 568 OFFCURVE",
+"227 568 CURVE SMOOTH",
+"248 568 OFFCURVE",
+"259 576 OFFCURVE",
+"259 590 CURVE SMOOTH",
+"259 608 OFFCURVE",
+"246 606 OFFCURVE",
+"246 618 CURVE SMOOTH",
+"246 633 OFFCURVE",
+"262 643 OFFCURVE",
+"283 643 CURVE SMOOTH",
+"303 643 OFFCURVE",
+"322 636 OFFCURVE",
+"322 598 CURVE SMOOTH",
+"322 574 OFFCURVE",
+"285 560 OFFCURVE",
+"285 524 CURVE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{284, 450}";
+},
+{
+name = top;
+position = "{281, 688}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"315 507 LINE",
+"315 557 OFFCURVE",
+"389 538 OFFCURVE",
+"389 600 CURVE SMOOTH",
+"389 671 OFFCURVE",
+"354 700 OFFCURVE",
+"281 700 CURVE SMOOTH",
+"221 700 OFFCURVE",
+"174 673 OFFCURVE",
+"174 608 CURVE SMOOTH",
+"174 578 OFFCURVE",
+"194 559 OFFCURVE",
+"218 559 CURVE SMOOTH",
+"235 559 OFFCURVE",
+"257 566 OFFCURVE",
+"257 585 CURVE SMOOTH",
+"257 613 OFFCURVE",
+"236 601 OFFCURVE",
+"236 625 CURVE SMOOTH",
+"236 639 OFFCURVE",
+"253 657 OFFCURVE",
+"281 657 CURVE SMOOTH",
+"310 657 OFFCURVE",
+"327 641 OFFCURVE",
+"327 609 CURVE SMOOTH",
+"327 585 OFFCURVE",
+"276 577 OFFCURVE",
+"276 507 CURVE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0309;
+},
+{
+glyphname = dblgravecomb;
+lastChange = "2022-03-23 16:30:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{253, 450}";
+},
+{
+name = top;
+position = "{213, 754}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"416 554 LINE",
+"298 714 LINE SMOOTH",
+"275 745 OFFCURVE",
+"255 754 OFFCURVE",
+"234 754 CURVE SMOOTH",
+"205 754 OFFCURVE",
+"188 736 OFFCURVE",
+"188 712 CURVE SMOOTH",
+"188 695 OFFCURVE",
+"196 677 OFFCURVE",
+"238 648 CURVE SMOOTH",
+"373 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 554 LINE",
+"120 714 LINE SMOOTH",
+"97 745 OFFCURVE",
+"77 754 OFFCURVE",
+"56 754 CURVE SMOOTH",
+"27 754 OFFCURVE",
+"10 736 OFFCURVE",
+"10 712 CURVE SMOOTH",
+"10 695 OFFCURVE",
+"18 677 OFFCURVE",
+"60 648 CURVE SMOOTH",
+"195 554 LINE"
+);
+}
+);
+width = 426;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{294, 450}";
+},
+{
+name = top;
+position = "{234, 760}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"458 554 LINE",
+"337 718 LINE SMOOTH",
+"312 752 OFFCURVE",
+"289 760 OFFCURVE",
+"266 760 CURVE SMOOTH",
+"228 760 OFFCURVE",
+"210 738 OFFCURVE",
+"210 714 CURVE SMOOTH",
+"210 696 OFFCURVE",
+"220 676 OFFCURVE",
+"258 649 CURVE SMOOTH",
+"395 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"258 554 LINE",
+"137 718 LINE SMOOTH",
+"112 752 OFFCURVE",
+"89 760 OFFCURVE",
+"66 760 CURVE SMOOTH",
+"28 760 OFFCURVE",
+"10 738 OFFCURVE",
+"10 714 CURVE SMOOTH",
+"10 696 OFFCURVE",
+"20 676 OFFCURVE",
+"58 649 CURVE SMOOTH",
+"195 554 LINE"
+);
+}
+);
+width = 468;
+}
+);
+unicode = 030F;
+},
+{
+glyphname = breveinvertedcomb;
+lastChange = "2016-08-22 11:53:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{167, 450}";
+},
+{
+name = top;
+position = "{167, 733}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"44 576 LINE",
+"47 632 OFFCURVE",
+"95 655 OFFCURVE",
+"165 655 CURVE SMOOTH",
+"236 655 OFFCURVE",
+"286 631 OFFCURVE",
+"289 576 CURVE",
+"323 576 LINE",
+"323 665 OFFCURVE",
+"273 733 OFFCURVE",
+"167 733 CURVE SMOOTH",
+"64 733 OFFCURVE",
+"10 669 OFFCURVE",
+"10 576 CURVE"
+);
+}
+);
+width = 333;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{177, 450}";
+},
+{
+name = top;
+position = "{177, 733}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"54 556 LINE",
+"57 612 OFFCURVE",
+"105 635 OFFCURVE",
+"175 635 CURVE SMOOTH",
+"246 635 OFFCURVE",
+"296 611 OFFCURVE",
+"299 556 CURVE",
+"343 556 LINE",
+"343 657 OFFCURVE",
+"290 733 OFFCURVE",
+"177 733 CURVE SMOOTH",
+"67 733 OFFCURVE",
+"10 661 OFFCURVE",
+"10 556 CURVE"
+);
+}
+);
+width = 353;
+}
+);
+unicode = 0311;
+},
+{
+glyphname = horncomb;
+lastChange = "2016-08-22 09:33:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _topright;
+position = "{312, 450}";
+},
+{
+name = topright;
+position = "{312, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"344 476 OFFCURVE",
+"378 499 OFFCURVE",
+"378 582 CURVE",
+"314 582 LINE",
+"311 527 OFFCURVE",
+"300 503 OFFCURVE",
+"229 503 CURVE",
+"231 476 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _topright;
+position = "{199, 450}";
+},
+{
+name = topright;
+position = "{323, 450}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"344 465 OFFCURVE",
+"394 481 OFFCURVE",
+"394 582 CURVE",
+"318 582 LINE",
+"315 527 OFFCURVE",
+"300 503 OFFCURVE",
+"229 503 CURVE",
+"231 465 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 031B;
+},
+{
+glyphname = dotbelowcomb;
+lastChange = "2016-08-22 09:41:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{284, 0}";
+},
+{
+name = bottom;
+position = "{284, -231}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"320 -231 OFFCURVE",
+"350 -201 OFFCURVE",
+"350 -165 CURVE SMOOTH",
+"350 -129 OFFCURVE",
+"320 -99 OFFCURVE",
+"284 -99 CURVE SMOOTH",
+"248 -99 OFFCURVE",
+"218 -129 OFFCURVE",
+"218 -165 CURVE SMOOTH",
+"218 -201 OFFCURVE",
+"248 -231 OFFCURVE",
+"284 -231 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _bottom;
+position = "{293, 0}";
+},
+{
+name = bottom;
+position = "{293, -260}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"336 -260 OFFCURVE",
+"373 -223 OFFCURVE",
+"373 -180 CURVE SMOOTH",
+"373 -136 OFFCURVE",
+"336 -99 OFFCURVE",
+"292 -99 CURVE SMOOTH",
+"249 -99 OFFCURVE",
+"212 -136 OFFCURVE",
+"212 -180 CURVE SMOOTH",
+"212 -223 OFFCURVE",
+"249 -260 OFFCURVE",
+"292 -260 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0323;
+},
+{
+glyphname = commaaccentcomb;
+lastChange = "2016-08-22 11:53:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{86, 0}";
+},
+{
+name = bottom;
+position = "{86, -309}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"123 -272 OFFCURVE",
+"162 -232 OFFCURVE",
+"162 -172 CURVE SMOOTH",
+"162 -115 OFFCURVE",
+"126 -79 OFFCURVE",
+"78 -79 CURVE SMOOTH",
+"38 -79 OFFCURVE",
+"10 -103 OFFCURVE",
+"10 -143 CURVE SMOOTH",
+"10 -178 OFFCURVE",
+"32 -196 OFFCURVE",
+"58 -196 CURVE SMOOTH",
+"91 -196 OFFCURVE",
+"112 -168 OFFCURVE",
+"121 -168 CURVE SMOOTH",
+"123 -168 OFFCURVE",
+"125 -171 OFFCURVE",
+"125 -180 CURVE SMOOTH",
+"125 -218 OFFCURVE",
+"98 -252 OFFCURVE",
+"33 -286 CURVE",
+"53 -309 LINE"
+);
+}
+);
+width = 172;
+},
+{
+anchors = (
+{
+name = _bottom;
+position = "{93, 0}";
+},
+{
+name = bottom;
+position = "{93, -314}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"135 -276 OFFCURVE",
+"176 -236 OFFCURVE",
+"176 -174 CURVE SMOOTH",
+"176 -121 OFFCURVE",
+"147 -69 OFFCURVE",
+"86 -69 CURVE SMOOTH",
+"39 -69 OFFCURVE",
+"10 -99 OFFCURVE",
+"10 -136 CURVE SMOOTH",
+"10 -167 OFFCURVE",
+"30 -198 OFFCURVE",
+"68 -198 CURVE SMOOTH",
+"106 -198 OFFCURVE",
+"111 -166 OFFCURVE",
+"123 -166 CURVE SMOOTH",
+"130 -166 OFFCURVE",
+"138 -171 OFFCURVE",
+"138 -188 CURVE SMOOTH",
+"138 -226 OFFCURVE",
+"110 -253 OFFCURVE",
+"36 -292 CURVE",
+"56 -314 LINE"
+);
+}
+);
+width = 186;
+}
+);
+unicode = 0326;
+},
+{
+glyphname = strokeshortcomb;
+lastChange = "2016-08-22 12:09:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _center;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-23 -6 LINE",
+"-23 29 LINE",
+"-388 29 LINE",
+"-388 -6 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _center;
+position = "{464, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"445 -3 LINE",
+"445 44 LINE",
+"50 44 LINE",
+"50 -3 LINE"
+);
+}
+);
+width = 495;
+}
+);
+unicode = 0335;
+},
+{
+glyphname = dieresis;
+lastChange = "2022-03-23 16:30:39 +0000";
+layers = (
+{
+components = (
+{
+name = dieresiscomb;
+}
+);
+layerId = UUID0;
+width = 320;
+},
+{
+components = (
+{
+name = dieresiscomb;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 342;
+}
+);
+unicode = 00A8;
+},
+{
+glyphname = dotaccent;
+lastChange = "2016-08-22 12:07:32 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{74, 453}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"112 601 OFFCURVE",
+"142 631 OFFCURVE",
+"142 667 CURVE SMOOTH",
+"142 703 OFFCURVE",
+"112 733 OFFCURVE",
+"76 733 CURVE SMOOTH",
+"40 733 OFFCURVE",
+"10 703 OFFCURVE",
+"10 667 CURVE SMOOTH",
+"10 631 OFFCURVE",
+"40 601 OFFCURVE",
+"76 601 CURVE SMOOTH"
+);
+}
+);
+width = 152;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{88, 457}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 573 OFFCURVE",
+"171 610 OFFCURVE",
+"171 653 CURVE SMOOTH",
+"171 697 OFFCURVE",
+"134 734 OFFCURVE",
+"90 734 CURVE SMOOTH",
+"47 734 OFFCURVE",
+"10 697 OFFCURVE",
+"10 653 CURVE SMOOTH",
+"10 610 OFFCURVE",
+"47 573 OFFCURVE",
+"90 573 CURVE SMOOTH"
+);
+}
+);
+width = 181;
+}
+);
+unicode = 02D9;
+},
+{
+glyphname = grave;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"238 554 LINE",
+"120 714 LINE SMOOTH",
+"97 745 OFFCURVE",
+"77 754 OFFCURVE",
+"56 754 CURVE SMOOTH",
+"27 754 OFFCURVE",
+"10 736 OFFCURVE",
+"10 712 CURVE SMOOTH",
+"10 695 OFFCURVE",
+"18 677 OFFCURVE",
+"60 648 CURVE SMOOTH",
+"195 554 LINE"
+);
+}
+);
+width = 248;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"258 554 LINE",
+"137 718 LINE SMOOTH",
+"112 752 OFFCURVE",
+"89 760 OFFCURVE",
+"66 760 CURVE SMOOTH",
+"28 760 OFFCURVE",
+"10 738 OFFCURVE",
+"10 714 CURVE SMOOTH",
+"10 696 OFFCURVE",
+"20 676 OFFCURVE",
+"58 649 CURVE SMOOTH",
+"195 554 LINE"
+);
+}
+);
+width = 268;
+}
+);
+unicode = 0060;
+},
+{
+glyphname = acute;
+lastChange = "2016-08-18 21:48:17 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"53 554 LINE",
+"188 648 LINE SMOOTH",
+"230 677 OFFCURVE",
+"238 695 OFFCURVE",
+"238 712 CURVE SMOOTH",
+"238 736 OFFCURVE",
+"221 754 OFFCURVE",
+"192 754 CURVE SMOOTH",
+"171 754 OFFCURVE",
+"151 745 OFFCURVE",
+"128 714 CURVE SMOOTH",
+"10 554 LINE"
+);
+}
+);
+width = 248;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"73 554 LINE",
+"210 649 LINE SMOOTH",
+"248 676 OFFCURVE",
+"258 696 OFFCURVE",
+"258 714 CURVE SMOOTH",
+"258 738 OFFCURVE",
+"240 760 OFFCURVE",
+"202 760 CURVE SMOOTH",
+"179 760 OFFCURVE",
+"156 752 OFFCURVE",
+"131 718 CURVE SMOOTH",
+"10 554 LINE"
+);
+}
+);
+width = 268;
+}
+);
+unicode = 00B4;
+},
+{
+glyphname = hungarumlaut;
+lastChange = "2016-08-18 22:02:17 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"231 554 LINE",
+"366 648 LINE SMOOTH",
+"408 677 OFFCURVE",
+"416 695 OFFCURVE",
+"416 712 CURVE SMOOTH",
+"416 736 OFFCURVE",
+"399 754 OFFCURVE",
+"370 754 CURVE SMOOTH",
+"349 754 OFFCURVE",
+"329 745 OFFCURVE",
+"306 714 CURVE SMOOTH",
+"188 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"53 554 LINE",
+"188 648 LINE SMOOTH",
+"230 677 OFFCURVE",
+"238 695 OFFCURVE",
+"238 712 CURVE SMOOTH",
+"238 736 OFFCURVE",
+"221 754 OFFCURVE",
+"192 754 CURVE SMOOTH",
+"171 754 OFFCURVE",
+"151 745 OFFCURVE",
+"128 714 CURVE SMOOTH",
+"10 554 LINE"
+);
+}
+);
+width = 426;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"273 554 LINE",
+"410 649 LINE SMOOTH",
+"448 676 OFFCURVE",
+"458 696 OFFCURVE",
+"458 714 CURVE SMOOTH",
+"458 738 OFFCURVE",
+"440 760 OFFCURVE",
+"402 760 CURVE SMOOTH",
+"379 760 OFFCURVE",
+"356 752 OFFCURVE",
+"331 718 CURVE SMOOTH",
+"210 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"73 554 LINE",
+"210 649 LINE SMOOTH",
+"248 676 OFFCURVE",
+"258 696 OFFCURVE",
+"258 714 CURVE SMOOTH",
+"258 738 OFFCURVE",
+"240 760 OFFCURVE",
+"202 760 CURVE SMOOTH",
+"179 760 OFFCURVE",
+"156 752 OFFCURVE",
+"131 718 CURVE SMOOTH",
+"10 554 LINE"
+);
+}
+);
+width = 468;
+}
+);
+unicode = 02DD;
+},
+{
+glyphname = circumflex;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"53 554 LINE",
+"172 660 LINE",
+"291 554 LINE",
+"334 554 LINE",
+"203 754 LINE",
+"141 754 LINE",
+"10 554 LINE"
+);
+}
+);
+width = 344;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"53 554 LINE",
+"192 640 LINE",
+"331 554 LINE",
+"374 554 LINE",
+"223 754 LINE",
+"161 754 LINE",
+"10 554 LINE"
+);
+}
+);
+width = 384;
+}
+);
+unicode = 02C6;
+},
+{
+glyphname = firsttonechinese;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"330 637 LINE",
+"330 703 LINE",
+"10 703 LINE",
+"10 637 LINE"
+);
+}
+);
+width = 340;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 627 LINE",
+"350 713 LINE",
+"10 713 LINE",
+"10 627 LINE"
+);
+}
+);
+width = 360;
+}
+);
+unicode = 02C9;
+},
+{
+glyphname = caron;
+lastChange = "2016-08-22 12:22:57 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{165, 459}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"203 554 LINE",
+"334 754 LINE",
+"291 754 LINE",
+"172 648 LINE",
+"53 754 LINE",
+"10 754 LINE",
+"141 554 LINE"
+);
+}
+);
+width = 344;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{190, 459}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"223 554 LINE",
+"374 754 LINE",
+"331 754 LINE",
+"192 668 LINE",
+"53 754 LINE",
+"10 754 LINE",
+"161 554 LINE"
+);
+}
+);
+width = 384;
+}
+);
+unicode = 02C7;
+},
+{
+glyphname = breve;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"273 576 OFFCURVE",
+"323 644 OFFCURVE",
+"323 733 CURVE",
+"289 733 LINE",
+"286 678 OFFCURVE",
+"236 654 OFFCURVE",
+"165 654 CURVE SMOOTH",
+"95 654 OFFCURVE",
+"47 677 OFFCURVE",
+"44 733 CURVE",
+"10 733 LINE",
+"10 640 OFFCURVE",
+"64 576 OFFCURVE",
+"167 576 CURVE SMOOTH"
+);
+}
+);
+width = 333;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"290 556 OFFCURVE",
+"343 632 OFFCURVE",
+"343 733 CURVE",
+"299 733 LINE",
+"296 678 OFFCURVE",
+"246 654 OFFCURVE",
+"175 654 CURVE SMOOTH",
+"105 654 OFFCURVE",
+"57 677 OFFCURVE",
+"54 733 CURVE",
+"10 733 LINE",
+"10 628 OFFCURVE",
+"67 556 OFFCURVE",
+"177 556 CURVE SMOOTH"
+);
+}
+);
+width = 353;
+}
+);
+unicode = 02D8;
+},
+{
+glyphname = ring;
+lastChange = "2022-03-23 16:26:44 +0000";
+layers = (
+{
+components = (
+{
+name = ringcomb;
+}
+);
+layerId = UUID0;
+width = 224;
+},
+{
+components = (
+{
+name = ringcomb;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 224;
+}
+);
+unicode = 02DA;
+},
+{
+glyphname = tilde;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"43 603 LINE",
+"50 631 OFFCURVE",
+"73 652 OFFCURVE",
+"106 652 CURVE SMOOTH",
+"153 652 OFFCURVE",
+"187 604 OFFCURVE",
+"243 604 CURVE SMOOTH",
+"312 604 OFFCURVE",
+"348 668 OFFCURVE",
+"362 731 CURVE",
+"328 731 LINE",
+"321 710 OFFCURVE",
+"303 680 OFFCURVE",
+"265 680 CURVE SMOOTH",
+"219 680 OFFCURVE",
+"182 728 OFFCURVE",
+"128 728 CURVE SMOOTH",
+"62 728 OFFCURVE",
+"20 665 OFFCURVE",
+"10 603 CURVE"
+);
+}
+);
+width = 372;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"43 583 LINE",
+"52 611 OFFCURVE",
+"83 632 OFFCURVE",
+"126 632 CURVE SMOOTH",
+"173 632 OFFCURVE",
+"207 584 OFFCURVE",
+"263 584 CURVE SMOOTH",
+"344 584 OFFCURVE",
+"386 658 OFFCURVE",
+"402 731 CURVE",
+"368 731 LINE",
+"359 710 OFFCURVE",
+"335 680 OFFCURVE",
+"285 680 CURVE SMOOTH",
+"239 680 OFFCURVE",
+"202 728 OFFCURVE",
+"148 728 CURVE SMOOTH",
+"70 728 OFFCURVE",
+"22 655 OFFCURVE",
+"10 583 CURVE"
+);
+}
+);
+width = 412;
+}
+);
+unicode = 02DC;
+},
+{
+glyphname = macron;
+lastChange = "2016-08-22 12:20:05 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{166, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"330 637 LINE",
+"330 703 LINE",
+"10 703 LINE",
+"10 637 LINE"
+);
+}
+);
+width = 340;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{174, 450}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 627 LINE",
+"350 713 LINE",
+"10 713 LINE",
+"10 627 LINE"
+);
+}
+);
+width = 360;
+}
+);
+unicode = 00AF;
+},
+{
+glyphname = cedilla;
+lastChange = "2016-08-22 12:01:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{105, -6}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"53 -107 LINE",
+"67 -113 LINE",
+"77 -110 OFFCURVE",
+"88 -108 OFFCURVE",
+"98 -108 CURVE SMOOTH",
+"121 -108 OFFCURVE",
+"142 -120 OFFCURVE",
+"142 -148 CURVE SMOOTH",
+"142 -181 OFFCURVE",
+"113 -195 OFFCURVE",
+"82 -195 CURVE SMOOTH",
+"62 -195 OFFCURVE",
+"40 -189 OFFCURVE",
+"20 -181 CURVE",
+"10 -208 LINE",
+"38 -219 OFFCURVE",
+"55 -225 OFFCURVE",
+"89 -225 CURVE SMOOTH",
+"160 -225 OFFCURVE",
+"220 -199 OFFCURVE",
+"220 -142 CURVE SMOOTH",
+"220 -97 OFFCURVE",
+"183 -69 OFFCURVE",
+"137 -69 CURVE SMOOTH",
+"125 -69 OFFCURVE",
+"113 -71 OFFCURVE",
+"101 -74 CURVE",
+"138 10 LINE",
+"106 10 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"165 -226 OFFCURVE",
+"217 -191 OFFCURVE",
+"217 -138 CURVE SMOOTH",
+"217 -92 OFFCURVE",
+"178 -66 OFFCURVE",
+"121 -66 CURVE SMOOTH",
+"102 -66 LINE",
+"126 10 LINE",
+"96 10 LINE",
+"62 -90 LINE",
+"114 -91 OFFCURVE",
+"137 -110 OFFCURVE",
+"137 -145 CURVE SMOOTH",
+"137 -179 OFFCURVE",
+"114 -195 OFFCURVE",
+"77 -195 CURVE SMOOTH",
+"57 -195 OFFCURVE",
+"31 -190 OFFCURVE",
+"21 -184 CURVE",
+"10 -209 LINE",
+"21 -216 OFFCURVE",
+"50 -226 OFFCURVE",
+"90 -226 CURVE SMOOTH"
+);
+}
+);
+width = 227;
+},
+{
+anchors = (
+{
+name = _bottom;
+position = "{117, -13}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"53 -122 LINE",
+"67 -128 LINE",
+"80 -125 OFFCURVE",
+"96 -123 OFFCURVE",
+"106 -123 CURVE SMOOTH",
+"126 -123 OFFCURVE",
+"142 -132 OFFCURVE",
+"142 -153 CURVE SMOOTH",
+"142 -179 OFFCURVE",
+"118 -190 OFFCURVE",
+"89 -190 CURVE SMOOTH",
+"71 -190 OFFCURVE",
+"46 -186 OFFCURVE",
+"25 -181 CURVE",
+"10 -218 LINE",
+"44 -230 OFFCURVE",
+"66 -235 OFFCURVE",
+"99 -235 CURVE SMOOTH",
+"178 -235 OFFCURVE",
+"240 -206 OFFCURVE",
+"240 -144 CURVE SMOOTH",
+"240 -96 OFFCURVE",
+"203 -69 OFFCURVE",
+"156 -69 CURVE SMOOTH",
+"143 -69 OFFCURVE",
+"126 -71 OFFCURVE",
+"111 -74 CURVE",
+"148 10 LINE",
+"106 10 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"180 -235 OFFCURVE",
+"240 -200 OFFCURVE",
+"240 -138 CURVE SMOOTH",
+"240 -92 OFFCURVE",
+"199 -66 OFFCURVE",
+"136 -66 CURVE SMOOTH",
+"117 -66 LINE",
+"141 10 LINE",
+"96 10 LINE",
+"57 -100 LINE",
+"112 -101 OFFCURVE",
+"137 -118 OFFCURVE",
+"137 -150 CURVE SMOOTH",
+"137 -181 OFFCURVE",
+"114 -195 OFFCURVE",
+"77 -195 CURVE SMOOTH",
+"57 -195 OFFCURVE",
+"31 -190 OFFCURVE",
+"21 -184 CURVE",
+"10 -218 LINE",
+"21 -225 OFFCURVE",
+"50 -235 OFFCURVE",
+"90 -235 CURVE SMOOTH"
+);
+}
+);
+width = 250;
+}
+);
+unicode = 00B8;
+},
+{
+glyphname = ogonek;
+lastChange = "2016-08-22 12:12:02 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"138 -231 OFFCURVE",
+"176 -214 OFFCURVE",
+"197 -188 CURVE",
+"197 -161 LINE",
+"193 -161 LINE",
+"164 -182 OFFCURVE",
+"144 -190 OFFCURVE",
+"126 -190 CURVE SMOOTH",
+"97 -190 OFFCURVE",
+"80 -171 OFFCURVE",
+"80 -137 CURVE SMOOTH",
+"80 -87 OFFCURVE",
+"118 -34 OFFCURVE",
+"194 22 CURVE",
+"158 22 LINE",
+"47 -51 OFFCURVE",
+"10 -94 OFFCURVE",
+"10 -147 CURVE SMOOTH",
+"10 -198 OFFCURVE",
+"46 -231 OFFCURVE",
+"100 -231 CURVE"
+);
+}
+);
+width = 210;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"138 -231 OFFCURVE",
+"176 -214 OFFCURVE",
+"197 -188 CURVE",
+"197 -161 LINE",
+"193 -161 LINE",
+"164 -182 OFFCURVE",
+"144 -190 OFFCURVE",
+"126 -190 CURVE SMOOTH",
+"97 -190 OFFCURVE",
+"80 -171 OFFCURVE",
+"80 -137 CURVE SMOOTH",
+"80 -87 OFFCURVE",
+"118 -34 OFFCURVE",
+"194 22 CURVE",
+"158 22 LINE",
+"47 -51 OFFCURVE",
+"10 -94 OFFCURVE",
+"10 -147 CURVE SMOOTH",
+"10 -198 OFFCURVE",
+"46 -231 OFFCURVE",
+"100 -231 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"138 -231 OFFCURVE",
+"174 -215 OFFCURVE",
+"197 -188 CURVE",
+"197 -153 LINE",
+"193 -153 LINE",
+"172 -171 OFFCURVE",
+"155 -178 OFFCURVE",
+"136 -178 CURVE SMOOTH",
+"112 -178 OFFCURVE",
+"100 -166 OFFCURVE",
+"100 -140 CURVE SMOOTH",
+"100 -94 OFFCURVE",
+"137 -33 OFFCURVE",
+"197 22 CURVE",
+"151 22 LINE",
+"47 -53 OFFCURVE",
+"10 -97 OFFCURVE",
+"10 -149 CURVE SMOOTH",
+"10 -199 OFFCURVE",
+"45 -231 OFFCURVE",
+"99 -231 CURVE SMOOTH"
+);
+}
+);
+width = 249;
+}
+);
+unicode = 02DB;
+},
+{
+glyphname = caron.alt;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"115 544 OFFCURVE",
+"162 600 OFFCURVE",
+"162 667 CURVE SMOOTH",
+"162 721 OFFCURVE",
+"131 763 OFFCURVE",
+"80 763 CURVE SMOOTH",
+"37 763 OFFCURVE",
+"10 734 OFFCURVE",
+"10 699 CURVE SMOOTH",
+"10 675 OFFCURVE",
+"24 649 OFFCURVE",
+"60 649 CURVE SMOOTH",
+"91 649 OFFCURVE",
+"111 676 OFFCURVE",
+"120 676 CURVE SMOOTH",
+"123 676 OFFCURVE",
+"125 673 OFFCURVE",
+"125 662 CURVE SMOOTH",
+"125 617 OFFCURVE",
+"93 569 OFFCURVE",
+"33 529 CURVE",
+"53 506 LINE"
+);
+}
+);
+width = 172;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"133 524 OFFCURVE",
+"176 573 OFFCURVE",
+"176 647 CURVE SMOOTH",
+"176 709 OFFCURVE",
+"146 764 OFFCURVE",
+"89 764 CURVE SMOOTH",
+"44 764 OFFCURVE",
+"10 730 OFFCURVE",
+"10 687 CURVE SMOOTH",
+"10 653 OFFCURVE",
+"30 620 OFFCURVE",
+"68 620 CURVE SMOOTH",
+"106 620 OFFCURVE",
+"111 652 OFFCURVE",
+"123 652 CURVE SMOOTH",
+"127 652 OFFCURVE",
+"132 648 OFFCURVE",
+"132 628 CURVE SMOOTH",
+"132 581 OFFCURVE",
+"105 543 OFFCURVE",
+"46 501 CURVE",
+"66 479 LINE"
+);
+}
+);
+width = 186;
+}
+);
+},
+{
+glyphname = dblgravecomb.cap;
+lastChange = "2016-08-22 11:53:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{213, 754}";
+},
+{
+name = top;
+position = "{213, 924}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"416 792 LINE",
+"298 884 LINE SMOOTH",
+"254 918 OFFCURVE",
+"246 924 OFFCURVE",
+"232 924 CURVE SMOOTH",
+"204 924 OFFCURVE",
+"188 907 OFFCURVE",
+"188 881 CURVE SMOOTH",
+"188 855 OFFCURVE",
+"205 837 OFFCURVE",
+"238 828 CURVE SMOOTH",
+"373 792 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 792 LINE",
+"120 884 LINE SMOOTH",
+"76 918 OFFCURVE",
+"68 924 OFFCURVE",
+"54 924 CURVE SMOOTH",
+"26 924 OFFCURVE",
+"10 907 OFFCURVE",
+"10 881 CURVE SMOOTH",
+"10 855 OFFCURVE",
+"27 837 OFFCURVE",
+"60 828 CURVE SMOOTH",
+"195 792 LINE"
+);
+}
+);
+width = 426;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{268, 754}";
+},
+{
+name = top;
+position = "{268, 924}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"525 787 LINE",
+"364 891 LINE SMOOTH",
+"329 914 OFFCURVE",
+"311 924 OFFCURVE",
+"282 924 CURVE SMOOTH",
+"249 924 OFFCURVE",
+"232 902 OFFCURVE",
+"232 878 CURVE SMOOTH",
+"232 855 OFFCURVE",
+"241 831 OFFCURVE",
+"285 822 CURVE SMOOTH",
+"462 787 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"303 787 LINE",
+"142 891 LINE SMOOTH",
+"107 914 OFFCURVE",
+"89 924 OFFCURVE",
+"60 924 CURVE SMOOTH",
+"27 924 OFFCURVE",
+"10 902 OFFCURVE",
+"10 878 CURVE SMOOTH",
+"10 855 OFFCURVE",
+"19 831 OFFCURVE",
+"63 822 CURVE SMOOTH",
+"240 787 LINE"
+);
+}
+);
+width = 535;
+}
+);
+},
+{
+glyphname = breveinvertedcomb.cap;
+lastChange = "2016-08-22 11:53:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{167, 754}";
+},
+{
+name = top;
+position = "{167, 924}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"44 792 LINE",
+"47 838 OFFCURVE",
+"95 856 OFFCURVE",
+"165 856 CURVE SMOOTH",
+"236 856 OFFCURVE",
+"286 836 OFFCURVE",
+"289 792 CURVE",
+"323 792 LINE",
+"323 869 OFFCURVE",
+"273 924 OFFCURVE",
+"167 924 CURVE SMOOTH",
+"64 924 OFFCURVE",
+"10 873 OFFCURVE",
+"10 792 CURVE"
+);
+}
+);
+width = 333;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{177, 754}";
+},
+{
+name = top;
+position = "{177, 924}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"54 787 LINE",
+"57 819 OFFCURVE",
+"105 831 OFFCURVE",
+"175 831 CURVE SMOOTH",
+"246 831 OFFCURVE",
+"296 817 OFFCURVE",
+"299 787 CURVE",
+"343 787 LINE",
+"343 864 OFFCURVE",
+"290 924 OFFCURVE",
+"177 924 CURVE SMOOTH",
+"67 924 OFFCURVE",
+"10 868 OFFCURVE",
+"10 787 CURVE"
+);
+}
+);
+width = 353;
+}
+);
+},
+{
+glyphname = dieresis.case;
+lastChange = "2016-08-22 11:55:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{164, 754}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"285 800 OFFCURVE",
+"310 825 OFFCURVE",
+"310 855 CURVE SMOOTH",
+"310 885 OFFCURVE",
+"285 910 OFFCURVE",
+"255 910 CURVE SMOOTH",
+"225 910 OFFCURVE",
+"200 885 OFFCURVE",
+"200 855 CURVE SMOOTH",
+"200 825 OFFCURVE",
+"225 800 OFFCURVE",
+"255 800 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"95 800 OFFCURVE",
+"120 825 OFFCURVE",
+"120 855 CURVE SMOOTH",
+"120 885 OFFCURVE",
+"95 910 OFFCURVE",
+"65 910 CURVE SMOOTH",
+"35 910 OFFCURVE",
+"10 885 OFFCURVE",
+"10 855 CURVE SMOOTH",
+"10 825 OFFCURVE",
+"35 800 OFFCURVE",
+"65 800 CURVE SMOOTH"
+);
+}
+);
+width = 320;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{170, 754}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"302 792 OFFCURVE",
+"332 822 OFFCURVE",
+"332 858 CURVE SMOOTH",
+"332 894 OFFCURVE",
+"302 924 OFFCURVE",
+"266 924 CURVE SMOOTH",
+"230 924 OFFCURVE",
+"200 894 OFFCURVE",
+"200 858 CURVE SMOOTH",
+"200 822 OFFCURVE",
+"230 792 OFFCURVE",
+"266 792 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"112 792 OFFCURVE",
+"142 822 OFFCURVE",
+"142 858 CURVE SMOOTH",
+"142 894 OFFCURVE",
+"112 924 OFFCURVE",
+"76 924 CURVE SMOOTH",
+"40 924 OFFCURVE",
+"10 894 OFFCURVE",
+"10 858 CURVE SMOOTH",
+"10 822 OFFCURVE",
+"40 792 OFFCURVE",
+"76 792 CURVE SMOOTH"
+);
+}
+);
+width = 342;
+}
+);
+},
+{
+glyphname = dotaccent.case;
+lastChange = "2016-08-22 12:08:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{75, 749}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"112 792 OFFCURVE",
+"142 822 OFFCURVE",
+"142 858 CURVE SMOOTH",
+"142 894 OFFCURVE",
+"112 924 OFFCURVE",
+"76 924 CURVE SMOOTH",
+"40 924 OFFCURVE",
+"10 894 OFFCURVE",
+"10 858 CURVE SMOOTH",
+"10 822 OFFCURVE",
+"40 792 OFFCURVE",
+"76 792 CURVE SMOOTH"
+);
+}
+);
+width = 152;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{79, 752}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"116 787 OFFCURVE",
+"147 818 OFFCURVE",
+"147 855 CURVE SMOOTH",
+"147 893 OFFCURVE",
+"116 924 OFFCURVE",
+"78 924 CURVE SMOOTH",
+"41 924 OFFCURVE",
+"10 893 OFFCURVE",
+"10 855 CURVE SMOOTH",
+"10 818 OFFCURVE",
+"41 787 OFFCURVE",
+"78 787 CURVE SMOOTH"
+);
+}
+);
+width = 157;
+}
+);
+},
+{
+glyphname = grave.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"278 792 LINE",
+"127 888 LINE SMOOTH",
+"80 918 OFFCURVE",
+"68 924 OFFCURVE",
+"54 924 CURVE SMOOTH",
+"26 924 OFFCURVE",
+"10 907 OFFCURVE",
+"10 881 CURVE SMOOTH",
+"10 855 OFFCURVE",
+"27 835 OFFCURVE",
+"60 828 CURVE SMOOTH",
+"235 792 LINE"
+);
+}
+);
+width = 288;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"303 787 LINE",
+"142 891 LINE SMOOTH",
+"107 914 OFFCURVE",
+"89 924 OFFCURVE",
+"60 924 CURVE SMOOTH",
+"27 924 OFFCURVE",
+"10 902 OFFCURVE",
+"10 878 CURVE SMOOTH",
+"10 855 OFFCURVE",
+"19 831 OFFCURVE",
+"63 822 CURVE SMOOTH",
+"240 787 LINE"
+);
+}
+);
+width = 313;
+}
+);
+},
+{
+glyphname = acute.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"53 792 LINE",
+"228 828 LINE SMOOTH",
+"261 835 OFFCURVE",
+"278 855 OFFCURVE",
+"278 881 CURVE SMOOTH",
+"278 907 OFFCURVE",
+"262 924 OFFCURVE",
+"234 924 CURVE SMOOTH",
+"220 924 OFFCURVE",
+"208 918 OFFCURVE",
+"161 888 CURVE SMOOTH",
+"10 792 LINE"
+);
+}
+);
+width = 288;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"73 787 LINE",
+"250 822 LINE SMOOTH",
+"294 831 OFFCURVE",
+"303 855 OFFCURVE",
+"303 878 CURVE SMOOTH",
+"303 902 OFFCURVE",
+"286 924 OFFCURVE",
+"253 924 CURVE SMOOTH",
+"224 924 OFFCURVE",
+"206 914 OFFCURVE",
+"171 891 CURVE SMOOTH",
+"10 787 LINE"
+);
+}
+);
+width = 313;
+}
+);
+},
+{
+glyphname = hungarumlaut.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"231 792 LINE",
+"366 828 LINE SMOOTH",
+"398 837 OFFCURVE",
+"416 855 OFFCURVE",
+"416 881 CURVE SMOOTH",
+"416 907 OFFCURVE",
+"400 924 OFFCURVE",
+"372 924 CURVE SMOOTH",
+"358 924 OFFCURVE",
+"350 918 OFFCURVE",
+"306 884 CURVE SMOOTH",
+"188 792 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"53 792 LINE",
+"188 828 LINE SMOOTH",
+"220 837 OFFCURVE",
+"238 855 OFFCURVE",
+"238 881 CURVE SMOOTH",
+"238 907 OFFCURVE",
+"222 924 OFFCURVE",
+"194 924 CURVE SMOOTH",
+"180 924 OFFCURVE",
+"172 918 OFFCURVE",
+"128 884 CURVE SMOOTH",
+"10 792 LINE"
+);
+}
+);
+width = 426;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 787 LINE",
+"472 822 LINE SMOOTH",
+"516 831 OFFCURVE",
+"525 855 OFFCURVE",
+"525 878 CURVE SMOOTH",
+"525 902 OFFCURVE",
+"508 924 OFFCURVE",
+"475 924 CURVE SMOOTH",
+"446 924 OFFCURVE",
+"428 914 OFFCURVE",
+"393 891 CURVE SMOOTH",
+"232 787 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"73 787 LINE",
+"250 822 LINE SMOOTH",
+"294 831 OFFCURVE",
+"303 855 OFFCURVE",
+"303 878 CURVE SMOOTH",
+"303 902 OFFCURVE",
+"286 924 OFFCURVE",
+"253 924 CURVE SMOOTH",
+"224 924 OFFCURVE",
+"206 914 OFFCURVE",
+"171 891 CURVE SMOOTH",
+"10 787 LINE"
+);
+}
+);
+width = 535;
+}
+);
+},
+{
+glyphname = circumflex.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"53 792 LINE",
+"172 853 LINE",
+"291 792 LINE",
+"334 792 LINE",
+"203 924 LINE",
+"141 924 LINE",
+"10 792 LINE"
+);
+}
+);
+width = 344;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"63 788 LINE",
+"212 830 LINE",
+"361 788 LINE",
+"414 788 LINE",
+"243 924 LINE",
+"181 924 LINE",
+"10 788 LINE"
+);
+}
+);
+width = 424;
+}
+);
+},
+{
+glyphname = caron.case;
+lastChange = "2016-08-22 12:00:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{170, 753}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"203 792 LINE",
+"334 924 LINE",
+"291 924 LINE",
+"172 863 LINE",
+"53 924 LINE",
+"10 924 LINE",
+"141 792 LINE"
+);
+}
+);
+width = 344;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{214, 752}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"243 788 LINE",
+"414 924 LINE",
+"361 924 LINE",
+"212 882 LINE",
+"63 924 LINE",
+"10 924 LINE",
+"181 788 LINE"
+);
+}
+);
+width = 424;
+}
+);
+},
+{
+glyphname = breve.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"273 792 OFFCURVE",
+"323 847 OFFCURVE",
+"323 924 CURVE",
+"289 924 LINE",
+"286 880 OFFCURVE",
+"236 860 OFFCURVE",
+"165 860 CURVE SMOOTH",
+"95 860 OFFCURVE",
+"47 878 OFFCURVE",
+"44 924 CURVE",
+"10 924 LINE",
+"10 843 OFFCURVE",
+"64 792 OFFCURVE",
+"167 792 CURVE SMOOTH"
+);
+}
+);
+width = 333;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"290 787 OFFCURVE",
+"343 847 OFFCURVE",
+"343 924 CURVE",
+"299 924 LINE",
+"296 894 OFFCURVE",
+"246 880 OFFCURVE",
+"175 880 CURVE SMOOTH",
+"105 880 OFFCURVE",
+"57 892 OFFCURVE",
+"54 924 CURVE",
+"10 924 LINE",
+"10 843 OFFCURVE",
+"67 787 OFFCURVE",
+"177 787 CURVE SMOOTH"
+);
+}
+);
+width = 353;
+}
+);
+},
+{
+glyphname = ring.case;
+lastChange = "2022-01-26 09:45:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{101, 714}";
+},
+{
+name = top;
+position = "{101, 924}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"142 777 OFFCURVE",
+"174 811 OFFCURVE",
+"174 852 CURVE SMOOTH",
+"174 893 OFFCURVE",
+"141 924 OFFCURVE",
+"101 924 CURVE SMOOTH",
+"61 924 OFFCURVE",
+"27 892 OFFCURVE",
+"27 852 CURVE SMOOTH",
+"27 811 OFFCURVE",
+"61 777 OFFCURVE",
+"101 777 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 810 OFFCURVE",
+"60 830 OFFCURVE",
+"60 852 CURVE SMOOTH",
+"60 873 OFFCURVE",
+"80 891 OFFCURVE",
+"101 891 CURVE SMOOTH",
+"122 891 OFFCURVE",
+"141 873 OFFCURVE",
+"141 852 CURVE SMOOTH",
+"141 830 OFFCURVE",
+"123 810 OFFCURVE",
+"101 810 CURVE SMOOTH"
+);
+}
+);
+width = 201;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{108, 674}";
+},
+{
+name = top;
+position = "{106, 924}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"159 732 OFFCURVE",
+"203 776 OFFCURVE",
+"203 828 CURVE SMOOTH",
+"203 881 OFFCURVE",
+"159 924 OFFCURVE",
+"106 924 CURVE SMOOTH",
+"54 924 OFFCURVE",
+"10 881 OFFCURVE",
+"10 828 CURVE SMOOTH",
+"10 776 OFFCURVE",
+"54 732 OFFCURVE",
+"106 732 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"83 785 OFFCURVE",
+"64 806 OFFCURVE",
+"64 828 CURVE SMOOTH",
+"64 851 OFFCURVE",
+"84 870 OFFCURVE",
+"106 870 CURVE SMOOTH",
+"129 870 OFFCURVE",
+"149 851 OFFCURVE",
+"149 828 CURVE SMOOTH",
+"149 805 OFFCURVE",
+"130 785 OFFCURVE",
+"106 785 CURVE SMOOTH"
+);
+}
+);
+width = 213;
+}
+);
+},
+{
+glyphname = tilde.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"43 791 LINE",
+"50 819 OFFCURVE",
+"73 840 OFFCURVE",
+"106 840 CURVE SMOOTH",
+"153 840 OFFCURVE",
+"187 792 OFFCURVE",
+"243 792 CURVE SMOOTH",
+"312 792 OFFCURVE",
+"348 856 OFFCURVE",
+"362 919 CURVE",
+"328 919 LINE",
+"321 898 OFFCURVE",
+"303 868 OFFCURVE",
+"265 868 CURVE SMOOTH",
+"219 868 OFFCURVE",
+"182 916 OFFCURVE",
+"128 916 CURVE SMOOTH",
+"62 916 OFFCURVE",
+"20 853 OFFCURVE",
+"10 791 CURVE"
+);
+}
+);
+width = 372;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"43 787 LINE",
+"52 811 OFFCURVE",
+"83 828 OFFCURVE",
+"126 828 CURVE SMOOTH",
+"173 828 OFFCURVE",
+"207 788 OFFCURVE",
+"263 788 CURVE SMOOTH",
+"344 788 OFFCURVE",
+"386 856 OFFCURVE",
+"402 924 CURVE",
+"368 924 LINE",
+"359 907 OFFCURVE",
+"335 884 OFFCURVE",
+"285 884 CURVE SMOOTH",
+"239 884 OFFCURVE",
+"202 924 OFFCURVE",
+"148 924 CURVE SMOOTH",
+"70 924 OFFCURVE",
+"22 854 OFFCURVE",
+"10 787 CURVE"
+);
+}
+);
+width = 412;
+}
+);
+},
+{
+glyphname = macron.case;
+lastChange = "2016-08-22 11:58:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{168, 754}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"330 851 LINE",
+"330 917 LINE",
+"10 917 LINE",
+"10 851 LINE"
+);
+}
+);
+width = 340;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{172, 755}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 813 LINE",
+"350 899 LINE",
+"10 899 LINE",
+"10 813 LINE"
+);
+}
+);
+width = 360;
+}
+);
+},
+{
+glyphname = apostrophemod;
+lastChange = "2016-10-31 09:56:15 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"162 721 OFFCURVE",
+"131 763 OFFCURVE",
+"80 763 CURVE SMOOTH",
+"37 763 OFFCURVE",
+"10 734 OFFCURVE",
+"10 699 CURVE SMOOTH",
+"10 675 OFFCURVE",
+"24 649 OFFCURVE",
+"60 649 CURVE SMOOTH",
+"91 649 OFFCURVE",
+"111 676 OFFCURVE",
+"120 676 CURVE SMOOTH",
+"123 676 OFFCURVE",
+"125 673 OFFCURVE",
+"125 662 CURVE SMOOTH",
+"125 617 OFFCURVE",
+"93 569 OFFCURVE",
+"33 529 CURVE",
+"53 506 LINE",
+"115 544 OFFCURVE",
+"162 600 OFFCURVE",
+"162 667 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"115 544 OFFCURVE",
+"162 600 OFFCURVE",
+"162 667 CURVE SMOOTH",
+"162 667 LINE SMOOTH",
+"162 721 OFFCURVE",
+"131 763 OFFCURVE",
+"80 763 CURVE SMOOTH",
+"37 763 OFFCURVE",
+"10 734 OFFCURVE",
+"10 699 CURVE SMOOTH",
+"10 675 OFFCURVE",
+"24 649 OFFCURVE",
+"60 649 CURVE SMOOTH",
+"91 649 OFFCURVE",
+"111 676 OFFCURVE",
+"120 676 CURVE SMOOTH",
+"123 676 OFFCURVE",
+"125 673 OFFCURVE",
+"125 662 CURVE SMOOTH",
+"125 617 OFFCURVE",
+"93 569 OFFCURVE",
+"33 529 CURVE",
+"53 506 LINE"
+);
+}
+);
+width = 172;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"176 709 OFFCURVE",
+"146 764 OFFCURVE",
+"89 764 CURVE SMOOTH",
+"44 764 OFFCURVE",
+"10 730 OFFCURVE",
+"10 687 CURVE SMOOTH",
+"10 653 OFFCURVE",
+"30 620 OFFCURVE",
+"68 620 CURVE SMOOTH",
+"106 620 OFFCURVE",
+"111 652 OFFCURVE",
+"123 652 CURVE SMOOTH",
+"127 652 OFFCURVE",
+"132 648 OFFCURVE",
+"132 628 CURVE SMOOTH",
+"132 581 OFFCURVE",
+"105 543 OFFCURVE",
+"46 501 CURVE",
+"66 479 LINE",
+"133 524 OFFCURVE",
+"176 573 OFFCURVE",
+"176 647 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"133 524 OFFCURVE",
+"176 573 OFFCURVE",
+"176 647 CURVE SMOOTH",
+"176 647 LINE SMOOTH",
+"176 709 OFFCURVE",
+"146 764 OFFCURVE",
+"89 764 CURVE SMOOTH",
+"44 764 OFFCURVE",
+"10 730 OFFCURVE",
+"10 687 CURVE SMOOTH",
+"10 653 OFFCURVE",
+"30 620 OFFCURVE",
+"68 620 CURVE SMOOTH",
+"106 620 OFFCURVE",
+"111 652 OFFCURVE",
+"123 652 CURVE SMOOTH",
+"127 652 OFFCURVE",
+"132 648 OFFCURVE",
+"132 628 CURVE SMOOTH",
+"132 581 OFFCURVE",
+"105 543 OFFCURVE",
+"46 501 CURVE",
+"66 479 LINE"
+);
+}
+);
+width = 186;
+}
+);
+unicode = 02BC;
+},
+{
+glyphname = dotbelow;
+lastChange = "2016-08-22 09:40:48 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"112 -231 OFFCURVE",
+"142 -201 OFFCURVE",
+"142 -165 CURVE SMOOTH",
+"142 -129 OFFCURVE",
+"112 -99 OFFCURVE",
+"76 -99 CURVE SMOOTH",
+"40 -99 OFFCURVE",
+"10 -129 OFFCURVE",
+"10 -165 CURVE SMOOTH",
+"10 -201 OFFCURVE",
+"40 -231 OFFCURVE",
+"76 -231 CURVE SMOOTH"
+);
+}
+);
+width = 152;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 -260 OFFCURVE",
+"171 -223 OFFCURVE",
+"171 -180 CURVE SMOOTH",
+"171 -136 OFFCURVE",
+"134 -99 OFFCURVE",
+"90 -99 CURVE SMOOTH",
+"47 -99 OFFCURVE",
+"10 -136 OFFCURVE",
+"10 -180 CURVE SMOOTH",
+"10 -223 OFFCURVE",
+"47 -260 OFFCURVE",
+"90 -260 CURVE SMOOTH"
+);
+}
+);
+width = 181;
+}
+);
+},
+{
+glyphname = espaciador;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"134 -326 LINE",
+"134 924 LINE",
+"0 924 LINE",
+"0 -326 LINE"
+);
+}
+);
+width = 134;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"158 -326 LINE",
+"158 924 LINE",
+"0 924 LINE",
+"0 -326 LINE"
+);
+}
+);
+width = 158;
+}
+);
+}
+);
+instances = (
+{
+interpolationWeight = 400;
+instanceInterpolations = {
+UUID0 = 1;
+};
+name = Regular;
+},
+{
+interpolationWeight = 550;
+instanceInterpolations = {
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = 0.5;
+UUID0 = 0.5;
+};
+linkStyle = Regular;
+name = Medium;
+weightClass = Medium;
+},
+{
+interpolationWeight = 700;
+instanceInterpolations = {
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = 1;
+};
+isBold = 1;
+name = Bold;
+}
+);
+kerning = {
+UUID0 = {
+"@MMK_L_A" = {
+"@MMK_R_A" = -80;
+"@MMK_R_C" = -52;
+"@MMK_R_G" = -52;
+"@MMK_R_O" = -52;
+"@MMK_R_T" = -28;
+"@MMK_R_U" = -48;
+"@MMK_R_W" = -92;
+"@MMK_R_Y" = -24;
+"@MMK_R_a" = 20;
+"@MMK_R_c" = -28;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -24;
+"@MMK_R_g" = 28;
+"@MMK_R_o" = -28;
+"@MMK_R_u" = -8;
+"@MMK_R_w" = -44;
+"@MMK_R_y" = -56;
+V = -112;
+b = -18;
+comma = 32;
+guillemetleft = -52;
+guilsinglleft = -52;
+hyphen = -12;
+period = 28;
+q = -16;
+quotedblleft = -60;
+quotedblright = -64;
+quoteleft = -60;
+quoteright = -64;
+v = -48;
+};
+"@MMK_L_C" = {
+"@MMK_R_A" = 28;
+"@MMK_R_AE" = 16;
+"@MMK_R_C" = -4;
+"@MMK_R_H" = 12;
+"@MMK_R_J" = 36;
+"@MMK_R_K" = 12;
+"@MMK_R_O" = -4;
+"@MMK_R_Y" = -16;
+"@MMK_R_Z" = 4;
+"@MMK_R_y" = -20;
+V = -36;
+comma = 40;
+hyphen = 28;
+period = 36;
+};
+"@MMK_L_D" = {
+"@MMK_R_A" = -52;
+"@MMK_R_J" = -40;
+"@MMK_R_N" = -20;
+"@MMK_R_T" = -4;
+"@MMK_R_U" = -28;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -64;
+V = -68;
+X = -48;
+comma = -8;
+period = -8;
+quotedblleft = 20;
+quotedblright = 12;
+};
+"@MMK_L_E" = {
+"@MMK_R_C" = -12;
+"@MMK_R_O" = -8;
+"@MMK_R_S" = 8;
+"@MMK_R_T" = -12;
+"@MMK_R_U" = -28;
+"@MMK_R_W" = -28;
+V = -48;
+v = -32;
+};
+"@MMK_L_G" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -58;
+"@MMK_R_T" = -24;
+"@MMK_R_W" = -40;
+"@MMK_R_Y" = -40;
+V = -60;
+X = -32;
+colon = 56;
+comma = 4;
+hyphen = 36;
+semicolon = 56;
+};
+"@MMK_L_H" = {
+"@MMK_R_y" = -12;
+};
+"@MMK_L_J" = {
+"@MMK_R_A" = -36;
+"@MMK_R_AE" = -64;
+"@MMK_R_Z" = -44;
+"@MMK_R_a" = -36;
+"@MMK_R_e" = -32;
+"@MMK_R_o" = -32;
+"@MMK_R_u" = -32;
+"@MMK_R_y" = -24;
+colon = -6;
+comma = -16;
+hyphen = -12;
+period = -16;
+};
+"@MMK_L_K" = {
+"@MMK_R_A" = -40;
+"@MMK_R_C" = -36;
+"@MMK_R_G" = -32;
+"@MMK_R_O" = -36;
+"@MMK_R_S" = 44;
+"@MMK_R_T" = -8;
+"@MMK_R_U" = -28;
+"@MMK_R_W" = -56;
+"@MMK_R_Y" = -4;
+"@MMK_R_a" = 40;
+"@MMK_R_e" = -4;
+"@MMK_R_o" = -8;
+"@MMK_R_u" = 16;
+"@MMK_R_w" = -24;
+"@MMK_R_y" = -44;
+Oslash = 12;
+V = -76;
+guillemetleft = -60;
+hyphen = -20;
+oslash = 8;
+quotedblleft = -52;
+quotedblright = -44;
+v = -40;
+};
+"@MMK_L_L" = {
+"@MMK_R_A" = 36;
+"@MMK_R_AE" = 4;
+"@MMK_R_C" = -8;
+"@MMK_R_G" = -4;
+"@MMK_R_O" = -8;
+"@MMK_R_T" = -52;
+"@MMK_R_U" = -32;
+"@MMK_R_W" = -80;
+"@MMK_R_Y" = -48;
+"@MMK_R_Z" = 16;
+"@MMK_R_w" = -16;
+"@MMK_R_y" = -24;
+V = -100;
+hyphen = 40;
+quotedblleft = -84;
+quotedblright = -96;
+quoteleft = -84;
+quoteright = -96;
+};
+"@MMK_L_N" = {
+"@MMK_R_A" = -4;
+"@MMK_R_AE" = -36;
+"@MMK_R_C" = -16;
+"@MMK_R_G" = -16;
+"@MMK_R_O" = -16;
+"@MMK_R_Z" = -24;
+"@MMK_R_a" = -16;
+"@MMK_R_e" = -12;
+"@MMK_R_o" = -12;
+"@MMK_R_u" = -12;
+"@MMK_R_y" = -4;
+comma = 12;
+oslash = -12;
+period = 8;
+};
+"@MMK_L_O" = {
+"@MMK_R_A" = -52;
+"@MMK_R_AE" = -84;
+"@MMK_R_J" = -36;
+"@MMK_R_N" = -16;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -64;
+"@MMK_R_Z" = -20;
+V = -68;
+X = -48;
+comma = -4;
+hyphen = 24;
+period = -8;
+};
+"@MMK_L_R" = {
+"@MMK_R_A" = -16;
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 68;
+"@MMK_R_O" = -8;
+"@MMK_R_U" = -20;
+"@MMK_R_W" = -28;
+"@MMK_R_Y" = -20;
+"@MMK_R_a" = 24;
+"@MMK_R_e" = -8;
+"@MMK_R_o" = -8;
+"@MMK_R_w" = -12;
+"@MMK_R_y" = -12;
+V = -48;
+hyphen = 16;
+quotedblleft = 24;
+quotedblright = 24;
+quoteleft = 24;
+quoteright = 24;
+v = -12;
+};
+"@MMK_L_S" = {
+"@MMK_R_A" = -16;
+"@MMK_R_AE" = -24;
+"@MMK_R_J" = -4;
+"@MMK_R_S" = 8;
+"@MMK_R_T" = -12;
+"@MMK_R_W" = -24;
+"@MMK_R_Y" = -28;
+"@MMK_R_w" = -12;
+"@MMK_R_y" = -16;
+V = -44;
+comma = 24;
+period = 24;
+v = -16;
+};
+"@MMK_L_T" = {
+"@MMK_R_A" = -24;
+"@MMK_R_AE" = -86;
+"@MMK_R_C" = -4;
+"@MMK_R_J" = -16;
+"@MMK_R_a" = -60;
+"@MMK_R_c" = -96;
+"@MMK_R_d" = -72;
+"@MMK_R_e" = -92;
+"@MMK_R_g" = -56;
+"@MMK_R_h" = -20;
+"@MMK_R_i" = -8;
+"@MMK_R_j" = -8;
+"@MMK_R_o" = -92;
+"@MMK_R_r" = -44;
+"@MMK_R_s" = -56;
+"@MMK_R_u" = -84;
+"@MMK_R_w" = -88;
+"@MMK_R_y" = -88;
+"@MMK_R_z" = -52;
+V = -20;
+colon = -32;
+comma = -48;
+guillemetleft = -124;
+guillemetright = -112;
+guilsinglleft = -124;
+hyphen = -76;
+m = -44;
+oslash = -92;
+period = -52;
+quotedblbase = -48;
+quotesinglbase = -48;
+semicolon = -36;
+v = -88;
+x = -24;
+};
+"@MMK_L_U" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -68;
+"@MMK_R_C" = -20;
+"@MMK_R_S" = -12;
+"@MMK_R_U" = -36;
+"@MMK_R_Z" = -28;
+"@MMK_R_a" = -20;
+"@MMK_R_c" = -20;
+"@MMK_R_d" = -16;
+"@MMK_R_f" = -20;
+"@MMK_R_g" = -16;
+"@MMK_R_j" = -24;
+"@MMK_R_n" = -24;
+"@MMK_R_r" = -20;
+"@MMK_R_s" = -12;
+"@MMK_R_t" = -16;
+"@MMK_R_y" = -4;
+"@MMK_R_z" = -24;
+guillemetleft = -40;
+m = -24;
+p = -16;
+period = -4;
+v = -4;
+};
+"@MMK_L_W" = {
+"@MMK_R_A" = -92;
+"@MMK_R_AE" = -144;
+"@MMK_R_C" = -48;
+"@MMK_R_G" = -48;
+"@MMK_R_O" = -48;
+"@MMK_R_S" = -32;
+"@MMK_R_a" = -64;
+"@MMK_R_c" = -68;
+"@MMK_R_d" = -64;
+"@MMK_R_e" = -64;
+"@MMK_R_g" = -64;
+"@MMK_R_i" = -36;
+"@MMK_R_n" = -40;
+"@MMK_R_o" = -68;
+"@MMK_R_r" = -40;
+"@MMK_R_s" = -60;
+"@MMK_R_u" = -32;
+"@MMK_R_y" = -20;
+"@MMK_R_z" = -60;
+Oslash = -36;
+colon = -12;
+comma = -64;
+guillemetleft = -92;
+guillemetright = -76;
+guilsinglleft = -92;
+guilsinglright = -68;
+hyphen = -52;
+m = -40;
+oslash = -68;
+p = -32;
+period = -68;
+q = -64;
+quotedblbase = -60;
+quotesinglbase = -60;
+semicolon = -8;
+v = -20;
+x = -20;
+};
+"@MMK_L_Y" = {
+"@MMK_R_A" = -12;
+"@MMK_R_AE" = -58;
+"@MMK_R_C" = -60;
+"@MMK_R_G" = -60;
+"@MMK_R_J" = -8;
+"@MMK_R_O" = -60;
+"@MMK_R_S" = -44;
+"@MMK_R_T" = -4;
+"@MMK_R_a" = -52;
+"@MMK_R_c" = -76;
+"@MMK_R_d" = -76;
+"@MMK_R_e" = -72;
+"@MMK_R_g" = -44;
+"@MMK_R_i" = -40;
+"@MMK_R_n" = -36;
+"@MMK_R_o" = -76;
+"@MMK_R_r" = -36;
+"@MMK_R_s" = -48;
+"@MMK_R_t" = -64;
+"@MMK_R_u" = -64;
+"@MMK_R_w" = -52;
+"@MMK_R_y" = -52;
+"@MMK_R_z" = -44;
+Oslash = -52;
+colon = -20;
+comma = -40;
+guillemetleft = -108;
+guillemetright = -96;
+guilsinglleft = -108;
+guilsinglright = -92;
+hyphen = -64;
+m = -36;
+oslash = -76;
+p = -60;
+period = -44;
+q = -76;
+quotedblbase = -36;
+quotesinglbase = -36;
+semicolon = -16;
+v = -52;
+x = -16;
+};
+"@MMK_L_Z" = {
+"@MMK_R_U" = -24;
+"@MMK_R_W" = -12;
+"@MMK_R_w" = -16;
+"@MMK_R_y" = -28;
+comma = 44;
+period = 50;
+v = -24;
+};
+"@MMK_L_a" = {
+"@MMK_R_j" = -8;
+"@MMK_R_w" = -4;
+"@MMK_R_y" = -8;
+quoteright = -16;
+v = -8;
+};
+"@MMK_L_c" = {
+"@MMK_R_h" = -8;
+comma = 24;
+};
+"@MMK_L_d" = {
+"@MMK_R_j" = -4;
+"@MMK_R_w" = 12;
+"@MMK_R_y" = 12;
+v = 12;
+};
+"@MMK_L_e" = {
+"@MMK_R_y" = -4;
+v = -4;
+x = -4;
+};
+"@MMK_L_f" = {
+"@MMK_R_c" = -24;
+"@MMK_R_e" = -20;
+"@MMK_R_f" = 32;
+"@MMK_R_i" = 28;
+"@MMK_R_j" = 28;
+"@MMK_R_l" = 28;
+"@MMK_R_o" = -20;
+"@MMK_R_s" = 8;
+"@MMK_R_t" = 36;
+asterisk = 64;
+bracketright = 32;
+comma = 16;
+exclam = 56;
+guillemetleft = -56;
+oslash = -20;
+parenright = 70;
+period = 12;
+question = 78;
+quotedblleft = 70;
+quotedblright = 78;
+quoteleft = 70;
+quoteright = 68;
+};
+"@MMK_L_g" = {
+"@MMK_R_e" = -12;
+"@MMK_R_r" = 24;
+comma = -4;
+period = -12;
+};
+"@MMK_L_h" = {
+"@MMK_R_w" = -4;
+"@MMK_R_y" = -8;
+quotedblright = -12;
+quoteright = -12;
+v = -8;
+};
+"@MMK_L_i" = {
+"@MMK_R_T" = -20;
+"@MMK_R_j" = -20;
+"@MMK_R_t" = -12;
+};
+"@MMK_L_j" = {
+comma = 8;
+};
+"@MMK_L_k" = {
+"@MMK_R_a" = 32;
+"@MMK_R_c" = -16;
+"@MMK_R_e" = -8;
+"@MMK_R_g" = 44;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = 40;
+"@MMK_R_u" = 30;
+"@MMK_R_y" = -12;
+comma = 48;
+hyphen = -20;
+period = 44;
+};
+"@MMK_L_l" = {
+"@MMK_R_y" = 4;
+v = 8;
+};
+"@MMK_L_n" = {
+"@MMK_R_T" = -44;
+"@MMK_R_y" = -8;
+quoteright = -12;
+v = -8;
+};
+"@MMK_L_o" = {
+"@MMK_R_T" = -100;
+"@MMK_R_f" = -16;
+"@MMK_R_t" = -8;
+"@MMK_R_w" = -16;
+"@MMK_R_y" = -20;
+comma = 8;
+period = 8;
+quotedblleft = -4;
+quoteright = -16;
+v = -20;
+x = -20;
+};
+"@MMK_L_r" = {
+"@MMK_R_a" = -4;
+"@MMK_R_c" = -12;
+"@MMK_R_d" = -8;
+"@MMK_R_e" = -8;
+"@MMK_R_f" = 24;
+"@MMK_R_g" = -8;
+"@MMK_R_h" = -16;
+"@MMK_R_i" = 20;
+"@MMK_R_j" = 20;
+"@MMK_R_k" = -12;
+"@MMK_R_l" = -12;
+"@MMK_R_n" = 16;
+"@MMK_R_o" = -12;
+"@MMK_R_r" = 20;
+"@MMK_R_t" = 28;
+"@MMK_R_u" = 28;
+"@MMK_R_w" = 40;
+"@MMK_R_y" = 36;
+b = -8;
+colon = 24;
+comma = -36;
+guillemetleft = -60;
+hyphen = -56;
+m = 20;
+oslash = -16;
+p = 28;
+period = -40;
+q = -8;
+quotedblbase = -32;
+quoteright = 12;
+quotesinglbase = -32;
+v = 40;
+x = 36;
+};
+"@MMK_L_s" = {
+"@MMK_R_t" = 8;
+"@MMK_R_w" = 20;
+"@MMK_R_y" = 20;
+v = 20;
+};
+"@MMK_L_t" = {
+"@MMK_R_S" = 8;
+"@MMK_R_a" = 16;
+"@MMK_R_c" = -12;
+"@MMK_R_e" = -8;
+"@MMK_R_h" = 12;
+"@MMK_R_o" = -12;
+colon = 40;
+quoteright = -8;
+semicolon = 40;
+};
+"@MMK_L_u" = {
+quoteright = -8;
+};
+"@MMK_L_w" = {
+"@MMK_R_a" = 8;
+"@MMK_R_c" = -12;
+"@MMK_R_e" = -4;
+"@MMK_R_l" = 16;
+"@MMK_R_o" = -8;
+"@MMK_R_s" = 16;
+colon = 40;
+comma = -20;
+hyphen = -4;
+oslash = -12;
+period = -24;
+quotedblbase = -16;
+quotesinglbase = -16;
+semicolon = 40;
+};
+"@MMK_L_y" = {
+"@MMK_R_a" = -4;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -16;
+"@MMK_R_g" = -16;
+"@MMK_R_l" = 8;
+"@MMK_R_o" = -20;
+colon = 24;
+comma = -36;
+hyphen = -16;
+oslash = -28;
+period = -36;
+quotedblbase = -28;
+quotesinglbase = -28;
+semicolon = 20;
+};
+"@MMK_L_z" = {
+colon = 60;
+comma = 36;
+};
+B = {
+"@MMK_R_A" = -28;
+"@MMK_R_AE" = -56;
+"@MMK_R_G" = -12;
+"@MMK_R_J" = -16;
+"@MMK_R_O" = -12;
+"@MMK_R_T" = -16;
+"@MMK_R_U" = -32;
+"@MMK_R_W" = -44;
+"@MMK_R_Y" = -52;
+"@MMK_R_y" = -24;
+V = -64;
+X = -20;
+comma = 20;
+hyphen = 28;
+period = -4;
+quotedblright = 8;
+slash = 38;
+};
+F = {
+"@MMK_R_A" = -84;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = -60;
+"@MMK_R_O" = -4;
+"@MMK_R_T" = 12;
+"@MMK_R_a" = -64;
+"@MMK_R_e" = -68;
+"@MMK_R_i" = -12;
+"@MMK_R_j" = -12;
+"@MMK_R_o" = -72;
+"@MMK_R_r" = -12;
+"@MMK_R_u" = -8;
+colon = -16;
+comma = -80;
+guillemetleft = -92;
+hyphen = -48;
+oslash = -72;
+period = -80;
+quotedblbase = -76;
+quotesinglbase = -76;
+};
+Lslash = {
+"@MMK_R_T" = -52;
+"@MMK_R_W" = -80;
+"@MMK_R_Y" = -48;
+V = -100;
+quotedblleft = -84;
+quotedblright = -88;
+quoteleft = -84;
+quoteright = -88;
+};
+Oslash = {
+"@MMK_R_A" = -44;
+"@MMK_R_Y" = -56;
+V = -60;
+X = -36;
+comma = 8;
+hyphen = 32;
+};
+P = {
+"@MMK_R_A" = -92;
+"@MMK_R_AE" = -152;
+"@MMK_R_J" = -60;
+"@MMK_R_T" = 16;
+"@MMK_R_Y" = -32;
+"@MMK_R_a" = -52;
+"@MMK_R_c" = -72;
+"@MMK_R_e" = -64;
+"@MMK_R_g" = -60;
+"@MMK_R_o" = -68;
+"@MMK_R_s" = -44;
+"@MMK_R_u" = 8;
+"@MMK_R_y" = 16;
+colon = -24;
+comma = -108;
+guillemetleft = -116;
+hyphen = -76;
+oslash = -72;
+period = -104;
+quotedblbase = -104;
+quotedblleft = 44;
+quotesinglbase = -104;
+semicolon = -28;
+};
+Q = {
+"@MMK_R_A" = -52;
+"@MMK_R_U" = -28;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -64;
+V = -68;
+period = -4;
+};
+V = {
+"@MMK_R_A" = -112;
+"@MMK_R_AE" = -174;
+"@MMK_R_C" = -68;
+"@MMK_R_G" = -68;
+"@MMK_R_J" = -92;
+"@MMK_R_O" = -68;
+"@MMK_R_S" = -52;
+"@MMK_R_T" = -20;
+"@MMK_R_a" = -84;
+"@MMK_R_c" = -88;
+"@MMK_R_d" = -84;
+"@MMK_R_e" = -84;
+"@MMK_R_g" = -88;
+"@MMK_R_i" = -56;
+"@MMK_R_n" = -60;
+"@MMK_R_o" = -88;
+"@MMK_R_r" = -60;
+"@MMK_R_s" = -76;
+"@MMK_R_u" = -52;
+"@MMK_R_w" = -40;
+"@MMK_R_y" = -40;
+"@MMK_R_z" = -80;
+Oslash = -56;
+colon = -32;
+comma = -84;
+guillemetleft = -112;
+guillemetright = -92;
+guilsinglleft = -112;
+guilsinglright = -88;
+hyphen = -72;
+m = -60;
+oslash = -88;
+p = -52;
+period = -88;
+q = -84;
+quotedblbase = -80;
+quotesinglbase = -80;
+semicolon = -28;
+v = -40;
+x = -40;
+};
+X = {
+"@MMK_R_A" = -66;
+"@MMK_R_C" = -48;
+"@MMK_R_G" = -44;
+"@MMK_R_O" = -48;
+"@MMK_R_T" = -24;
+"@MMK_R_a" = 28;
+"@MMK_R_e" = -12;
+"@MMK_R_o" = -16;
+"@MMK_R_y" = -60;
+Oslash = -8;
+guillemetleft = -60;
+guilsinglleft = -60;
+hyphen = -20;
+quotedblleft = -32;
+};
+b = {
+"@MMK_R_w" = -8;
+"@MMK_R_y" = -12;
+comma = 12;
+v = -12;
+};
+comma = {
+one = 24;
+quotedblright = -16;
+quoteright = -16;
+};
+eight = {
+four = 16;
+one = -20;
+seven = -12;
+};
+five = {
+four = 20;
+seven = -36;
+};
+four = {
+four = 20;
+seven = -40;
+};
+guillemetleft = {
+"@MMK_R_J" = 16;
+"@MMK_R_T" = -108;
+"@MMK_R_U" = -36;
+"@MMK_R_W" = -72;
+"@MMK_R_Y" = -100;
+V = -92;
+};
+guillemetright = {
+"@MMK_R_A" = -44;
+"@MMK_R_AE" = -80;
+"@MMK_R_J" = -52;
+"@MMK_R_T" = -120;
+"@MMK_R_U" = -44;
+"@MMK_R_W" = -88;
+"@MMK_R_Y" = -108;
+V = -108;
+X = -72;
+};
+guilsinglleft = {
+"@MMK_R_T" = -108;
+"@MMK_R_W" = -72;
+"@MMK_R_Y" = -100;
+V = -92;
+};
+guilsinglright = {
+"@MMK_R_A" = -52;
+"@MMK_R_AE" = -84;
+"@MMK_R_T" = -124;
+"@MMK_R_W" = -92;
+"@MMK_R_Y" = -112;
+V = -112;
+X = -76;
+};
+hyphen = {
+"@MMK_R_A" = -8;
+"@MMK_R_AE" = -40;
+"@MMK_R_C" = 20;
+"@MMK_R_G" = 24;
+"@MMK_R_J" = -24;
+"@MMK_R_O" = 24;
+"@MMK_R_S" = 24;
+"@MMK_R_T" = -84;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -72;
+"@MMK_R_Z" = -8;
+V = -72;
+X = -36;
+};
+m = {
+"@MMK_R_w" = -4;
+"@MMK_R_y" = -8;
+p = -4;
+v = -8;
+};
+nine = {
+four = -4;
+one = -32;
+};
+one = {
+comma = 20;
+eight = -20;
+four = -40;
+nine = -36;
+one = 32;
+period = 16;
+seven = -52;
+six = -36;
+two = 20;
+zero = -32;
+};
+oslash = {
+x = 12;
+};
+p = {
+"@MMK_R_f" = -12;
+"@MMK_R_w" = -8;
+"@MMK_R_y" = -16;
+};
+period = {
+one = 16;
+quotedblright = -12;
+quoteright = -12;
+};
+q = {
+"@MMK_R_u" = 40;
+};
+quotedblbase = {
+"@MMK_R_A" = 32;
+"@MMK_R_AE" = 20;
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 40;
+"@MMK_R_O" = -8;
+"@MMK_R_T" = -56;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -68;
+"@MMK_R_Y" = -52;
+"@MMK_R_w" = -28;
+"@MMK_R_y" = -44;
+Oslash = 8;
+V = -88;
+v = -44;
+};
+quotedblleft = {
+"@MMK_R_A" = -64;
+"@MMK_R_AE" = -136;
+"@MMK_R_J" = -24;
+"@MMK_R_T" = 24;
+"@MMK_R_W" = 8;
+"@MMK_R_Y" = -8;
+"@MMK_R_c" = -8;
+"@MMK_R_f" = 12;
+V = -8;
+};
+quotedblright = {
+"@MMK_R_A" = -72;
+"@MMK_R_AE" = -170;
+"@MMK_R_T" = 24;
+"@MMK_R_W" = 8;
+"@MMK_R_Y" = -8;
+V = -16;
+period = -16;
+};
+quoteleft = {
+"@MMK_R_A" = -64;
+"@MMK_R_AE" = -156;
+"@MMK_R_J" = -24;
+"@MMK_R_T" = 24;
+"@MMK_R_W" = 8;
+"@MMK_R_Y" = -8;
+V = -8;
+};
+quoteright = {
+"@MMK_R_A" = -72;
+"@MMK_R_AE" = -156;
+"@MMK_R_d" = -12;
+"@MMK_R_o" = -16;
+"@MMK_R_s" = -4;
+"@MMK_R_t" = 4;
+"@MMK_R_w" = 16;
+"@MMK_R_y" = 16;
+comma = -12;
+period = -16;
+v = 16;
+};
+quotesinglbase = {
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 40;
+"@MMK_R_O" = -8;
+"@MMK_R_T" = -56;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -64;
+"@MMK_R_Y" = -52;
+"@MMK_R_w" = -28;
+"@MMK_R_y" = -44;
+Oslash = 8;
+V = -88;
+v = -44;
+};
+seven = {
+colon = 12;
+comma = -24;
+eight = -20;
+five = -20;
+four = -56;
+hyphen = -32;
+nine = -16;
+one = 36;
+period = -28;
+six = -32;
+three = -8;
+two = -12;
+zero = -24;
+};
+six = {
+four = 20;
+one = -28;
+seven = -52;
+};
+three = {
+four = 16;
+one = -24;
+seven = -20;
+};
+two = {
+four = 8;
+one = 12;
+seven = -4;
+};
+v = {
+"@MMK_R_a" = -4;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -16;
+"@MMK_R_g" = -16;
+"@MMK_R_o" = -24;
+colon = 24;
+comma = -36;
+hyphen = -16;
+oslash = -28;
+period = -36;
+semicolon = 24;
+};
+x = {
+"@MMK_R_a" = 20;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -20;
+"@MMK_R_o" = -24;
+oslash = -8;
+q = -16;
+};
+zero = {
+one = -32;
+seven = -12;
+two = -16;
+};
+};
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = {
+"@MMK_L_A" = {
+"@MMK_R_A" = -74;
+"@MMK_R_C" = -48;
+"@MMK_R_G" = -48;
+"@MMK_R_O" = -40;
+"@MMK_R_T" = -32;
+"@MMK_R_U" = -40;
+"@MMK_R_W" = -96;
+"@MMK_R_Y" = -52;
+"@MMK_R_a" = 20;
+"@MMK_R_c" = -16;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -16;
+"@MMK_R_g" = 28;
+"@MMK_R_o" = -12;
+"@MMK_R_w" = -28;
+"@MMK_R_y" = -44;
+V = -92;
+b = 40;
+comma = 24;
+guillemetleft = -28;
+guilsinglleft = -44;
+period = 20;
+q = -16;
+quotedblleft = -60;
+quotedblright = -72;
+quoteleft = -60;
+quoteright = -68;
+v = -40;
+};
+"@MMK_L_AE" = {
+"@MMK_R_S" = 28;
+"@MMK_R_T" = 8;
+"@MMK_R_U" = -8;
+"@MMK_R_W" = -20;
+"@MMK_R_Z" = 20;
+V = -16;
+v = -16;
+};
+"@MMK_L_C" = {
+"@MMK_R_A" = 24;
+"@MMK_R_AE" = 12;
+"@MMK_R_C" = -8;
+"@MMK_R_H" = 8;
+"@MMK_R_J" = 136;
+"@MMK_R_K" = 8;
+"@MMK_R_Y" = -36;
+"@MMK_R_Z" = 12;
+"@MMK_R_y" = -12;
+V = -20;
+comma = 32;
+hyphen = 32;
+period = 32;
+};
+"@MMK_L_D" = {
+"@MMK_R_A" = -56;
+"@MMK_R_Eng" = -20;
+"@MMK_R_T" = 8;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -56;
+"@MMK_R_Y" = -80;
+V = -48;
+X = -40;
+comma = -12;
+period = -8;
+quotedblleft = 20;
+quotedblright = 8;
+};
+"@MMK_L_G" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -52;
+"@MMK_R_T" = -32;
+"@MMK_R_W" = -56;
+"@MMK_R_Y" = -68;
+V = -56;
+X = -44;
+colon = 52;
+hyphen = 36;
+quotedblright = -16;
+semicolon = 52;
+};
+"@MMK_L_H" = {
+"@MMK_R_y" = -4;
+};
+"@MMK_L_IJ" = {
+"@MMK_R_A" = -16;
+"@MMK_R_AE" = -28;
+"@MMK_R_Z" = -20;
+"@MMK_R_a" = -16;
+"@MMK_R_e" = -20;
+"@MMK_R_o" = -20;
+"@MMK_R_u" = -16;
+"@MMK_R_y" = -8;
+colon = 40;
+comma = -4;
+period = -4;
+};
+"@MMK_L_K" = {
+"@MMK_R_A" = -104;
+"@MMK_R_C" = -56;
+"@MMK_R_G" = -52;
+"@MMK_R_O" = -52;
+"@MMK_R_S" = 32;
+"@MMK_R_T" = -32;
+"@MMK_R_U" = -40;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -52;
+"@MMK_R_a" = 20;
+"@MMK_R_e" = -16;
+"@MMK_R_o" = -12;
+"@MMK_R_w" = -40;
+"@MMK_R_y" = -64;
+Oslash = -28;
+V = -80;
+guillemetleft = -60;
+hyphen = -32;
+quotedblleft = -88;
+quotedblright = -76;
+v = -52;
+};
+"@MMK_L_L" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -66;
+"@MMK_R_C" = -4;
+"@MMK_R_S" = 12;
+"@MMK_R_T" = -48;
+"@MMK_R_U" = -24;
+"@MMK_R_W" = -88;
+"@MMK_R_Y" = -72;
+"@MMK_R_Z" = 24;
+"@MMK_R_u" = 12;
+"@MMK_R_y" = -16;
+V = -84;
+hyphen = 48;
+quotedblleft = -68;
+quotedblright = -84;
+quoteleft = -68;
+quoteright = -80;
+};
+"@MMK_L_N" = {
+"@MMK_R_A" = -8;
+"@MMK_R_AE" = -24;
+"@MMK_R_C" = -24;
+"@MMK_R_G" = -24;
+"@MMK_R_O" = -16;
+"@MMK_R_Z" = -20;
+"@MMK_R_a" = -16;
+"@MMK_R_e" = -20;
+"@MMK_R_o" = -20;
+"@MMK_R_u" = -16;
+"@MMK_R_y" = -8;
+oslash = -20;
+};
+"@MMK_L_O" = {
+"@MMK_R_A" = -52;
+"@MMK_R_AE" = -64;
+"@MMK_R_Eng" = -24;
+"@MMK_R_W" = -60;
+"@MMK_R_Y" = -84;
+"@MMK_R_Z" = -16;
+V = -52;
+X = -48;
+comma = -12;
+hyphen = 24;
+period = -12;
+};
+"@MMK_L_R" = {
+"@MMK_R_A" = -24;
+"@MMK_R_C" = -16;
+"@MMK_R_G" = -16;
+"@MMK_R_J" = 104;
+"@MMK_R_O" = -12;
+"@MMK_R_U" = -20;
+"@MMK_R_W" = -40;
+"@MMK_R_Y" = -52;
+"@MMK_R_a" = 20;
+"@MMK_R_e" = -16;
+"@MMK_R_o" = -12;
+"@MMK_R_w" = -20;
+"@MMK_R_y" = -16;
+V = -40;
+hyphen = 12;
+quotedblright = -4;
+quoteright = -4;
+v = -20;
+};
+"@MMK_L_S" = {
+"@MMK_R_AE" = -22;
+"@MMK_R_J" = 76;
+"@MMK_R_S" = 24;
+"@MMK_R_W" = -24;
+"@MMK_R_Y" = -36;
+"@MMK_R_t" = 12;
+"@MMK_R_w" = 8;
+V = -24;
+comma = 8;
+period = 8;
+v = 8;
+};
+"@MMK_L_T" = {
+"@MMK_R_A" = -36;
+"@MMK_R_AE" = -48;
+"@MMK_R_C" = -4;
+"@MMK_R_G" = -4;
+"@MMK_R_J" = 46;
+"@MMK_R_S" = 12;
+"@MMK_R_Y" = -32;
+"@MMK_R_a" = -72;
+"@MMK_R_c" = -100;
+"@MMK_R_d" = -68;
+"@MMK_R_e" = -100;
+"@MMK_R_g" = -60;
+"@MMK_R_h" = -16;
+"@MMK_R_o" = -96;
+"@MMK_R_r" = -48;
+"@MMK_R_s" = -56;
+"@MMK_R_u" = -92;
+"@MMK_R_w" = -92;
+"@MMK_R_y" = -92;
+"@MMK_R_z" = -52;
+colon = -36;
+comma = -68;
+guillemetleft = -104;
+guillemetright = -104;
+guilsinglleft = -120;
+hyphen = -80;
+m = -48;
+oslash = -92;
+period = -68;
+quotedblbase = -72;
+quotesinglbase = -72;
+semicolon = -36;
+v = -92;
+x = -44;
+};
+"@MMK_L_U" = {
+"@MMK_R_A" = -36;
+"@MMK_R_AE" = -48;
+"@MMK_R_C" = -24;
+"@MMK_R_S" = -4;
+"@MMK_R_U" = -32;
+"@MMK_R_Z" = -20;
+"@MMK_R_a" = -20;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -20;
+"@MMK_R_eng" = -24;
+"@MMK_R_f" = -24;
+"@MMK_R_g" = -20;
+"@MMK_R_j" = -24;
+"@MMK_R_r" = -24;
+"@MMK_R_s" = -8;
+"@MMK_R_t" = -20;
+"@MMK_R_y" = -8;
+"@MMK_R_z" = -20;
+comma = -32;
+guillemetleft = -28;
+m = -24;
+p = -24;
+period = -12;
+v = -8;
+};
+"@MMK_L_W" = {
+"@MMK_R_A" = -112;
+"@MMK_R_AE" = -124;
+"@MMK_R_C" = -64;
+"@MMK_R_G" = -64;
+"@MMK_R_O" = -60;
+"@MMK_R_S" = -40;
+"@MMK_R_T" = -4;
+"@MMK_R_a" = -80;
+"@MMK_R_c" = -88;
+"@MMK_R_d" = -84;
+"@MMK_R_e" = -84;
+"@MMK_R_eng" = -52;
+"@MMK_R_g" = -80;
+"@MMK_R_i" = -44;
+"@MMK_R_o" = -84;
+"@MMK_R_r" = -52;
+"@MMK_R_s" = -68;
+"@MMK_R_u" = -48;
+"@MMK_R_y" = -36;
+"@MMK_R_z" = -72;
+Oslash = -60;
+colon = -32;
+comma = -84;
+guillemetleft = -92;
+guillemetright = -84;
+guilsinglleft = -108;
+guilsinglright = -84;
+hyphen = -68;
+m = -52;
+oslash = -84;
+p = -52;
+period = -84;
+q = -84;
+quotedblbase = -84;
+quotesinglbase = -84;
+semicolon = -32;
+v = -36;
+x = -52;
+};
+"@MMK_L_Y" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -52;
+"@MMK_R_C" = -84;
+"@MMK_R_G" = -84;
+"@MMK_R_J" = 12;
+"@MMK_R_O" = -80;
+"@MMK_R_S" = -60;
+"@MMK_R_T" = -20;
+"@MMK_R_a" = -76;
+"@MMK_R_c" = -100;
+"@MMK_R_d" = -100;
+"@MMK_R_e" = -100;
+"@MMK_R_eng" = -52;
+"@MMK_R_g" = -64;
+"@MMK_R_i" = -52;
+"@MMK_R_o" = -100;
+"@MMK_R_r" = -52;
+"@MMK_R_s" = -60;
+"@MMK_R_t" = -84;
+"@MMK_R_u" = -84;
+"@MMK_R_w" = -72;
+"@MMK_R_y" = -68;
+"@MMK_R_z" = -56;
+Oslash = -80;
+colon = -40;
+comma = -72;
+guillemetleft = -108;
+guillemetright = -104;
+guilsinglleft = -124;
+guilsinglright = -104;
+hyphen = -84;
+m = -52;
+oslash = -96;
+p = -84;
+period = -72;
+q = -100;
+quotedblbase = -76;
+quotesinglbase = -76;
+semicolon = -40;
+v = -72;
+x = -48;
+};
+"@MMK_L_Z" = {
+"@MMK_R_T" = 28;
+"@MMK_R_U" = -4;
+"@MMK_R_y" = -12;
+comma = 48;
+period = 48;
+v = -8;
+};
+"@MMK_L_a" = {
+quoteright = -28;
+};
+"@MMK_L_ae" = {
+quoteright = -20;
+x = -4;
+};
+"@MMK_L_c" = {
+"@MMK_R_h" = -8;
+"@MMK_R_k" = -8;
+comma = 12;
+};
+"@MMK_L_d" = {
+"@MMK_R_j" = -12;
+};
+"@MMK_L_f" = {
+"@MMK_R_a" = 12;
+"@MMK_R_c" = -12;
+"@MMK_R_e" = -12;
+"@MMK_R_f" = 36;
+"@MMK_R_i" = 56;
+"@MMK_R_j" = 56;
+"@MMK_R_l" = 82;
+"@MMK_R_o" = -8;
+"@MMK_R_s" = 28;
+"@MMK_R_t" = 44;
+asterisk = 158;
+bracketright = 98;
+comma = 16;
+exclam = 114;
+guillemetleft = -24;
+oslash = -8;
+parenright = 104;
+period = 16;
+question = 112;
+quotedblleft = 104;
+quotedblright = 132;
+quoteleft = 104;
+quoteright = 112;
+};
+"@MMK_L_f_f_l" = {
+"@MMK_R_y" = 8;
+v = 8;
+};
+"@MMK_L_g" = {
+"@MMK_R_a" = 12;
+"@MMK_R_l" = 4;
+"@MMK_R_r" = 44;
+comma = -8;
+period = -12;
+};
+"@MMK_L_h" = {
+"@MMK_R_w" = 8;
+quotedblright = -24;
+quoteright = -24;
+v = 8;
+};
+"@MMK_L_k" = {
+"@MMK_R_a" = 10;
+"@MMK_R_c" = -16;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -16;
+"@MMK_R_g" = 28;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = 22;
+"@MMK_R_u" = 16;
+"@MMK_R_y" = -42;
+comma = 24;
+hyphen = -44;
+period = 20;
+};
+"@MMK_L_n" = {
+"@MMK_R_T" = -40;
+"@MMK_R_w" = 8;
+"@MMK_R_y" = 4;
+p = -8;
+quotedblleft = -12;
+quoteleft = -12;
+quoteright = -24;
+v = 8;
+};
+"@MMK_L_o" = {
+"@MMK_R_T" = -96;
+"@MMK_R_f" = -12;
+"@MMK_R_t" = -8;
+"@MMK_R_w" = -16;
+"@MMK_R_y" = -20;
+quotedblleft = -24;
+quoteright = -32;
+v = -16;
+x = -20;
+};
+"@MMK_L_r" = {
+"@MMK_R_a" = -8;
+"@MMK_R_c" = -8;
+"@MMK_R_d" = -4;
+"@MMK_R_e" = -8;
+"@MMK_R_eng" = 16;
+"@MMK_R_f" = 16;
+"@MMK_R_g" = -8;
+"@MMK_R_h" = -20;
+"@MMK_R_i" = 16;
+"@MMK_R_j" = 20;
+"@MMK_R_k" = -20;
+"@MMK_R_l" = -20;
+"@MMK_R_o" = -8;
+"@MMK_R_r" = 16;
+"@MMK_R_t" = 24;
+"@MMK_R_u" = 24;
+"@MMK_R_w" = 36;
+"@MMK_R_y" = 32;
+b = -20;
+colon = 8;
+comma = -84;
+guillemetleft = -28;
+hyphen = -48;
+m = 16;
+oslash = -8;
+p = 16;
+period = -84;
+q = -4;
+quotedblbase = -84;
+quotesinglbase = -84;
+v = 36;
+x = 20;
+};
+"@MMK_L_s" = {
+"@MMK_R_t" = 12;
+"@MMK_R_w" = 24;
+"@MMK_R_y" = 24;
+quoteright = -8;
+v = 24;
+};
+"@MMK_L_t" = {
+"@MMK_R_S" = 28;
+"@MMK_R_a" = 28;
+"@MMK_R_h" = 28;
+"@MMK_R_o" = 8;
+colon = 44;
+quoteright = -8;
+semicolon = 44;
+};
+"@MMK_L_u" = {
+quoteright = -28;
+};
+"@MMK_L_uni01C5" = {
+"@MMK_R_o" = 8;
+colon = 60;
+comma = 24;
+};
+"@MMK_L_w" = {
+"@MMK_R_a" = 4;
+"@MMK_R_c" = -16;
+"@MMK_R_e" = -12;
+"@MMK_R_l" = 4;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = 20;
+colon = 32;
+comma = -36;
+hyphen = -16;
+oslash = -12;
+period = -36;
+quotedblbase = -32;
+quotesinglbase = -32;
+semicolon = 32;
+};
+"@MMK_L_y" = {
+"@MMK_R_a" = -4;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -12;
+"@MMK_R_e" = -20;
+"@MMK_R_g" = -12;
+"@MMK_R_o" = -20;
+"@MMK_R_s" = 8;
+colon = 24;
+comma = -48;
+hyphen = -24;
+oslash = -20;
+period = -48;
+quotedblbase = -44;
+quotesinglbase = -44;
+semicolon = 24;
+};
+B = {
+"@MMK_R_A" = -26;
+"@MMK_R_AE" = -28;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 50;
+"@MMK_R_O" = -4;
+"@MMK_R_T" = -4;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -64;
+"@MMK_R_y" = -8;
+V = -44;
+X = -16;
+comma = -10;
+hyphen = 36;
+slash = 44;
+};
+F = {
+"@MMK_R_A" = -104;
+"@MMK_R_G" = -32;
+"@MMK_R_J" = -40;
+"@MMK_R_O" = -28;
+"@MMK_R_T" = 4;
+"@MMK_R_a" = -84;
+"@MMK_R_e" = -84;
+"@MMK_R_i" = -28;
+"@MMK_R_j" = -28;
+"@MMK_R_o" = -80;
+"@MMK_R_r" = -36;
+"@MMK_R_u" = -40;
+"@MMK_R_y" = -24;
+colon = -28;
+comma = -88;
+guillemetleft = -80;
+hyphen = -56;
+oslash = -80;
+period = -88;
+quotedblbase = -88;
+quotesinglbase = -88;
+};
+Lslash = {
+"@MMK_R_T" = -48;
+"@MMK_R_W" = -88;
+"@MMK_R_Y" = -72;
+V = -84;
+quotedblleft = -68;
+quotedblright = -84;
+quoteleft = -68;
+quoteright = -80;
+};
+Oslash = {
+"@MMK_R_A" = -52;
+"@MMK_R_Y" = -84;
+V = -52;
+X = -48;
+comma = -12;
+hyphen = 24;
+period = -12;
+};
+P = {
+"@MMK_R_A" = -88;
+"@MMK_R_AE" = -120;
+"@MMK_R_J" = -20;
+"@MMK_R_T" = 32;
+"@MMK_R_Y" = -36;
+"@MMK_R_a" = -44;
+"@MMK_R_c" = -64;
+"@MMK_R_e" = -60;
+"@MMK_R_g" = -48;
+"@MMK_R_o" = -60;
+"@MMK_R_r" = 16;
+"@MMK_R_s" = -32;
+"@MMK_R_u" = 12;
+"@MMK_R_y" = 28;
+colon = -16;
+comma = -104;
+guillemetleft = -84;
+hyphen = -68;
+oslash = -60;
+period = -104;
+quotedblbase = -100;
+quotedblleft = 40;
+quotesinglbase = -100;
+semicolon = -16;
+};
+Q = {
+"@MMK_R_A" = -52;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -60;
+"@MMK_R_Y" = -84;
+V = -52;
+comma = -12;
+period = -12;
+};
+V = {
+"@MMK_R_A" = -104;
+"@MMK_R_AE" = -116;
+"@MMK_R_C" = -56;
+"@MMK_R_G" = -56;
+"@MMK_R_J" = -44;
+"@MMK_R_O" = -48;
+"@MMK_R_S" = -32;
+"@MMK_R_a" = -76;
+"@MMK_R_c" = -76;
+"@MMK_R_d" = -72;
+"@MMK_R_e" = -76;
+"@MMK_R_eng" = -44;
+"@MMK_R_g" = -76;
+"@MMK_R_i" = -36;
+"@MMK_R_o" = -76;
+"@MMK_R_r" = -44;
+"@MMK_R_s" = -64;
+"@MMK_R_u" = -40;
+"@MMK_R_w" = -28;
+"@MMK_R_y" = -28;
+"@MMK_R_z" = -64;
+Oslash = -48;
+colon = -20;
+comma = -80;
+guillemetleft = -80;
+guillemetright = -76;
+guilsinglleft = -96;
+guilsinglright = -76;
+hyphen = -60;
+m = -44;
+oslash = -72;
+p = -44;
+period = -80;
+q = -72;
+quotedblbase = -80;
+quotesinglbase = -80;
+semicolon = -20;
+v = -28;
+x = -40;
+};
+X = {
+"@MMK_R_A" = -94;
+"@MMK_R_C" = -56;
+"@MMK_R_G" = -52;
+"@MMK_R_O" = -52;
+"@MMK_R_T" = -32;
+"@MMK_R_a" = 20;
+"@MMK_R_e" = -16;
+"@MMK_R_o" = -12;
+"@MMK_R_y" = -64;
+Oslash = -28;
+guillemetleft = -52;
+guilsinglleft = -68;
+hyphen = -24;
+quotedblleft = -60;
+};
+b = {
+"@MMK_R_t" = -8;
+"@MMK_R_w" = -4;
+"@MMK_R_y" = -8;
+v = -4;
+};
+comma = {
+one = 12;
+quotedblright = -44;
+quoteright = -40;
+};
+eight = {
+four = 16;
+one = -16;
+seven = -20;
+};
+five = {
+four = 16;
+seven = -32;
+};
+four = {
+four = 16;
+one = -12;
+seven = -44;
+};
+germandbls = {
+quotedblleft = -24;
+};
+guillemetleft = {
+"@MMK_R_J" = 64;
+"@MMK_R_T" = -104;
+"@MMK_R_U" = -24;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -116;
+V = -76;
+};
+guillemetright = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -64;
+"@MMK_R_J" = 12;
+"@MMK_R_T" = -104;
+"@MMK_R_U" = -24;
+"@MMK_R_W" = -88;
+"@MMK_R_Y" = -120;
+V = -84;
+X = -60;
+};
+guilsinglleft = {
+"@MMK_R_T" = -104;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -116;
+V = -76;
+};
+guilsinglright = {
+"@MMK_R_A" = -52;
+"@MMK_R_AE" = -76;
+"@MMK_R_T" = -116;
+"@MMK_R_W" = -96;
+"@MMK_R_Y" = -132;
+V = -96;
+X = -72;
+};
+hyphen = {
+"@MMK_R_A" = -16;
+"@MMK_R_AE" = -36;
+"@MMK_R_C" = 20;
+"@MMK_R_G" = 20;
+"@MMK_R_O" = 24;
+"@MMK_R_S" = 32;
+"@MMK_R_T" = -80;
+"@MMK_R_U" = 4;
+"@MMK_R_W" = -64;
+"@MMK_R_Y" = -96;
+V = -60;
+X = -40;
+};
+m = {
+"@MMK_R_w" = 8;
+p = -12;
+v = 8;
+};
+nine = {
+four = -12;
+one = -36;
+};
+one = {
+comma = 12;
+eight = -16;
+four = -44;
+nine = -16;
+one = 32;
+period = 8;
+seven = -56;
+six = -36;
+two = 20;
+zero = -32;
+};
+p = {
+"@MMK_R_f" = -12;
+"@MMK_R_t" = -8;
+"@MMK_R_w" = -8;
+"@MMK_R_y" = -12;
+};
+period = {
+one = 8;
+quotedblright = -40;
+quoteright = -40;
+};
+q = {
+"@MMK_R_u" = 36;
+};
+quotedblbase = {
+"@MMK_R_A" = 24;
+"@MMK_R_AE" = 12;
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 132;
+"@MMK_R_O" = -12;
+"@MMK_R_T" = -64;
+"@MMK_R_U" = -12;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -88;
+"@MMK_R_w" = -32;
+"@MMK_R_y" = -52;
+Oslash = -8;
+V = -84;
+v = -44;
+};
+quotedblleft = {
+"@MMK_R_A" = -84;
+"@MMK_R_AE" = -132;
+"@MMK_R_T" = 8;
+"@MMK_R_W" = -8;
+"@MMK_R_Y" = -40;
+"@MMK_R_c" = -20;
+"@MMK_R_d" = -12;
+"@MMK_R_e" = -16;
+V = -8;
+q = -12;
+};
+quotedblright = {
+"@MMK_R_A" = -84;
+"@MMK_R_AE" = -132;
+"@MMK_R_T" = 16;
+"@MMK_R_W" = -8;
+"@MMK_R_Y" = -36;
+V = -8;
+period = -36;
+};
+quoteleft = {
+"@MMK_R_A" = -84;
+"@MMK_R_AE" = -132;
+"@MMK_R_T" = 18;
+"@MMK_R_W" = -8;
+"@MMK_R_Y" = -40;
+"@MMK_R_d" = -12;
+V = -8;
+q = -12;
+};
+quoteright = {
+"@MMK_R_A" = -84;
+"@MMK_R_AE" = -132;
+"@MMK_R_d" = -24;
+"@MMK_R_o" = -28;
+"@MMK_R_r" = -8;
+"@MMK_R_s" = -8;
+"@MMK_R_w" = 8;
+"@MMK_R_y" = 12;
+comma = -32;
+period = -32;
+v = 8;
+};
+quotesinglbase = {
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 132;
+"@MMK_R_O" = -12;
+"@MMK_R_T" = -64;
+"@MMK_R_U" = -12;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -88;
+"@MMK_R_w" = -32;
+"@MMK_R_y" = -52;
+Oslash = -8;
+V = -84;
+v = -44;
+};
+seven = {
+colon = -4;
+comma = -48;
+eight = -16;
+five = -24;
+four = -64;
+hyphen = -48;
+nine = -16;
+one = 28;
+period = -48;
+seven = -12;
+six = -44;
+three = -12;
+two = -16;
+zero = -32;
+};
+six = {
+four = 20;
+one = -28;
+seven = -48;
+};
+three = {
+four = 16;
+one = -24;
+seven = -24;
+};
+two = {
+four = 8;
+one = 12;
+seven = -8;
+};
+v = {
+"@MMK_R_a" = 4;
+"@MMK_R_c" = -16;
+"@MMK_R_e" = -12;
+"@MMK_R_l" = 4;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = 20;
+colon = 28;
+comma = -44;
+hyphen = -20;
+oslash = -12;
+period = -44;
+semicolon = 28;
+};
+x = {
+"@MMK_R_a" = 12;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -24;
+"@MMK_R_e" = -24;
+"@MMK_R_o" = -20;
+oslash = -8;
+q = -20;
+};
+zero = {
+one = -32;
+seven = -8;
+two = -12;
+};
+};
+};
+manufacturer = "Impallari Type";
+manufacturerURL = www.impallari.com;
+unitsPerEm = 1000;
+userData = {
+GSDimensionPlugin.Dimensions = {
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = {
+nV = "138";
+oH = "35";
+};
+"426C3F01-D24D-4224-A47E-56DA036E4742" = {
+nV = "103";
+oH = "25";
+};
+"DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC" = {
+nV = "138";
+oH = "35";
+};
+UUID0 = {
+nV = "110";
+oH = "30";
+};
+};
+};
+versionMajor = 2;
+versionMinor = 3;
+}

--- a/data/test/Libre-Bodoni/sources/config.yaml
+++ b/data/test/Libre-Bodoni/sources/config.yaml
@@ -1,0 +1,45 @@
+    sources:
+      - LibreBodoni.glyphs
+      - LibreBodoni-Italic.glyphs
+    axisOrder:
+      - wght
+      - ital
+    familyName: "Libre Bodoni"
+    stat:
+      LibreBodoni[wght].ttf:
+      - name: Weight
+        tag: wght
+        values:
+        - name: Regular
+          value: 400
+          linkedValue: 700
+          flags: 2
+        - name: Medium
+          value: 500
+        - name: Bold
+          value: 700
+      - name: Italic
+        tag: ital
+        values:
+        - name: Roman
+          value: 0
+          linkedValue: 1
+          flags: 2
+      LibreBodoni-Italic[wght].ttf:
+      - name: Weight
+        tag: wght
+        values:
+        - name: Regular
+          value: 400
+          linkedValue: 700
+          flags: 2
+        - name: Medium
+          value: 500
+        - name: Bold
+          value: 700
+      - name: Italic
+        tag: ital
+        values:
+        - name: Italic
+          value: 1
+          


### PR DESCRIPTION
If a config file contains 2 or more sources, the second sources onwards will inherit the previous source's args. We want fresh args for each source. 

Hence why the ci complains in https://github.com/eliheuer/hasubi-mono/runs/6088671254?check_suite_focus=true

Fixes https://github.com/googlefonts/googlefonts-project-template/issues/72

Apologies for crappy explanation. Haven't slept well and I'm having a new floor laid. It's louder than a Dutch Gabber rave. 