### PR TITLE
Expose more fontmake args in the config

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -99,6 +99,9 @@ required, all others have sensible defaults:
 * ``googleFonts``: Whether this font is destined for release on Google Fonts. Used by GitHub Actions. Defaults to ``false``.
 * ``category``: If this font is destined for release on Google Fonts, a list of the categories it should be catalogued under. Used by GitHub Actions. Must be set if ``googleFonts`` is set.
 * ``fvarInstanceAxisDflts``: Mapping to set every fvar instance's non-wght axis
+* ``expandFeaturesToInstances``: Resolve all includes in the sources' features, so that generated instances can be compiled without errors. Defaults to ``true``.
+* ``reverseOutlineDirection``: Reverse the outline direction when compiling TTFs (no effect for OTFs). Defaults to fontmake's default.
+* ``removeOutlineOverlaps``: Remove overlaps when compiling fonts. Defaults to fontmake's default.
 value e.g if a font has a wdth and wght axis, we can set the wdth to be 100 for
 every fvar instance. Defaults to ``None``
 """
@@ -333,6 +336,18 @@ class GFBuilder:
         # ... will run the filters in the ufo's lib,
         # https://github.com/googlefonts/fontmake/issues/872
         args["filters"] = [...] + filters
+
+        # The following arguments must be determined dynamically.
+        if source.endswith((".glyphs", ".designspace")):
+            args["expand_features_to_instances"] = self.config.get(
+                "expandFeaturesToInstances", True
+            )
+        # XXX: This will blow up if output formats are mixing TTFs/OTFs.
+        is_ttf = args["output"][0] in {"ttf", "ttf-interpolatable", "variable"}
+        if "reverseOutlineDirection" in self.config and is_ttf:
+            args["reverse_direction"] = self.config["reverseOutlineDirection"]
+        if "removeOutlineOverlaps" in self.config:
+            args["remove_overlaps"] = self.config["removeOutlineOverlaps"]
 
         if source.endswith(".glyphs"):
             FontProject().run_from_glyphs(source, **args)

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -81,5 +81,8 @@ schema = Map(
         Optional("ttfaUseScript"): Bool(),
         Optional("googleFonts"): Bool(),
         Optional("category"): UniqueSeq(Enum(CATEGORIES)),
+        Optional("reverseOutlineDirection"): Bool(),
+        Optional("removeOutlineOverlaps"): Bool(),
+        Optional("expandFeaturesToInstances"): Bool(),
     }
 )


### PR DESCRIPTION
Expose the reverse outlines, remove overlaps and expand features to instance arguments in the config.yml.

Expanding features is on by default because it's the only default that makes sense.

I chose to only expose these three, because GFBuilder calls fontmake's internals directly, bypassing the argument parser. I don't want to duplicate the logic of the parser.

Closes #301 
Closes #558 
Closes #581 