### PR TITLE
manage-traffic-jam: parse Familymeta and Designers better

### DIFF
--- a/Lib/gftools/push/items.py
+++ b/Lib/gftools/push/items.py
@@ -200,9 +200,9 @@ class FamilyMeta(Itemer):
             stroke=stroke,
             classifications=[c.lower() for c in meta["classifications"]],
             description=None if article else parse_html(meta["description"]),
-            primary_script=None
-            if meta["primaryScript"] == ""
-            else meta["primaryScript"],
+            primary_script=(
+                None if meta["primaryScript"] == "" else meta["primaryScript"]
+            ),
             article=article,
             minisite_url=None if meta["minisiteUrl"] == "" else meta["minisiteUrl"],
         )

--- a/Lib/gftools/push/servers.py
+++ b/Lib/gftools/push/servers.py
@@ -171,12 +171,20 @@ class GFServers(Itemer):
 
     def __init__(self):
         self.last_checked = datetime.fromordinal(1).isoformat().split("T")[0]
-        self.dev = GFServer(GFServers.DEV, DEV_META_URL, DEV_FAMILY_DOWNLOAD, DEV_VERSIONS_URL)
+        self.dev = GFServer(
+            GFServers.DEV, DEV_META_URL, DEV_FAMILY_DOWNLOAD, DEV_VERSIONS_URL
+        )
         self.sandbox = GFServer(
-            GFServers.SANDBOX, SANDBOX_META_URL, SANDBOX_FAMILY_DOWNLOAD, SANDBOX_VERSIONS_URL
+            GFServers.SANDBOX,
+            SANDBOX_META_URL,
+            SANDBOX_FAMILY_DOWNLOAD,
+            SANDBOX_VERSIONS_URL,
         )
         self.production = GFServer(
-            GFServers.PRODUCTION, PRODUCTION_META_URL, PROD_FAMILY_DOWNLOAD, PRODUCTION_VERSIONS_URL
+            GFServers.PRODUCTION,
+            PRODUCTION_META_URL,
+            PROD_FAMILY_DOWNLOAD,
+            PRODUCTION_VERSIONS_URL,
         )
         self.fp = None
 

--- a/Lib/gftools/push/trafficjam.py
+++ b/Lib/gftools/push/trafficjam.py
@@ -459,7 +459,9 @@ class PushItems(list):
             last_item = data["data"]["organization"]["projectV2"]["items"]["edges"][-1][
                 "cursor"
             ]
-            item_count = data["data"]["organization"]["projectV2"]["items"]["totalCount"]
+            item_count = data["data"]["organization"]["projectV2"]["items"][
+                "totalCount"
+            ]
             while len(board_items) < item_count:
                 data = None
                 while not data:
@@ -469,10 +471,12 @@ class PushItems(list):
                         )
                     except:
                         data = None
-                board_items += data["data"]["organization"]["projectV2"]["items"]["nodes"]
-                last_item = data["data"]["organization"]["projectV2"]["items"]["edges"][-1][
-                    "cursor"
+                board_items += data["data"]["organization"]["projectV2"]["items"][
+                    "nodes"
                 ]
+                last_item = data["data"]["organization"]["projectV2"]["items"]["edges"][
+                    -1
+                ]["cursor"]
                 log.info(f"Getting items up to {last_item}")
             for item in board_items:
                 if item["type"] != "PULL_REQUEST":
@@ -495,13 +499,15 @@ class PushItems(list):
                     f"{pr_url} has {changed_files} changed files. Attempting to fetch them."
                 )
                 files = g.pr_files(pr_number)
-                item["content"]["files"]["nodes"] = [{"path": f["filename"]} for f in files]
+                item["content"]["files"]["nodes"] = [
+                    {"path": f["filename"]} for f in files
+                ]
 
             # save
             if fp:
                 dat = {
                     "updatedAt": data["data"]["organization"]["projectV2"]["updatedAt"],
-                    "board_items": board_items
+                    "board_items": board_items,
                 }
                 with open(fp, "w", encoding="utf-8") as doc:
                     json.dump(dat, doc, indent=4)

