### PR TITLE
push: handle knowledge articles better and improve UX

### DIFF
--- a/Lib/gftools/push.py
+++ b/Lib/gftools/push.py
@@ -8,6 +8,7 @@ import requests  # type: ignore[import]
 from enum import Enum
 from io import TextIOWrapper
 import pygit2
+import subprocess
 
 
 def _get_google_fonts_remote(repo):
@@ -20,6 +21,9 @@ def _get_google_fonts_remote(repo):
 def branch_matches_google_fonts_main(path):
     repo = pygit2.Repository(path)
     remote_name = _get_google_fonts_remote(repo)
+
+    # fetch latest remote data from branch main
+    subprocess.run(["git", "fetch", remote_name, "main"])
 
     # Check local is in sync with remote
     diff = repo.diff(repo.head, f"{remote_name}/main")

--- a/Lib/gftools/push.py
+++ b/Lib/gftools/push.py
@@ -213,7 +213,7 @@ class PushItems(list):
         # Pop any push items which are a child of the item's path
         to_pop = None
         for idx, i in enumerate(self):
-            if i.path.parts[-1] in item.path.parts or i.path == item.path:
+            if str(i.path.parent) in str(i.path) or i.path == item.path:
                 to_pop = idx
                 break
         if to_pop:

--- a/Lib/gftools/push.py
+++ b/Lib/gftools/push.py
@@ -7,6 +7,28 @@ import gftools.fonts_public_pb2 as fonts_pb2
 import requests  # type: ignore[import]
 from enum import Enum
 from io import TextIOWrapper
+import pygit2
+
+
+def _get_google_fonts_remote(repo):
+    for remote in repo.remotes:
+        if "google/fonts.git" in remote.url:
+            return remote.name
+    raise ValueError("Cannot find remote with url https://www.github.com/google/fonts")
+
+
+def branch_matches_google_fonts_main(path):
+    repo = pygit2.Repository(path)
+    remote_name = _get_google_fonts_remote(repo)
+
+    # Check local is in sync with remote
+    diff = repo.diff(repo.head, f"{remote_name}/main")
+    if diff.stats.files_changed != 0:
+        raise ValueError(
+            "Your local branch is not in sync with the google/fonts "
+            "main branch. Please pull or remove any commits."
+        )
+    return True
 
 
 class PushCategory(Enum):

--- a/Lib/gftools/scripts/gen_push_lists.py
+++ b/Lib/gftools/scripts/gen_push_lists.py
@@ -29,6 +29,13 @@ def main(args=None):
         sys.exit()
 
     gf_path = sys.argv[2]
+    if not "ofl" in os.listdir(gf_path):
+        raise ValueError(
+            f"'{gf_path}' does not contain an 'ofl' dir so it isn't a google/fonts repo."
+        )
+    cwd = os.getcwd()
+
+    os.chdir(gf_path)
     branch_matches_google_fonts_main(gf_path)
     to_sandbox_fp = os.path.join(gf_path, "to_sandbox.txt")
     to_production_fp = os.path.join(gf_path, "to_production.txt")
@@ -51,6 +58,8 @@ def main(args=None):
 
     to_sandbox.to_server_file(to_sandbox_fp)
     to_production.to_server_file(to_production_fp)
+
+    os.chdir(cwd)
 
 
 if __name__ == "__main__":

