### PR TITLE
Add [googlefonts] optional to fontbakery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
 
 [project.optional-dependencies]
 qa = [
-  "fontbakery",
+  "fontbakery[googlefonts]",
   "diffenator2>=0.2.0"
 ]
 ninja = [ "ninja" ]


### PR DESCRIPTION
fontbakery >=0.9.0 slimmed down its dependencies and we need to install `fontbakery[googlefonts]` for our profile to work. I'm sure I opened an issue about this but I can't find it now.