### PR TITLE
Allow partial font renames

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -317,7 +317,7 @@ def fix_nametable(ttFont):
         log.info("")
 
 
-def rename_font(font, new_name):
+def rename_font(font, new_name, aggressive=True):
     nametable = font["name"]
     current_name = font_familyname(font)
     if not current_name:
@@ -326,7 +326,7 @@ def rename_font(font, new_name):
             "This tool does not work on webfonts."
         )
     log.info("Updating font name records")
-    build_name_table(font, family_name=new_name)
+    build_name_table(font, family_name=new_name, aggressive=aggressive)
 
 
 def fix_filename(ttFont):

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -318,7 +318,6 @@ def fix_nametable(ttFont):
 
 
 def rename_font(font, new_name, aggressive=True):
-    nametable = font["name"]
     current_name = font_familyname(font)
     if not current_name:
         raise Exception(

--- a/Lib/gftools/scripts/rename_font.py
+++ b/Lib/gftools/scripts/rename_font.py
@@ -17,13 +17,18 @@ from gftools.fix import rename_font
 def main(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("font")
-    parser.add_argument("new_name")
-    parser.add_argument("-o", "--out")
+    parser.add_argument("new_name", help="New family name")
+    parser.add_argument("-o", "--out", help="Output path")
+    parser.add_argument("--just-family", action="store_true",
+                        help="Only change family name and names based off it, such as the "
+                             "PostScript name. (By default, the old family name is replaced "
+                             "by the new name in all name table entries, including copyright, "
+                             "description, etc.)")
     args = parser.parse_args(args)
 
     font = TTFont(args.font)
     current_name = font_familyname(font)
-    rename_font(font, args.new_name)
+    rename_font(font, args.new_name, aggressive=not args.just_family)
 
     if args.out:
         out = args.out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
   'setuptools',
   'FontTools[ufo]',
-  'axisregistry>=0.3.1', # API update removed fallback names pre-processing
+  'axisregistry>=0.4.9', # Needed for "aggressive" param to build_name_table
   'absl-py',
   'glyphsLib',
   'gflanguages>=0.4.0',


### PR DESCRIPTION
Adds a `--just-family` option to gftools-rename-font. This depends on axisregistry 0.4.9, which is not yet released...