### PR TITLE
qa: display log message instead of raising an error if fontbakery report cannot be posted.

### DIFF
--- a/Lib/gftools/qa.py
+++ b/Lib/gftools/qa.py
@@ -6,7 +6,7 @@ import traceback
 from gftools.gfgithub import GitHubClient
 from gftools.utils import mkdir
 import sys
-
+from requests.exceptions import HTTPError
 try:
     from diffenator2 import ninja_diff, ninja_proof
 except ModuleNotFoundError:
@@ -167,7 +167,17 @@ class FontQA:
 
         client = GitHubClient(repo_owner, repo_name)
 
-        if issue_number:
-            client.create_issue_comment(issue_number, text)
-        else:
-            client.create_issue("Google Font QA report", text)
+        try:
+            if issue_number:
+                client.create_issue_comment(issue_number, text)
+            else:
+                client.create_issue("Google Font QA report", text)
+        except Exception as e:
+            logger.warn(
+                "Cannot post Fontbakery report!\n"
+                "Most likely, the repository may lack a GH_TOKEN secret, or "
+                "the pull request has come from a forked repo which "
+                "is not allowed to access the repo's secrets for "
+                f"security reasons. Full traceback:\n{e}"
+            )
+

--- a/Lib/gftools/qa.py
+++ b/Lib/gftools/qa.py
@@ -6,7 +6,6 @@ import traceback
 from gftools.gfgithub import GitHubClient
 from gftools.utils import mkdir
 import sys
-from requests.exceptions import HTTPError
 try:
     from diffenator2 import ninja_diff, ninja_proof
 except ModuleNotFoundError:


### PR DESCRIPTION
gftools qa can post fontbakery reports back as issue comments. This functionality isn't possible in the google/fonts ci if the pull request has come from a forked repo e.g https://github.com/google/fonts/pull/7136. Github Actions doesn't allow forked repos to access secrets since the user could just steal them. Instead of raising an error, I've decided to add a warn log message instead with the full traceback.

@simoncozens thoughts on this?