### PR TITLE
Stop duplicating empty sample text

### DIFF
--- a/Lib/gftools/scripts/add_font.py
+++ b/Lib/gftools/scripts/add_font.py
@@ -150,7 +150,7 @@ def _MakeMetadata(args, is_new):
       metadata.display_name = old_metadata.display_name
     if old_metadata.primary_script:
       metadata.primary_script = old_metadata.primary_script
-    if old_metadata.sample_text:
+    if old_metadata.sample_text and old_metadata.sample_text.ByteSize():
       metadata.sample_text.CopyFrom(old_metadata.sample_text)
     if old_metadata.minisite_url:
       metadata.minisite_url = old_metadata.minisite_url


### PR DESCRIPTION
Fixes #707

Because `sample_text` is a Protobuf "message" (i.e. a nested dictionary), unlike a Python dictionary and unlike a standard scalar field, this has a boolean value of true even if it has no fields. We have to check if there's actually anything in it.