### PR TITLE
Better gftools-remap-layout

### DIFF
--- a/Lib/gftools/scripts/remap_layout.py
+++ b/Lib/gftools/scripts/remap_layout.py
@@ -3,10 +3,14 @@
 Rearrange the features in a font file: drop features
 or move lookups into another feature or language system.
 """
-from argparse import ArgumentParser, RawTextHelpFormatter
-from fontTools.ttLib import TTFont
-import re
+from collections import defaultdict
 import logging
+import re
+from argparse import ArgumentParser, RawTextHelpFormatter
+from typing import List, Tuple
+
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables import otTables
 
 logging.basicConfig(level=logging.INFO)
 
@@ -36,101 +40,196 @@ Commands may be:
 """,
 )
 LAYOUT_TABLES = ["GSUB", "GPOS"]
-KEY_RE = r"(?:(\w+)/)?(?:(\w+)/)?(\w+)"
+KEY_RE = r"(?:(\w+|\*)/)?(?:(\w+|\*)/)?(\w+|\*)"
 
 
 def parse_key(key):
+    """Parse a language system and feature tag combination"""
     match = re.match(KEY_RE, key)
     if match is None:
         raise ValueError(f"Invalid feature or lookup: {key}")
     script, lang, feature = match.groups()
-    script = (script or "DFLT").ljust(4)
-    lang = (lang or "dflt").ljust(4)
+    script = (script or "*").ljust(4)
+    lang = (lang or "*").ljust(4)
     return script, lang, feature
 
 
-def find_langsys(table, script, lang):
-    tag = type(table).__name__
-    scripts = [
-        sr.Script for sr in table.ScriptList.ScriptRecord if sr.ScriptTag == script
-    ]
-    if not scripts:
-        logging.info(f"[{tag}] Script not found: {script}")
-        return
-    if lang == "dflt":
-        langsys = scripts[0].DefaultLangSys
-    else:
-        langsys = [
-            ls.LangSys for ls in scripts[0].LangSysRecord if ls.LangSysTag == lang
-        ]
-        if not langsys:
-            logging.info(f"[{tag}] Language system not found: {lang}")
-            return
-        langsys = langsys[0]
-    return langsys
+def build_targets(
+    src_langsyses: List[Tuple[str, str]], dst_langsyses: List[Tuple[str, str]]
+):
+    targets = []
+    # Many to one
+    if len(src_langsyses) > 1 and len(dst_langsyses) == 1:
+        dst = dst_langsyses[0]
+        for src in src_langsyses:
+            targets.append((src, dst))
+    # One to many
+    elif len(src_langsyses) == 1 and len(dst_langsyses) > 1:
+        src = src_langsyses[0]
+        for dst in dst_langsyses:
+            targets.append((src, dst))
+    elif len(src_langsyses) == 1 and len(dst_langsyses) == 1:
+        targets.append((src_langsyses[0], dst_langsyses[0]))
+    # Many to many
+    elif len(src_langsyses) == len(dst_langsyses):
+        if src_langsyses != dst_langsyses:
+            logging.error(
+                "Source and destination language systems do not match: %s vs %s",
+                src_langsyses,
+                dst_langsyses,
+            )
+            return []
+        for src in src_langsyses:
+            targets.append((src, src))
+    return targets
 
-def delete_feature(table, script, lang, feature):
-    tag = type(table).__name__
-    langsys = find_langsys(table, script, lang)
-    featurelist = table.FeatureList.FeatureRecord
-    logging.info(f"[{tag}] Feature indices were: {langsys.FeatureIndex}")
-    langsys.FeatureIndex = [
-        i for i in langsys.FeatureIndex if featurelist[i].FeatureTag != feature
-    ]
-    logging.info(f"[{tag}] Feature indices are now: {langsys.FeatureIndex}")
 
-def delete_lookup(table, script, lang, feature, lookup):
-    tag = type(table).__name__
-    langsys = find_langsys(table, script, lang)
+def freeze_lookuplist(table):
+    """Turns the header of a GSUB/GPOS table into a dictionary, keyed by
+    (script,lang) with the values being dictionaries mapping feature tags
+    to a list of lookup indices."""
+    lookuplist = defaultdict(lambda: defaultdict(list))
     featurelist = table.FeatureList.FeatureRecord
