### PR TITLE
builder: gen stat tables after post processing fonts

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -337,12 +337,12 @@ class GFBuilder:
         if not ttFonts:
             return
 
-        self.gen_stat(ttFonts)
-        # We post process each variable font after generating the STAT tables
-        # because these tables are needed in order to fix the name tables.
         for ttFont in ttFonts:
             self.post_process_variable(ttFont.reader.file.name)
             self.outputs.add(ttFont.reader.file.name)
+
+        ttFonts = [TTFont(f.reader.file.name) for f in ttFonts]
+        self.gen_stat(ttFonts)
 
     def run_fontmake(self, source, args):
         if "output_dir" in args:

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -708,6 +708,12 @@ def fix_colr_font(ttfont: TTFont) -> TTFont:
         raise NotImplementedError(f"COLR version '{colr_version}' not supported.")
 
 
+def fix_nbspace_glyph(ttfont: TTFont):
+    cmap = ttfont.getBestCmap()
+    if 0x00A0 in cmap:
+        return
+    
+
 def fix_font(font, include_source_fixes=False, new_family_name=None, fvar_instance_axis_dflts=None):
     fixed_font = deepcopy(font)
     if new_family_name:


### PR DESCRIPTION
We currently generate the stat tables and then post process the fonts. If a STAT table uses nameID 2 or 17 in an axisValue, these may be changed by the post processing step. By post processing the fonts first, we ensure that the STAT table doesn't change.

cc @RosaWagner 