### PR TITLE
Die noisily when variable fonts fail to build

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -291,13 +291,10 @@ class GFBuilder:
             args["output_path"] = os.path.join(
                 self.config["vfDir"], sourcebase + "-VF.ttf",
             )
-            try:
-                output_files = self.run_fontmake(source, args)
-                newname = self.rename_variable(output_files[0])
-                ttFont = TTFont(newname)
-                ttFonts.append(ttFont)
-            except Exception as e:
-                self.logger.error("Could not build variable font: %s" % e)
+            output_files = self.run_fontmake(source, args)
+            newname = self.rename_variable(output_files[0])
+            ttFont = TTFont(newname)
+            ttFonts.append(ttFont)
 
         if not ttFonts:
             return


### PR DESCRIPTION
I had an idea (in a6d9b067) that we should allow variable builds to fail and then track whether or not they succeeded by looking at the `.outputs` list.

In retrospect, this was a bad idea. If someone's said in the config file that they want a variable build, they should get an error if they don't get a variable build.

Fixes #503.