-    done = False
-    for i in langsys.FeatureIndex:
-        if featurelist[i].FeatureTag != feature:
-            continue
-        lookups = featurelist[i].Feature.LookupListIndex
-        if lookup in lookups:
-            lookups.remove(lookup)
-            logging.info(f"[{tag}] Removed lookup {lookup} from {feature}")
-            done = True
-    if not done:
-        logging.info(f"[{tag}] Lookup {lookup} not found in {feature}")    
+
+    def freeze_langsys(script_tag, lang_tag, langsys):
+        for index in langsys.FeatureIndex:
+            feature_tag = featurelist[index].FeatureTag
+            lookups = featurelist[index].Feature.LookupListIndex
+            lookuplist[(script_tag, lang_tag)][feature_tag].extend(lookups)
+
+    for scriptrecord in table.ScriptList.ScriptRecord:
+        script_tag = scriptrecord.ScriptTag
+        freeze_langsys(script_tag, "dflt", scriptrecord.Script.DefaultLangSys)
+        for langsys in scriptrecord.Script.LangSysRecord:
+            freeze_langsys(script_tag, langsys.LangSysTag, langsys.LangSys)
+    return lookuplist
+
+
+def thaw_lookuplist(table, lookuplist, params):
+    """Builds a feature list from a lookup list dictionary. Patterned after
+    fontTools.feaLib.builder.makeTable."""
+    table.FeatureList = otTables.FeatureList()
+    table.FeatureList.FeatureRecord = []
+    combinations = []  # List of (script, lang, feature_tag, indices)
+    for (script, lang), features in lookuplist.items():
+        for feature_tag, indices in features.items():
+            combinations.append((script, lang, feature_tag, tuple(indices)))
+    # Sort combinations by feature tag
+    combinations.sort(key=lambda x: x[2])
+    # Build the list
+    feature_indices = {}
+    new_langsys_feature_indices = defaultdict(list)
+    for script, lang, feature_tag, lookup_indices in combinations:
+        feature_key = (feature_tag, lookup_indices)
+        feature_index = feature_indices.get(feature_key)
+        feature_index = feature_indices.get(feature_key)
+        if feature_index is None:
+            feature_index = len(table.FeatureList.FeatureRecord)
+            frec = otTables.FeatureRecord()
+            frec.FeatureTag = feature_tag
+            frec.Feature = otTables.Feature()
+            frec.Feature.FeatureParams = params.get(feature_tag, None)
+            frec.Feature.LookupListIndex = list(lookup_indices)
+            frec.Feature.LookupCount = len(lookup_indices)
+            table.FeatureList.FeatureRecord.append(frec)
+            feature_indices[feature_key] = feature_index
+        new_langsys_feature_indices[(script, lang)].append(feature_index)
+
+    # Build the script list
+    def fixup_feature_indices(langsys, indices):
+        if indices:
+            langsys.FeatureIndex = indices
+        else:
+            langsys.FeatureIndex = []
+        langsys.FeatureCount = len(langsys.FeatureIndex)
+
+    for scriptrecord in table.ScriptList.ScriptRecord:
+        script_tag = scriptrecord.ScriptTag
+        fixup_feature_indices(
+            scriptrecord.Script.DefaultLangSys,
+            new_langsys_feature_indices.get((script_tag, "dflt")),
+        )
+        for langsys in scriptrecord.Script.LangSysRecord:
+            fixup_feature_indices(
+                langsys.LangSys,
+                new_langsys_feature_indices.get((script_tag, langsys.LangSysTag)),
+            )
+
+
+def find_langsyses(lookuplist, wanted_script, wanted_lang):
+    """Find the language systems in a lookup list"""
+    matching = []
+    for script, lang in lookuplist.keys():
+        if (script == wanted_script or wanted_script == "*   ") and (
+            lang == wanted_lang or wanted_lang == "*   "
+        ):
+            matching.append((script, lang))
+    return matching
+
+
+def de_default(d):
+    """Turn a defaultdict into an ordinary dictionary"""
+    return {k: dict(v) for k, v in d.items()}
+
 
 def remap_lookups(table, src, dst, operation="copy", start=False):
     tag = type(table).__name__
-    src_script, src_lang, src_feature = src
-    dst_script, dst_lang, dst_feature = dst
-    src_langsys = find_langsys(table, src_script, src_lang)
-    dst_langsys = find_langsys(table, dst_script, dst_lang)
-    if not src_langsys:
-        logging.error(f"[{tag}] Languagesystem {src_script}/{src_lang} not found")
+    src_script, src_lang, src_feature_name = src
+    dst_script, dst_lang, dst_feature_name = dst
+    lookuplists = freeze_lookuplist(table)
+    src_langsyses = find_langsyses(lookuplists, src_script, src_lang)
+    dst_langsyses = find_langsyses(lookuplists, dst_script, dst_lang)
+    logging.debug("[%s] Before: %s", tag, de_default(lookuplists))
+    if not src_langsyses:
+        logging.error(f"[%s] Languagesystem {src_script}/{src_lang} not found", tag)
         return
