### PR TITLE
Provide UFO structure

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -389,6 +389,9 @@ class GFBuilder:
             args["check_compatibility"] = self.config["checkCompatibility"]
             if "glyphData" in self.config:
                 args["glyph_data"] = self.config["glyphData"]
+            # The following line should be removed once we require
+            # fontmake >= 3.7.1
+            args["ufo_structure"] = "package"
             FontProject().run_from_glyphs(source, **args)
         elif source.endswith(".designspace"):
             args["check_compatibility"] = self.config["checkCompatibility"]


### PR DESCRIPTION
Fonttools v3.7.0 changed the API (thanks!) requiring an extra keyword argument to `run_from_glyphs`. See https://github.com/googlefonts/googlefonts-project-template/issues/109