--- a/Lib/gftools/scripts/gen_push_lists.py
+++ b/Lib/gftools/scripts/gen_push_lists.py
@@ -15,7 +15,12 @@ gftools gen-push-lists /path/to/google/fonts
 """
 import sys
 import os
-from gftools.push import PushItems, PushStatus, PushList
+from gftools.push import (
+    PushItems,
+    PushStatus,
+    PushList,
+    branch_matches_google_fonts_main,
+)
 
 
 def main(args=None):
@@ -24,6 +29,7 @@ def main(args=None):
         sys.exit()
 
     gf_path = sys.argv[2]
+    branch_matches_google_fonts_main(gf_path)
     to_sandbox_fp = os.path.join(gf_path, "to_sandbox.txt")
     to_production_fp = os.path.join(gf_path, "to_production.txt")
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -472,6 +472,43 @@ def test_push_items_operators(operator, item1, item2, expected):
                 ]
             ),
         ),
+        # Ensure Knowledge articles are unique
+        (
+            [
+                PushItem(
+                    Path("cc-by-sa/knowledge/glossary/terms/xopq_axis/content.md"),
+                    PushCategory.NEW,
+                    PushStatus.IN_DEV,
+                    "1",
+                ),
+                PushItem(
+                    Path(
+                        "cc-by-sa/knowledge/modules/using_type/lessons/the_complications_of_typographic_size/content.md"
+                    ),
+                    PushCategory.NEW,
+                    PushStatus.IN_DEV,
+                    "1",
+                ),
+            ],
+            PushItems(
+                [
+                    PushItem(
+                        Path("cc-by-sa/knowledge/glossary/terms/xopq_axis/content.md"),
+                        PushCategory.NEW,
+                        PushStatus.IN_DEV,
+                        "1",
+                    ),
+                    PushItem(
+                        Path(
+                            "cc-by-sa/knowledge/modules/using_type/lessons/the_complications_of_typographic_size/content.md"
+                        ),
+                        PushCategory.NEW,
+                        PushStatus.IN_DEV,
+                        "1",
+                    ),
+                ]
+            ),
+        ),
     ],
 )
 def test_push_items_add(items, expected):
@@ -499,7 +536,7 @@ def test_push_items_add(items, expected):
     [
         ("ofl/noto # 2", 1),
         ("# New\nofl/noto # 2\nofl/foobar # 3\n\n# Upgrade\nofl/mavenPro # 4", 3),
-        ("# New\nofl/noto\n# Deleted: lang/languages/wsg_Gong.textproto # 5", 2)
+        ("# New\nofl/noto\n# Deleted: lang/languages/wsg_Gong.textproto # 5", 2),
     ],
 )
 def test_push_items_from_server_file(string, expected_size):
@@ -629,7 +666,12 @@ def test_push_items_missing_paths(path, expected):
                 PushStatus.IN_DEV,
                 "45",
             ),
-            {'path': 'ofl/mavenpro', 'category': 'Upgrade', 'status': 'In Dev / PR Merged', 'url': '45'}
+            {
+                "path": "ofl/mavenpro",
+                "category": "Upgrade",
+                "status": "In Dev / PR Merged",
+                "url": "45",
+            },
         ),
         (
             PushItem(
@@ -638,7 +680,7 @@ def test_push_items_missing_paths(path, expected):
                 None,
                 "45",
             ),
-            {'path': 'ofl/mavenpro', 'category': None, 'status': None, 'url': '45'}
+            {"path": "ofl/mavenpro", "category": None, "status": None, "url": "45"},
         ),
         (
             PushItem(
@@ -647,10 +689,9 @@ def test_push_items_missing_paths(path, expected):
                 None,
                 None,
             ),
-            {'path': 'ofl/mavenpro', 'category': None, 'status': None, 'url': None}
+            {"path": "ofl/mavenpro", "category": None, "status": None, "url": None},
         ),
-
-    ]
+    ],
 )
 def test_push_items_to_json(item, expected):
     assert item.to_json() == expected


### PR DESCRIPTION
This PR addresses two issues in the push module and push tools. 

1. @eliheuer noticed that some of the knowledge articles were getting removed from the push lists. This is happening because we are popping child items incorrectly.

2. We currently allow `gftools gen-push-lists` to be run a user's local google/fonts repo may not be in an ideal state. You only want to run this tool when your local repo matches the google/fonts main branch, otherwise you get an incorrect pushlist e.g https://github.com/google/fonts/pull/6531/files#diff-f692d04a6bb7f729595b26e06b24f9bc8174de517c2e3d2001fec2a5b2ea28de. I've added the function `branch_matches_google_fonts_main` to catch these situations and raise an error.