### PR TITLE
gen-html: auto set script direction

### DIFF
--- a/Lib/gftools/templates/text.html
+++ b/Lib/gftools/templates/text.html
@@ -6,11 +6,9 @@
 {% endblock %}
 {% block content %}
   {% for font_class in css_font_classes or css_font_classes_before or css_font_classes_after %}
-      <div class="box">
-	<div class="box-title">{{ font_class.selector }} {{ pt_size }}pt</div>
-	<span class="{{ font_class.selector }}" style="font-size: {{ pt_size }}pt">
-	  {{ sample_text }}
-          </span>
-       </div>
-    {% endfor %}
+    <div class="box">
+      <div class="box-title">{{ font_class.selector }} {{ pt_size }}pt</div>
+      <div dir="auto" class="{{ font_class.selector }}" style="font-size: {{ pt_size }}pt">{{ sample_text }}</span>
+    </div>
+  {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Currently, ltr is used for all scripts. This means we're having issues when proofing rtl scripts such as Arabic. I've simply used the html `dir="auto"` to enable this functionality.

<img width="1552" alt="Screenshot 2022-08-01 at 12 23 48" src="https://user-images.githubusercontent.com/7525512/182138013-80a9f85d-3675-4131-bf57-a21421e16943.png">

*Noto Sans Arabic now rtl*

cc @simoncozens  