### PR TITLE
[qa] Allow multiple --extra-fontbakery-args

### DIFF
--- a/Lib/gftools/scripts/qa.py
+++ b/Lib/gftools/scripts/qa.py
@@ -138,7 +138,7 @@ def main(args=None):
     check_group.add_argument(
         "--extra-fontbakery-args",
         help="Additional arguments to FontBakery",
-        nargs="*",
+        action="append",
     )
 
     parser.add_argument("--imgs", action="store_true", help="Gen images using Selenium")


### PR DESCRIPTION
`--extra-fontbakery-args` is a flag on `gftools-qa` which passes *another flag* to fontbakery. Of course this causes problems. If you say `--extra-fontbakery-args --foo` this gets interpreted as a `--foo` flag to `gftools-qa`. `"--foo"` doesn't help because the shell eats the quotes. Apparently the right way to do it is `--extra-fontbakery-args="--foo"` which parses properly. But then `--extra-fontbakery-args="--foo bar"` works on the `gftools-qa` side, but adds a single string "--foo bar" string to fontbakery's argv, which does not parse on that side. Much joy. And you *really* don't want to get into splitting arguments on spaces and feeding them to argv, because `--html "A Report.html"` should be two arguments, not three. And `--extra-fontbakery-args="--foo" "bar"` doesn't work either.

So (deep breath) it turns out the right way to do it is `--extra-fontbakery-args="--foo" --extra-fontbakery-args="bar"`, and that in turn means we need to use `action="append"` instead of `nargs="*"`.
