### PR TITLE
Only pass check_compatibility option for run_from_glyphs or run_from_designspace

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -383,11 +383,12 @@ class GFBuilder:
         if "removeOutlineOverlaps" in self.config:
             args["remove_overlaps"] = self.config["removeOutlineOverlaps"]
 
-        args["check_compatibility"] = self.config["checkCompatibility"]
 
         if source.endswith(".glyphs") or source.endswith(".glyphspackage"):
+            args["check_compatibility"] = self.config["checkCompatibility"]
             FontProject().run_from_glyphs(source, **args)
         elif source.endswith(".designspace"):
+            args["check_compatibility"] = self.config["checkCompatibility"]
             FontProject().run_from_designspace(source, **args)
         elif source.endswith(".ufo"):
             FontProject().run_from_ufos([source], **args)


### PR DESCRIPTION
The `check_compatbility` option was recently added in #662. Unfortunately this causes builds for "plain" UFO files to fail, as the `run_from_ufos` function in fontmake does not accept a named `check_compatibility` argument. This produces the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/gftools", line 8, in <module>
    sys.exit(main())
  File "/gftools/lib/python3.10/site-packages/gftools/scripts/__init__.py", line 91, in main
    mod.main(args[2:])
  File "/gftools/lib/python3.10/site-packages/gftools/builder/__init__.py", line 665, in main
    builder.build()
  File "/gftools/lib/python3.10/site-packages/gftools/builder/__init__.py", line 212, in build
    self.build_static()
  File "/gftools/lib/python3.10/site-packages/gftools/builder/__init__.py", line 460, in build_static
    self.build_a_static_format("otf", self.config["otDir"], self.post_process)
  File "/gftools/lib/python3.10/site-packages/gftools/builder/__init__.py", line 517, in build_a_static_format
    for fontfile in self.run_fontmake(source, args):
  File "/gftools/lib/python3.10/site-packages/gftools/builder/__init__.py", line 393, in run_fontmake
    FontProject().run_from_ufos([source], **args)
  File "/gftools/lib/python3.10/site-packages/fontmake/font_project.py", line 1283, in run_from_ufos
    self.build_otfs(ufos, cff_version=cff_version, **kwargs)
  File "/gftools/lib/python3.10/site-packages/fontmake/font_project.py", line 279, in build_otfs
    self.save_otfs(ufos, **kwargs)
  File "/gftools/lib/python3.10/site-packages/fontTools/misc/loggingTools.py", line 375, in wrapper
    return func(*args, **kwds)
TypeError: FontProject.save_otfs() got an unexpected keyword argument 'check_compatibility'
```

This PR modifies the code to only pass the `check_compatibility` parameter when calling either `run_from_glyphs` or `run_from_designspace`.