### PR TITLE
Update _ninja.py

### DIFF
--- a/Lib/gftools/builder/_ninja.py
+++ b/Lib/gftools/builder/_ninja.py
@@ -63,19 +63,20 @@ class NinjaBuilder(GFBuilder):
                 os.remove(temporary)
 
         # Clean up temp build files
-        search_directory = os.getcwd()
-        target_names = ["build.ninja", ".ninja_log", "instance_ufo", "master_ufo"]
-        for root, dirs, files in os.walk(search_directory, topdown=False):
-            for file in files:
-                if file in target_names:
-                    file_path = os.path.join(root, file)
-                    os.remove(file_path)
-                    print(f"Removed file: {file_path}")
-            for dir_name in dirs:
-                if dir_name in target_names:
-                    dir_path = os.path.join(root, dir_name)
-                    shutil.rmtree(dir_path)
-                    print(f"Removed directory: {dir_path}")
+        if self.config["cleanUp"]:
+            search_directory = os.getcwd()
+            target_names = ["build.ninja", ".ninja_log", "instance_ufo", "master_ufo"]
+            for root, dirs, files in os.walk(search_directory, topdown=False):
+                for file in files:
+                    if file in target_names:
+                        file_path = os.path.join(root, file)
+                        os.remove(file_path)
+                        print(f"Removed file: {file_path}")
+                for dir_name in dirs:
+                    if dir_name in target_names:
+                        dir_path = os.path.join(root, dir_name)
+                        shutil.rmtree(dir_path)
+                        print(f"Removed directory: {dir_path}")
 
         print("Done building fonts!")
 


### PR DESCRIPTION
Making the Ninja script aware if "cleanUp" has been set in project.yaml. Otherwise Ninja will *always* delete all the temp files, even if that is undesirable (such as when running two separate project.yaml files that point to the same master_ufo directory). 

#782 - Resolves this issue