### PR TITLE
push-status: fix paths for checking languages

### DIFF
--- a/Lib/gftools/push.py
+++ b/Lib/gftools/push.py
@@ -97,12 +97,16 @@ def push_report(fp):
 
 def missing_paths(fp):
     paths = [fp.parent / p.path for p in parse_server_file(fp)]
-    axis_files = [p for p in paths if p.name.endswith(("textproto", "svg"))]
-    dirs = [p for p in paths if p not in axis_files]
+    lang_files = [p for p in paths if "lang" in p.parts]
+    axis_files = [p for p in paths if p.name.endswith(("textproto", "svg")) if p not in lang_files]
+    dirs = [p for p in paths if p not in axis_files + lang_files]
 
     missing_dirs = [p for p in dirs if not p.is_dir()]
     missing_axis_files = [p for p in axis_files if not p.is_file()]
-    return missing_dirs + missing_axis_files
+    missing_lang_files = [p for p in lang_files if not
+        (p.parent.parent / "Lib" / "gflanguages" / "data" / "languages" / lang_files[0].name).is_file()
+    ]
+    return missing_dirs + missing_axis_files + missing_lang_files
 
 
 def lint_server_files(fp):


### PR DESCRIPTION
In https://github.com/google/fonts/pull/4679 we can see that Rod has changed the paths so they're specific to their backend. Currently, this makes our CI fail. In order to fix this, I modify the file paths so they match theirs and then check.


cc @RosaWagner