### PR TITLE
Deprecate the fix-glyphs script

### DIFF
--- a/Lib/gftools/scripts/fix_glyphs.py
+++ b/Lib/gftools/scripts/fix_glyphs.py
@@ -14,41 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import unicode_literals
-import argparse
-from glyphsLib import GSFont
-
-parser = argparse.ArgumentParser(description='Report issues'
-                                             ' on .glyphs font files')
-parser.add_argument('font', nargs="+")
-#parser.add_argument('--autofix', default=False,
-#                    action='store_true', help='Apply autofix')
-
-def customparam(font, name):
-  for param in font.customParameters:
-      if param.name == name:
-          return param.value
-
-
 def main(args=None):
-  args = parser.parse_args(args)
-
-  for font_path in args.font:
-      font = GSFont(font_path)
-      print('Copyright: "{}"'.format(font.copyright))
-      print('VendorID: "{}"'.format(customparam(font, "vendorID")))
-      print('fsType: {}'.format(customparam(font, "fsType")))
-      print('license: "{}"'.format(customparam(font, "license")))
-      print('licenseURL: "{}"'.format(customparam(font, "licenseURL")))
-  # TODO: handle these other fields:
-  #
-  # for master/instance in masters-or-instances:
-  #   print: 8 Vertical Metrics
-  #
-  # Instance ExtraLight weightClass set to 275
-  # Instances italicAngle set to 0, if the master/instance slant value is not 0
-  # Instance named Regular (400) for families with a single instance
-  # Instance Bold style linking set for families with a 400 and 700 instance
+  print("This script is deprecated (it never really did anything anyway)")
+  print(r"You may be looking for https://github.com/googlefonts/gf-glyphs-scripts/blob/main/Google%20Fonts/fixfonts.py instead")
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
In #94, Marc says:

> This script is misleading and still appears to be a wip. It doesn't fix anything, [master/bin/gftools-fix-glyphs.py#L38-L43](https://github.com/googlefonts/gftools/blob/master/bin/gftools-fix-glyphs.py?rgh-link-date=2018-11-01T09%3A32%3A51Z#L38-L43)

> There's a fix QA and fix script here (specific to GF), [googlefonts/gf-glyphs-scripts](https://github.com/googlefonts/gf-glyphs-scripts).

Eventually we should get rid of this script, but first we will redirect people to the actual Glyphs fixing script. 