### PR TITLE
Make the qa tool more robust

### DIFF
--- a/Lib/gftools/qa.py
+++ b/Lib/gftools/qa.py
@@ -40,7 +40,7 @@ class FontQA:
             diffenator=True,
             diffbrowsers=False,
         )
-    
+
     def diffbrowsers(self, imgs=False):
         logger.info("Running Diffbrowsers")
         if not self.fonts_before:
@@ -88,6 +88,16 @@ class FontQA:
             cmd.extend(extra_args)
         subprocess.call(cmd)
 
+        fontbakery_report = os.path.join(self.out, "Fontbakery", "report.md")
+        if not os.path.isfile(fontbakery_report):
+            logger.warning(
+                "Cannot Post Github message because no Fontbakery report exists"
+            )
+            return
+        with open(fontbakery_report) as doc:
+            msg = doc.read()
+            self.post_to_github(msg)
+
     def googlefonts_upgrade(self, imgs=False):
         self.fontbakery()
         self.diffenator()
@@ -103,19 +113,7 @@ class FontQA:
         else:
             self.proof(imgs)
 
-    def post_to_github(self):
-        """Post fontbakery report to GitHub"""
-        fontbakery_report = os.path.join(self.out, "Fontbakery", "report.md")
-        if not os.path.isfile(fontbakery_report):
-            logger.warning(
-                "Cannot Post Github message because no Fontbakery report exists"
-            )
-            return
-        with open(fontbakery_report) as doc:
-            msg = doc.read()
-            self._post_to_github(msg)
-
-    def _post_to_github(self, text):
+    def post_to_github(self, text):
         """Post text as a new issue or as a comment to an open
         PR"""
         if not self.url:

--- a/Lib/gftools/qa.py
+++ b/Lib/gftools/qa.py
@@ -4,12 +4,17 @@ import subprocess
 
 from gftools.gfgithub import GitHubClient
 from gftools.utils import mkdir
+
 try:
     from diffenator2 import ninja_diff, ninja_proof
 except ModuleNotFoundError:
-    raise ModuleNotFoundError(("gftools was installed without the QA "
-        "dependencies. To install the dependencies, see the ReadMe, "
-        "https://github.com/googlefonts/gftools#installation"))
+    raise ModuleNotFoundError(
+        (
+            "gftools was installed without the QA "
+            "dependencies. To install the dependencies, see the ReadMe, "
+            "https://github.com/googlefonts/gftools#installation"
+        )
+    )
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -25,9 +30,7 @@ class FontQA:
     def diffenator(self, **kwargs):
         logger.info("Running Diffenator")
         if not self.fonts_before:
-            logger.warning(
-                "Cannot run Diffenator since there are no fonts before"
-            )
+            logger.warning("Cannot run Diffenator since there are no fonts before")
             return
         dst = os.path.join(self.out, "Diffenator")
         ninja_diff(
@@ -44,9 +47,7 @@ class FontQA:
     def diffbrowsers(self, imgs=False):
         logger.info("Running Diffbrowsers")
         if not self.fonts_before:
-            logger.warning(
-                "Cannot run diffbrowsers since there are no fonts before"
-            )
+            logger.warning("Cannot run diffbrowsers since there are no fonts before")
             return
         dst = os.path.join(self.out, "Diffbrowsers")
         mkdir(dst)
@@ -60,7 +61,7 @@ class FontQA:
             diffenator=False,
             diffbrowsers=True,
         )
-    
+
     def proof(self, imgs=False):
         logger.info("Running proofing tools")
         dst = os.path.join(self.out, "Proof")
