### PR TITLE
Fix unimported array (and unused sys) in drop_hints

### DIFF
--- a/Lib/gftools/scripts/drop_hints.py
+++ b/Lib/gftools/scripts/drop_hints.py
@@ -17,7 +17,7 @@
 #
 """Drop hints from a font."""
 import argparse
-import sys
+import array
 from fontTools.ttLib import TTFont
 
 parser = argparse.ArgumentParser(description=__doc__)


### PR DESCRIPTION
We should probably run a linter...