### PR TITLE
[packager] Add article/ARTICLE.en_us.html to allowlist

### DIFF
--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -287,6 +287,7 @@ LICENSE_DIRS = tuple(zip(*LICENSE_FILES_2_DIRS))[1]
 ALLOWED_FILES = {
     'DESCRIPTION.en_us.html'
   , 'FONTLOG.txt'
+  , 'article/ARTICLE.en_us.html'
   , *dict(LICENSE_FILES_2_DIRS).keys() # just the file names/keys
 # METADATA.pb is not taken from upstream, technically we update the
 # version in google fonts or create it newly


### PR DESCRIPTION
This adds articles to the packager's allowlist. I need them for Noto and I had a few options here:

* Just keep this to my Noto gftools branch: possible but I'm trying to reduce divergence.
* Use `--no-allowlist`: but sanity checking is a good thing!
* Allow it for everyone: least bad option, probably won't be used by anyone other than Noto, but also it allows for the future possibility of having articles about library fonts.