### PR TITLE
Update glyphsets for designers README link to new path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This project contains tools used for working with the Google Fonts collection, p
 
 The tools and files under this directory are available under the Apache License v2.0, for details see [LICENSE](LICENSE)
 
-## Google Fonts Official Glyph Sets (Encodings)
+## Google Fonts Official Glyph Sets
 
 The glyph sets useful for type designers that were previously hosted in this repository have been moved to:
 
-<https://github.com/googlefonts/glyphsets/tree/main/Lib/glyphsets/encodings>
+<https://github.com/googlefonts/glyphsets/tree/main/GF_glyphsets>
 
 ## Tool Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The tools and files under this directory are available under the Apache License 
 
 ## Google Fonts Official Glyph Sets (Encodings)
 
-This repo also contains definitions of glyph sets useful for type designers:
+The glyph sets useful for type designers that were previously hosted in this repository have been moved to:
 
-<https://github.com/googlefonts/glyphsets/tree/main/Lib/glyphsets/encodings/GF%20Glyph%20Sets>
+<https://github.com/googlefonts/glyphsets/tree/main/Lib/glyphsets/encodings>
 
 ## Tool Usage Examples
 


### PR DESCRIPTION
The current URL on the README has a 404 error.  I believe that this is the new location for the same data.