### PR TITLE
add-font: fix min_pct_ext default val

### DIFF
--- a/Lib/gftools/scripts/add_font.py
+++ b/Lib/gftools/scripts/add_font.py
@@ -70,9 +70,9 @@ axis_registry = AxisRegistry()
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--min_pct", type=int, default=50, help='What percentage of subset codepoints have to be supported'
                      ' for a non-ext subset.')
-parser.add_argument("--min_pct_ext", type=float, default=0.01, help='What percentage of subset codepoints have to be supported'
+parser.add_argument("--min_pct_ext", type=float, default=1, help='What percentage of subset codepoints have to be supported'
                    ' for a -ext subset.')
-parser.add_argument("--min_relaxed_pct", type=int, default=0.5, help='What percentage of subset codepoints have to be supported'
+parser.add_argument("--min_relaxed_pct", type=int, default=50, help='What percentage of subset codepoints have to be supported'
                      f' for a relaxed subset ({", ".join(RELAXED_SUBSETS)}).')
 parser.add_argument("--lang", type=str, help='Path to lang metadata package', default=None)
 parser.add_argument("directory", type=str, help='A directory containing a font family')


### PR DESCRIPTION
@emmamarichal pointed out that `add-font` will add `greek-ext` and `cyrillic-ext` subsets to greek and cyrillic families that don't contain the extended glyphs. In nam-files, we have, https://github.com/googlefonts/nam-files/blob/main/Lib/gfsubsets/__init__.py#L203-L204:

```PYTHON
        if 100.0 * len(overlap) / len(subset_cps) > target_pct:
            results.append((subset, len(overlap), len(subset_cps)))
```

We're multiplying the result by 100 so we're expecting an integer value, not a float which we've currently got. By changing this value to an int, it also matches `--min_pct` int.