### PR TITLE
[builder2] Pass --glyph-data to fontmake when converting glyphs to ufo

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -104,7 +104,8 @@ class GFBuilder:
                 "output_dir": directory,
                 "master_dir": directory,
                 "designspace_path": output,
-                "ufo_structure": "json"
+                "ufo_structure": "json",
+                "glyph_data": self.config.get("glyphData")
             },
         )
         return source.with_suffix(".designspace").name


### PR DESCRIPTION
This seems to have been dropped during the refactoring.