-    if not dst_langsys:
-        logging.error(f"[{tag}] Languagesystem {dst_script}/{dst_lang} not found")
-        return
-    src_features = src_langsys.FeatureIndex
-    dst_features = dst_langsys.FeatureIndex
-    src_lookups = []
-    featurelist = table.FeatureList.FeatureRecord
-    for src_feature_index in src_features:
-        if featurelist[src_feature_index].FeatureTag == src_feature:
-            src_lookups.extend(featurelist[src_feature_index].Feature.LookupListIndex)
-            if operation == "move":
-                featurelist[src_feature_index].Feature.LookupListIndex = []
-    if not src_lookups:
-        logging.info(f"[{tag}] No lookups found")
-        return
-    
-    for dst_feature_index in dst_features:
-        if featurelist[dst_feature_index].FeatureTag == dst_feature:
-            dst_feature = featurelist[dst_feature_index].Feature
-            if start:
-                dst_feature.LookupListIndex = src_lookups + dst_feature.LookupListIndex
-            else:
-                dst_feature.LookupListIndex.extend(src_lookups)
-            logging.info(f"[{tag}] {operation} lookups {src_lookups} to {featurelist[dst_feature_index].FeatureTag}")
-            return
-    logging.error(f"[{tag}] destination feature {dst_script}/{dst_lang}/{dst_feature} not found")
-    
+    for (src_script, src_lang), (dst_script, dst_lang) in build_targets(
+        src_langsyses, dst_langsyses
+    ):
+        key = src_script + "/" + src_lang
+        if src_feature_name not in lookuplists[(src_script, src_lang)]:
+            logging.info("[%s/%s] No source feature found", tag, key)
+            continue
+        lookups = lookuplists[(src_script, src_lang)][src_feature_name]
+        if operation == "move":
+            logging.info(
+                "[%s/%s/%s] Removing lookups %s", tag, key, src_feature_name, lookups
+            )
+
+            lookuplists[(src_script, src_lang)][src_feature_name] = []
+        logging.info(
+            "[%s/%s/%s] Adding lookups %s",
+            tag,
+            dst_script + "/" + dst_lang,
+            dst_feature_name,
+            lookups,
+        )
+        if start:
+            lookuplists[(dst_script, dst_lang)][dst_feature_name] = (
+                lookups + lookuplists[(dst_script, dst_lang)][dst_feature_name]
+            )
+        else:
+            lookuplists[(dst_script, dst_lang)][dst_feature_name].extend(lookups)
+    logging.debug("[%s] After: %s", tag, de_default(lookuplists))
+    thaw_lookuplist(table, lookuplists, {})
+
+
+def delete_feature(table, script, lang, feature):
+    tag = type(table).__name__
+    lookuplists = freeze_lookuplist(table)
+    logging.debug("[%s] Before: %s", tag, de_default(lookuplists))
+    src_langsyses = find_langsyses(lookuplists, script, lang)
+    for src_script, src_lang in src_langsyses:
+        key = src_script + "/" + src_lang
+        if feature not in lookuplists[(src_script, src_lang)]:
+            logging.info("[%s/%s] No source feature found", tag, key)
+            continue
+        lookuplists[(src_script, src_lang)][feature] = []
+        logging.info("[%s/%s] Removed feature %s", tag, key, feature)
+    logging.debug("[%s] After: %s", tag, de_default(lookuplists))
+    thaw_lookuplist(table, lookuplists, {})
+
+
 def main(args=None):
     args = parser.parse_args()
     ttfont = TTFont(args.font)
@@ -144,7 +243,7 @@ def main(args=None):
         src = re.match(KEY_RE, cmd)
         if src is None:
             raise ValueError(f"Could not parse source: {cmd}")
-        cmd = cmd[len(src.group(0)):]
+        cmd = cmd[len(src.group(0)) :]
 
         remap = None
         if re.match(r"^\s*->\s*", cmd):
