### PR TITLE
push: fix PushItems.missing_paths

### DIFF
--- a/Lib/gftools/push.py
+++ b/Lib/gftools/push.py
@@ -292,12 +292,22 @@ class PushItems(list):
             elif "#" in line:
                 path, url = line.split("#")
                 item = PushItem(
-                    Path(path.strip()), category if not deleted else PushCategory.DELETED, status, url.strip(), push_list
+                    Path(path.strip()),
+                    category if not deleted else PushCategory.DELETED,
+                    status,
+                    url.strip(),
+                    push_list,
                 )
                 results.add(item)
             # some paths may not contain a PR, still add them
             else:
-                item = PushItem(Path(line.strip()), category if not deleted else PushCategory.DELETED, status, "", push_list)
+                item = PushItem(
+                    Path(line.strip()),
+                    category if not deleted else PushCategory.DELETED,
+                    status,
+                    "",
+                    push_list,
+                )
                 results.add(item)
             deleted = False
         return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
   'ttfautohint-py',
   'brotli',
   'jinja2',
-  'hyperglot',
+  'hyperglot<=0.4.5',
   'fontFeatures',
   'vharfbuzz',
   'bumpfontversion',

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -499,6 +499,7 @@ def test_push_items_add(items, expected):
     [
         ("ofl/noto # 2", 1),
         ("# New\nofl/noto # 2\nofl/foobar # 3\n\n# Upgrade\nofl/mavenPro # 4", 3),
+        ("# New\nofl/noto\n# Deleted: lang/languages/wsg_Gong.textproto # 5", 2)
     ],
 )
 def test_push_items_from_server_file(string, expected_size):


### PR DESCRIPTION
Currently, this method will flag filepaths for deleted items. We need to skip them instead.

cc @RosaWagner 