### PR TITLE
push-stats: cache issues

### DIFF
--- a/Lib/gftools/push-templates/index.html
+++ b/Lib/gftools/push-templates/index.html
@@ -74,7 +74,7 @@
             <label for="start-date">Start:</label>
             <input type="date" id="start-date" name="start-date" value="2019-01-01" min="2014-01-01">
             <label for="end-date">End:</label>
-            <input type="date" id="end-date" name="end-date" value="2022-12-31" min="2014-01-01">
+            <input type="date" id="end-date" name="end-date" value="2023-12-31" min="2014-01-01">
         </div>
 
         <h2>Pushes</h2>


### PR DESCRIPTION
Currently, each time we run the tool, it'll find all the issues from 2014 onwards. This PR implements caching by saving the results to a json file and if the tool is rerun, it'll only fetch issues from the date the tool was last run.