### PR TITLE
Add option to interpolate between masters for static fonts.

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -107,6 +107,7 @@ required, all others have sensible defaults:
 * ``expandFeaturesToInstances``: Resolve all includes in the sources' features, so that generated instances can be compiled without errors. Defaults to ``true``.
 * ``reverseOutlineDirection``: Reverse the outline direction when compiling TTFs (no effect for OTFs). Defaults to fontmake's default.
 * ``removeOutlineOverlaps``: Remove overlaps when compiling fonts. Defaults to fontmake's default.
+* ``interpolateMasters``: Interpolate between masters when generating static fonts. Defaults to ``false``.
 """
 
 from fontmake.font_project import FontProject
@@ -310,6 +311,8 @@ class GFBuilder:
             self.config["addGftoolsVersion"] = True
         if "decomposeTransformedComponents" not in self.config:
             self.config["decomposeTransformedComponents"] = True
+        if "interpolateMasters" not in self.config:
+            self.config["interpolateMasters"] = False
 
     def build_variable(self):
         self.mkdir(self.config["vfDir"], clean=True)
@@ -498,7 +501,7 @@ class GFBuilder:
                 "output_dir": directory,
                 "optimize_cff": CFFOptimization.SUBROUTINIZE,
             }
-            if self.config["buildVariable"]:
+            if self.config["buildVariable"] or self.config["interpolateMasters"]:
                 args["interpolate"] = True
             self.logger.info("Creating static fonts from %s" % source)
             for fontfile in self.run_fontmake(source, args):

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -501,7 +501,7 @@ class GFBuilder:
                 "output_dir": directory,
                 "optimize_cff": CFFOptimization.SUBROUTINIZE,
             }
-            if self.config["buildVariable"] or self.config["interpolateMasters"]:
+            if self.config["buildVariable"] or self.config["interpolate"]:
                 args["interpolate"] = True
             self.logger.info("Creating static fonts from %s" % source)
             for fontfile in self.run_fontmake(source, args):

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -107,7 +107,7 @@ required, all others have sensible defaults:
 * ``expandFeaturesToInstances``: Resolve all includes in the sources' features, so that generated instances can be compiled without errors. Defaults to ``true``.
 * ``reverseOutlineDirection``: Reverse the outline direction when compiling TTFs (no effect for OTFs). Defaults to fontmake's default.
 * ``removeOutlineOverlaps``: Remove overlaps when compiling fonts. Defaults to fontmake's default.
-* ``interpolateMasters``: Interpolate between masters when generating static fonts. Defaults to ``false``.
+* ``interpolate``: Enable fontmake --interpolate flag. Defaults to ``false``.
 """
 
 from fontmake.font_project import FontProject

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -311,8 +311,8 @@ class GFBuilder:
             self.config["addGftoolsVersion"] = True
         if "decomposeTransformedComponents" not in self.config:
             self.config["decomposeTransformedComponents"] = True
-        if "interpolateMasters" not in self.config:
-            self.config["interpolateMasters"] = False
+        if "interpolate" not in self.config:
+            self.config["interpolate"] = False
 
     def build_variable(self):
         self.mkdir(self.config["vfDir"], clean=True)

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -82,7 +82,7 @@ schema = Map(
         Optional("googleFonts"): Bool(),
         Optional("category"): UniqueSeq(Enum(CATEGORIES)),
         Optional("reverseOutlineDirection"): Bool(),
-        Optional("interpolateMasters"): Bool(),
+        Optional("interpolate"): Bool(),
         Optional("removeOutlineOverlaps"): Bool(),
         Optional("expandFeaturesToInstances"): Bool(),
         Optional("version"): Str(),

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -82,6 +82,7 @@ schema = Map(
         Optional("googleFonts"): Bool(),
         Optional("category"): UniqueSeq(Enum(CATEGORIES)),
         Optional("reverseOutlineDirection"): Bool(),
+        Optional("interpolateMasters"): Bool(),
         Optional("removeOutlineOverlaps"): Bool(),
         Optional("expandFeaturesToInstances"): Bool(),
         Optional("version"): Str(),


### PR DESCRIPTION
We recently moved to gftools v0.9.23 and noticed some of our Glyphs-based families stopped building correctly. Instead generating static fonts for each export in Glyphs, only the masters were built.

I believe the change in https://github.com/googlefonts/gftools/commit/bfb90fadbfde4431828f80b531f202da4a64eb0d is the cause. We have quite a few families that are interpolatable but not variable. That means that glyphs can be interpolated between some masters, but not all masters, so enabling the creation of variable fonts (through `buildVariable`) wouldn't help. I have attached an example Glyphs file (excuse my terrible design skills) of a family with some compatible masters using interpolation.

[Example.zip](https://github.com/googlefonts/gftools/files/10793928/Example.zip)

We would like to add a new `gftools builder` option that allows us to explicitly opt into interpolation in these cases.
