### PR TITLE
Improve reporting of source fixes

### DIFF
--- a/bin/gftools-fix-font.py
+++ b/bin/gftools-fix-font.py
@@ -18,7 +18,7 @@ from fontTools.ttLib import TTFont
 from gftools.fix import *
 
 
-log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 
 def main():


### PR DESCRIPTION
Currently if you run `gftools-fix-font.py --include-source-fixes` it will tell you to consider fixing the sources instead, but if won't tell you *what* you need to fix in the sources!

With this PR:

```
INFO:gftools.fix:Changed OS/2 table's fsSelection flag to 64
INFO:gftools.fix:Consider fixing in the source (e.g. adding an 'openTypeOS2Selection' or 'Use Typo Metrics' custom parameter in Glyphs)

INFO:gftools.fix:Set instances in fvar table to: Thin, ExtraLight, Light, Regular, Medium, SemiBold, Bold, ExtraBold, Black
INFO:gftools.fix:(Old instances were: Thin, ExtraLight, Light, Regular, Medium, SemiBold, Bold, ExtraBold, Black, Condensed Thin, Condensed ExtraLight, Condensed Light, Condensed, Condensed Medium, Condensed SemiBold , Condensed Bold, Condensed ExtraBold, Condensed Black, SemiCondensed Thin, SemiCondensed ExtraLight, SemiCondensed Light, SemiCondensed, SemiCondensed Medium, SemiCondensed SemiBold, SemiCondensed Bold, SemiCondensed ExtraBold, SemiCondensed Black, ExtraCondensed Thin, ExtraCondensed ExtraLight, ExtraCondensed Light, ExtraCondensed, ExtraCondensed Medium, ExtraCondensed SemiBold, ExtraCondensed Bold, ExtraCondensed ExtraBold, ExtraCondensed Black)
INFO:gftools.fix:Consider fixing export list in source
```