### PR TITLE
Try harder to get more sample text

### DIFF
--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -470,7 +470,7 @@ def font_sample_text(ttFont):
 
     _add_words(words, uhdr, seen_chars)
 
-    if not words:
+    if len(seen_chars) < len(cmap):
         languages = LoadLanguages()
         for file, proto in languages.items():
             if hasattr(proto, "sample_text"):


### PR DESCRIPTION
Currently we use UDHR to get some sample text, and then look in gflanguages' sample text collection if we got *nothing*. But we hardly ever get nothing at all, because there may be punctuation etc. in the font. (Even spaces!)

So this is more aggressive, and uses the gflanguages sample texts to try and get more text if we don't have complete coverage of the font's encoded characters.