### PR TITLE
utils: remove_url_prefix added

### DIFF
--- a/Lib/gftools/scripts/add_designer.py
+++ b/Lib/gftools/scripts/add_designer.py
@@ -34,6 +34,7 @@ from unidecode import unidecode
 from PIL import Image
 from gftools.designers_pb2 import DesignerInfoProto
 from google.protobuf import text_format
+from gftools.utils import remove_url_prefix
 
 
 def process_image(fp):
@@ -87,7 +88,7 @@ def gen_hrefs(urls):
             res[url] = "Github"
         else:
             # https://www.mysite.com --> mysite.com
-            res[url] = url.split("//")[1]
+            res[url] = remove_url_prefix(url)
     return " | ".join(f'<a href="{k}">{v}</a>' for k,v in res.items())
 
 

--- a/Lib/gftools/scripts/add_font.py
+++ b/Lib/gftools/scripts/add_font.py
@@ -59,6 +59,7 @@ from axisregistry import AxisRegistry
 from glyphsets.codepoints import SubsetsInFont
 from google.protobuf import text_format
 from pkg_resources import resource_filename
+from gftools.utils import remove_url_prefix
 
 axis_registry = AxisRegistry()
 
@@ -306,9 +307,8 @@ def main(args=None):
   else:
     desc_text = "N/A"
     if args.github_url:
-      pattern = r'(https?://)?(www\.)?'
-      cleaned_url = re.sub(pattern, '', args.github_url)
-      desc_text += f'\n<p>To contribute, please see <a href="{args.github_url}">{cleaned_url}</a>.</p>'
+      human_url = remove_url_prefix(args.github_url)
+      desc_text += f'\n<p>To contribute, please see <a href="{args.github_url}">{human_url}</a>.</p>'
     _WriteTextFile(desc, desc_text)
 
 

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -28,6 +28,7 @@ from pkg_resources import resource_filename
 from google.protobuf import text_format
 import json
 from PIL import Image
+import re
 if sys.version_info[0] == 3:
     from configparser import ConfigParser
 else:
@@ -499,3 +500,9 @@ def parse_axis_dflts(string):
         res[k] = float(v)
     return res
 
+
+def remove_url_prefix(url):
+    """https://www.google.com --> google.com"""
+    pattern = r'(https?://)?(www\.)?'
+    cleaned_url = re.sub(pattern, '', url)
+    return cleaned_url

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "url,want",
+    [
+        ("https://www.google.com", "google.com"),
+        ("https://google.com", "google.com"),
+        ("http://www.google.com", "google.com"),
+        ("http://google.com", "google.com"),
+        ("google.com", "google.com"),
+        ("", ""),
+    ]
+)
+def test_remove_url_prefix(url, want):
+    from gftools.utils import remove_url_prefix
+    got = remove_url_prefix(url)
+    assert got == want


### PR DESCRIPTION
`gftools add-designers` will now remove `www.` in the visible part of the <a> tag e.g

Current
`<a href="https://www.google.com>www.google.com</a>`

This PR
`<a href="https://www.google.com>google.com</a>`

I've also reused this function in yesterday's packager pr #687 

cc @RosaWagner 