@@ -77,7 +78,7 @@ class FontQA:
         out = os.path.join(self.out, "Fontbakery")
         mkdir(out)
         cmd = (
-            ["fontbakery", "check-"+profile, "-l", "INFO", "--succinct"]
+            ["fontbakery", "check-" + profile, "-l", "INFO", "--succinct"]
             + [f.path for f in self.fonts]
             + ["-C"]
             + ["--ghmarkdown", os.path.join(out, "report.md")]

--- a/Lib/gftools/qa.py
+++ b/Lib/gftools/qa.py
@@ -16,10 +16,11 @@ logger.setLevel(logging.INFO)
 
 
 class FontQA:
-    def __init__(self, fonts, fonts_before=None, out="out"):
+    def __init__(self, fonts, fonts_before=None, out="out", url=None):
         self.fonts = fonts
         self.fonts_before = fonts_before
         self.out = out
+        self.url = url
 
     def diffenator(self, **kwargs):
         logger.info("Running Diffenator")
@@ -102,14 +103,16 @@ class FontQA:
         else:
             self.proof(imgs)
 
-    def post_to_github(self, url):
+    def post_to_github(self):
         """Post Fontbakery report as a new issue or as a comment to an open
         PR"""
+        if not self.url:
+            return
         # Parse url tokens
-        url_split = url.split("/")
+        url_split = self.url.split("/")
         repo_owner = url_split[3]
         repo_name = url_split[4]
-        issue_number = url_split[-1] if "pull" in url else None
+        issue_number = url_split[-1] if "pull" in self.url else None
 
         fontbakery_report = os.path.join(self.out, "Fontbakery", "report.md")
         if not os.path.isfile(fontbakery_report):

--- a/Lib/gftools/qa.py
+++ b/Lib/gftools/qa.py
@@ -104,7 +104,19 @@ class FontQA:
             self.proof(imgs)
 
     def post_to_github(self):
-        """Post Fontbakery report as a new issue or as a comment to an open
+        """Post fontbakery report to GitHub"""
+        fontbakery_report = os.path.join(self.out, "Fontbakery", "report.md")
+        if not os.path.isfile(fontbakery_report):
+            logger.warning(
+                "Cannot Post Github message because no Fontbakery report exists"
+            )
+            return
+        with open(fontbakery_report) as doc:
+            msg = doc.read()
+            self._post_to_github(msg)
+
+    def _post_to_github(self, text):
+        """Post text as a new issue or as a comment to an open
         PR"""
         if not self.url:
             return
@@ -114,18 +126,9 @@ class FontQA:
         repo_name = url_split[4]
         issue_number = url_split[-1] if "pull" in self.url else None
 
-        fontbakery_report = os.path.join(self.out, "Fontbakery", "report.md")
-        if not os.path.isfile(fontbakery_report):
-            logger.warning(
-                "Cannot Post Github message because no Fontbakery report exists"
-            )
-            return
-        
         client = GitHubClient(repo_owner, repo_name)
 
-        with open(fontbakery_report) as doc:
-            msg = doc.read()
-            if issue_number:
-                client.create_issue_comment(issue_number, msg)
-            else:
-                client.create_issue("Google Font QA report", msg)
+        if issue_number:
+            client.create_issue_comment(issue_number, text)
+        else:
+            client.create_issue("Google Font QA report", text)

--- a/Lib/gftools/scripts/qa.py
+++ b/Lib/gftools/scripts/qa.py
@@ -246,8 +246,6 @@ def main(args=None):
     if args.proof:
         qa.proof()
 
-    qa.post_to_github()
-
 
 if __name__ == "__main__":
     main()

--- a/Lib/gftools/scripts/qa.py
+++ b/Lib/gftools/scripts/qa.py
@@ -216,12 +216,20 @@ def main(args=None):
             family_name, fonts_before_dir
         )
 
+    url = None
+    if args.out_url:
+        url = args.out_url
+    elif args.out_github and args.pull_request:
+        url = args.pull_request
+    elif args.out_github and args.github_dir:
+        url = args.github_dir
+
     if fonts_before:
         dfonts_before = [DFont(f) for f in fonts_before if f.endswith((".ttf", ".otf"))
                           and "static" not in f]
-        qa = FontQA(dfonts, dfonts_before, args.out)
+        qa = FontQA(dfonts, dfonts_before, args.out, url=url)
     else:
-        qa = FontQA(dfonts, out=args.out)
+        qa = FontQA(dfonts, out=args.out, url=url)
 
     if args.auto_qa and family_on_gf:
         qa.googlefonts_upgrade(args.imgs)
@@ -238,12 +246,7 @@ def main(args=None):
     if args.proof:
         qa.proof()
 
-    if args.out_url:
-        qa.post_to_github(args.out_url)
-    elif args.out_github and args.pull_request:
-        qa.post_to_github(args.pull_request)
-    elif args.out_github and args.github_dir:
-        qa.post_to_github(args.github_dir)
+    qa.post_to_github()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This improves the robustness of ghtools.qa in a couple of ways:

- Ensures that the fontbakery report is posted as a GH comment just after fontbakery runs, so it is encapsulated from other methods.
- Wraps each function in a decorator which catches exceptions so that an exception in one test does not crash the whole tool.
- Posts a notification of any exceptions/failures to GH.

This is split into fairly small self-contained commits, so may be easiest to review one commit at a time.