### PR TITLE
publish-release: use gh-action-pypi-publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Create and Publish Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v2
@@ -23,7 +25,7 @@ jobs:
       - name: Install release dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel twine build
+          pip install --upgrade setuptools wheel build
 
       - name: Get release notes
         id: release_notes
@@ -48,10 +50,8 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Build and publish to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python -m build
-          twine upload dist/gftools*
+      - name: Build package
+        run: python -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Currently, Twine doesn't support the "trusted publishing" which we now need to use (or an api token but apparently this trusted publishing is preferred). However, trusted publishing is supported by the official pypi gh action, https://github.com/pypa/gh-action-pypi-publish.