### PR TITLE
Use gftools-autohint in ninja builder

### DIFF
--- a/Lib/gftools/builder/_ninja.py
+++ b/Lib/gftools/builder/_ninja.py
@@ -134,7 +134,7 @@ class NinjaBuilder(GFBuilder):
         self.w.comment("Run the ttfautohint in-place and touch a stamp file")
         self.w.rule(
             "autohint",
-            "ttfautohint $in $in.autohinted && mv $in.autohinted $in && touch $in.autohintstamp",
+            "gftools-autohint $in && touch $in.autohintstamp",
             **args,
         )
 


### PR DESCRIPTION
Fixes #727. gftools doesn't install ttfautohint, but does install ttfautohint-py; gftools-autohint wraps this, so we can use this instead of ttfautohint.