--- a/tests/push/test_items.py
+++ b/tests/push/test_items.py
@@ -35,30 +35,26 @@ FONTS_JSON = json.load(open(os.path.join(SERVER_DIR, "fonts.json"), encoding="ut
             TEST_FAMILY_DIR,
             FAMILY_JSON,
             FamilyMeta(
-                name="Maven Pro",
-                designer=["Joe Prince"],
-                license="ofl",
-                category="SANS_SERIF",
+                name='Maven Pro',
+                designer=['Joe Prince'],
+                license='ofl',
+                category='SANS_SERIF',
                 subsets=['latin', 'latin-ext', 'vietnamese'],
-                stroke="SANS_SERIF",
+                stroke='SANS_SERIF',
                 classifications=[],
-                description= \
-"""<html>
- <body>
-  <p>
-   Maven Pro is a sans-serif typeface with unique curvature and flowing rhythm. Its forms make it very distinguishable and legible when in context. It blends styles of many great typefaces and is suitable for any design medium. Maven Pro’s modern design is great for the web and fits in any environment.
-  </p>
-  <p>
-   Updated in January 2019 with a Variable Font "Weight" axis.
-  </p>
-  <p>
-   The Maven Pro project was initiated by Joe Price, a type designer based in the USA. To contribute, see
-   <a href="https://github.com/googlefonts/mavenproFont">
-    github.com/googlefonts/mavenproFont
-   </a>
-  </p>
- </body>
-</html>"""
+                description='Maven Pro is a sans-serif typeface with unique '
+                            'curvature and flowing rhythm. Its forms make it very '
+                            'distinguishable and legible when in context. It blends '
+                            'styles of many great typefaces and is suitable for any '
+                            'design medium. Maven Pro’s modern design is great for '
+                            'the web and fits in any environment. Updated in '
+                            'January 2019 with a Variable Font "Weight" axis. The '
+                            'Maven Pro project was initiated by Joe Price, a type '
+                            'designer based in the USA. To contribute, see '
+                            'github.com/googlefonts/mavenproFont',
+                primary_script=None,
+                article=None,
+                minisite_url=None
             )
         ),
         (

--- a/tests/push/test_servers.py
+++ b/tests/push/test_servers.py
@@ -57,7 +57,7 @@ def server():
         # probably use mocks at some point
         ("update_family", "Allan", Family("Allan", "Version 1.002")),
         ("update_family_designers", "Allan", Designer(name='Anton Koovit', bio=None)),
-        ("update_metadata", "Allan", FamilyMeta(name='Allan', designer=['Anton Koovit'], license='ofl', category='DISPLAY', subsets=['latin', 'latin-ext'], stroke='SERIF', classifications=['display'], description='<html>\n <body>\n  <p>\n   Once Allan was a sign painter in Berlin. Grey paneling work in the subway, bad materials, a city split in two. Now things have changed. His (character) palette of activities have expanded tremendously: he happily spends time traveling, experimenting in the gastronomic field, all kinds of festivities are no longer foreign to him. He comes with alternate features, and hints. A typeface suited for bigger sizes and display use. Truly a type that you like to see!\n  </p>\n </body>\n</html>'))
+        ("update_metadata", "Allan", FamilyMeta(name='Allan', designer=['Anton Koovit'], license='ofl', category='DISPLAY', subsets=['latin', 'latin-ext'], stroke='SERIF', classifications=['display'], description='Once Allan was a sign painter in Berlin. Grey paneling work in the subway, bad materials, a city split in two. Now things have changed. His (character) palette of activities have expanded tremendously: he happily spends time traveling, experimenting in the gastronomic field, all kinds of festivities are no longer foreign to him. He comes with alternate features, and hints. A typeface suited for bigger sizes and display use. Truly a type that you like to see!'))
     ]
 )
 def test_update_server(server, method, family_name, res):


### PR DESCRIPTION
I'm now only parsing the text from html files and replacing all whitespace with spaces. I'm finding it's matching items so much better.

Removing the html tags does require regenerating all the cached data. I'll send this via email to the relevant people.