### PR TITLE
packager: add github url to new description files

### DIFF
--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -867,9 +867,17 @@ def _create_or_update_metadata_pb(upstream_conf: YAML,
                                   upstream_archive_url:str=None) -> None:
   metadata_file_name = os.path.join(tmp_package_family_dir, 'METADATA.pb')
   try:
-    subprocess.run(['gftools', 'add-font', tmp_package_family_dir]
-                                , check=True, stdout=subprocess.PIPE
-                                , stderr=subprocess.PIPE)
+    subprocess.run(
+      [
+        'gftools',
+        'add-font',
+        tmp_package_family_dir,
+        "--github_url",
+        upstream_conf["repository_url"],
+      ],
+      check=True, stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE
+    )
   except subprocess.CalledProcessError as e:
     print(str(e.stderr, 'utf-8'), file=sys.stderr)
     raise e

--- a/Lib/gftools/scripts/add_font.py
+++ b/Lib/gftools/scripts/add_font.py
@@ -70,6 +70,9 @@ parser.add_argument("--min_pct_ext", type=float, default=0.01, help='What percen
                    ' for a -ext subset.')
 parser.add_argument("--lang", type=str, help='Path to lang metadata package', default=None)
 parser.add_argument("directory", type=str, help='A directory containing a font family')
+parser.add_argument("--github_url", type=str, default=None,
+  help="The font family's github url which gets written to new description files"
+)
 
 
 def _FileFamilyStyleWeights(fontdir):
@@ -301,7 +304,12 @@ def main(args=None):
   if os.path.isfile(desc):
     print('DESCRIPTION.en_us.html exists')
   else:
-    _WriteTextFile(desc, 'N/A')
+    desc_text = "N/A"
+    if args.github_url:
+      pattern = r'(https?://)?(www\.)?'
+      cleaned_url = re.sub(pattern, '', args.github_url)
+      desc_text += f'\n<p>To contribute, please see <a href="{args.github_url}">{cleaned_url}</a>.</p>'
+    _WriteTextFile(desc, desc_text)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, when you use gftools packager on a new family, the description placeholder is "N/A". This PR will add the "To contribute, please see url" to the description.

<img width="436" alt="Screenshot 2023-06-22 at 15 28 29" src="https://github.com/googlefonts/gftools/assets/7525512/7c437230-7f75-4b46-abd3-ed35393221b1">

cc @RosaWagner @emmamarichal 