@@ -164,13 +263,18 @@ def main(args=None):
             raise ValueError(f"Could not parse destination: {cmd}")
         for table in tables:
             remap_lookups(
-                table, parse_key(src[0]), parse_key(dst[0]), operation=remap, start=start
+                table,
+                parse_key(src[0]),
+                parse_key(dst[0]),
+                operation=remap,
+                start=start,
             )
 
     if args.o:
         ttfont.save(args.o)
     else:
         ttfont.save(args.font)
+
 
 if __name__ == "__main__":
     main()

--- a/Lib/gftools/scripts/remap_layout.py
+++ b/Lib/gftools/scripts/remap_layout.py
@@ -180,6 +180,7 @@ def remap_lookups(table, src, dst, operation="copy", start=False):
     src_langsyses = find_langsyses(lookuplists, src_script, src_lang)
     dst_langsyses = find_langsyses(lookuplists, dst_script, dst_lang)
     logging.debug("[%s] Before: %s", tag, de_default(lookuplists))
+    to_remove = set()
     if not src_langsyses:
         logging.error(f"[%s] Languagesystem {src_script}/{src_lang} not found", tag)
         return
@@ -192,11 +193,7 @@ def remap_lookups(table, src, dst, operation="copy", start=False):
             continue
         lookups = lookuplists[(src_script, src_lang)][src_feature_name]
         if operation == "move":
-            logging.info(
-                "[%s/%s/%s] Removing lookups %s", tag, key, src_feature_name, lookups
-            )
-
-            lookuplists[(src_script, src_lang)][src_feature_name] = []
+            to_remove.add((src_script, src_lang, src_feature_name, tuple(lookups)))
         logging.info(
             "[%s/%s/%s] Adding lookups %s",
             tag,
@@ -210,6 +207,13 @@ def remap_lookups(table, src, dst, operation="copy", start=False):
             )
         else:
             lookuplists[(dst_script, dst_lang)][dst_feature_name].extend(lookups)
+    for script, lang, feature, lookups in to_remove:
+        logging.info(
+            "[%s/%s/%s/%s] Removing lookups %s", tag, script, lang, feature, list(lookups)
+        )
+        lookuplists[(script, lang)][feature] = [
+            l for l in lookuplists[(script, lang)][feature] if l not in lookups
+        ]
     logging.debug("[%s] After: %s", tag, de_default(lookuplists))
     thaw_lookuplist(table, lookuplists, {})
 


### PR DESCRIPTION
This is a new version of gftools-remap-layout which handles scripts and languages much better. The previous version edited the FeatureList table directly, which caused problems when FeatureList items were shared between languagesystems - a change to one languagesystem ended up being reflected in unexpected places. This one extracts the lookup list for each languagesystem/feature combination, modifies it, and then puts it back again. It also has some fun matching options, so you can do many-to-many:

```
# Move smcp lookups from each language system into test
$ gftools-remap-layout -o test2.ttf test.ttf "smcp => test"
INFO:root:[GSUB/DFLT/dflt/test] Adding lookups [1]
INFO:root:[GSUB/latn/dflt/test] Adding lookups [1, 2]
INFO:root:[GSUB/latn/CAT /test] Adding lookups [3]
INFO:root:[GSUB/latn/dflt/smcp] Removing lookups [1, 2]
INFO:root:[GSUB/DFLT/dflt/smcp] Removing lookups [1]
INFO:root:[GSUB/latn/CAT /smcp] Removing lookups [3]
```

and many-to-one:

```
# Move all smcp lookups to default languagesystem's test
$ gftools-remap-layout -o test2.ttf test.ttf "smcp => DFLT/dflt/test"
INFO:root:[GSUB/DFLT/dflt/test] Adding lookups [1]
INFO:root:[GSUB/DFLT/dflt/test] Adding lookups [1, 2]
INFO:root:[GSUB/DFLT/dflt/test] Adding lookups [3]
INFO:root:[GSUB/DFLT/dflt/smcp] Removing lookups [1]
INFO:root:[GSUB/latn/CAT /smcp] Removing lookups [3]
INFO:root:[GSUB/latn/dflt/smcp] Removing lookups [1, 2]
```

and one-to-many:

```
# Every smcp languagesystem gets a copy of what's in the default test
$ gftools-remap-layout -o test2.ttf test.ttf "DFLT/dflt/test => smcp"
INFO:root:[GSUB/DFLT/dflt/smcp] Adding lookups [0]
INFO:root:[GSUB/latn/dflt/smcp] Adding lookups [0]
INFO:root:[GSUB/latn/CAT /smcp] Adding lookups [0]
INFO:root:[GSUB/DFLT/dflt/test] Removing lookups [0]
```