### PR TITLE
Only use StrictYAML for validation

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -38,6 +38,7 @@ class GFBuilder:
             with open(config, "r") as file:
                 config = file.read()
             chdir(parentpath)
+            self._orig_config = config
             # StrictYAML is great for validating the input, but its strongly
             # typed nature makes it hard to work with. So we use it to
             # validate the input, but just treat it as a regular Python dict.
@@ -47,8 +48,9 @@ class GFBuilder:
                 raise ValueError("Could not validate configuration") from e
             self.config = yaml.safe_load(config)
         else:
+            self._orig_config = yaml.dump(config)
             try:
-                strictyaml.YAML(config, BASE_SCHEMA)
+                strictyaml.YAML(config).revalidate(BASE_SCHEMA)
             except Exception as e:
                 raise ValueError("Could not validate configuration") from e
             self.config = config

--- a/Lib/gftools/builder/recipeproviders/__init__.py
+++ b/Lib/gftools/builder/recipeproviders/__init__.py
@@ -3,7 +3,6 @@ import importlib
 import inspect
 from typing import List
 from gftools.builder.file import File
-from strictyaml import YAML, Bool
 
 filecache = {}
 
@@ -16,7 +15,7 @@ def get_file(path):
 
 @dataclass
 class RecipeProviderBase:
-    config: YAML
+    config: dict
     builder: "gftools.builder.GFBuilder"
 
     def write_recipe(self):
@@ -24,24 +23,8 @@ class RecipeProviderBase:
 
     @property
     def sources(self) -> List[File]:
-        return [get_file(str(p)) for p in self.config["sources"].data]
+        return [get_file(str(p)) for p in self.config["sources"]]
 
-
-def boolify(s):
-    # Could be YAML(true), YAML(false) or bool, or None
-
-    # strictYAML is hilarious:
-    # >>> bool(YAML("false"))
-    # TypeError: Cannot cast 'YAML(false)' to bool.
-    # Use bool(yamlobj.data) or bool(yamlobj.text) instead.
-    # >>> bool(YAML("false").data)
-    # True
-    # >>> bool(YAML("false").text)
-    # True
-    if isinstance(s, YAML):
-        s.revalidate(Bool())
-        return bool(s)
-    return s
 
 
 def get_provider(provider: str):

--- a/Lib/gftools/builder/recipeproviders/noto.py
+++ b/Lib/gftools/builder/recipeproviders/noto.py
@@ -2,13 +2,14 @@ import copy
 import os
 import sys
 from collections import defaultdict
-from strictyaml import Map, Seq, Str, Optional, HexInt, Bool, YAML, YAMLValidationError
 
-from gftools.builder.recipeproviders.googlefonts import (
-    DEFAULTS,
-    GFBuilder,
-    GOOGLEFONTS_SCHEMA,
-)
+import yaml
+from strictyaml import (Bool, HexInt, Map, Optional, Seq, Str,
+                        YAMLValidationError, load)
+
+from gftools.builder.recipeproviders.googlefonts import (DEFAULTS,
+                                                         GOOGLEFONTS_SCHEMA,
+                                                         GFBuilder)
 from gftools.util.styles import STYLE_NAMES
 
 name = "Noto builder"
@@ -31,13 +32,10 @@ schema = Map(_newschema)
 
 
 class NotoBuilder(GFBuilder):
-    def write_recipe(self):
-        # Revalidate using our schema
-        try:
-            YAML(self.config, schema)
-        except YAMLValidationError as e:
-            raise ValueError(f"Invalid config: {e}")
+    schema = schema
 
+    def write_recipe(self):
+        self.revalidate()
 
         self.config = {**DEFAULTS, **self.config}
         # Convert any glyphs sources to DS

--- a/data/test/builder/recipeprovider_noto/TestFamily.glyphs
+++ b/data/test/builder/recipeprovider_noto/TestFamily.glyphs
@@ -1,0 +1,174 @@
+{
+.appVersion = "3108";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Axis Mappings";
+value = {
+};
+}
+);
+date = "2023-03-23 13:10:20 +0000";
+familyName = "Test Family";
+fontMaster = (
+{
+axesValues = (
+100
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+},
+{
+}
+);
+name = Thin;
+},
+{
+axesValues = (
+900
+);
+id = "9DF3CCAA-57F5-4938-AE55-ABF45B80491E";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Black;
+}
+);
+glyphs = (
+{
+glyphname = A;
+lastChange = "2023-03-23 13:12:50 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(618,0,l),
+(618,667,l),
+(50,667,l)
+);
+}
+);
+width = 668;
+},
+{
+layerId = "9DF3CCAA-57F5-4938-AE55-ABF45B80491E";
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,0,l),
+(618,0,l),
+(618,667,l),
+(50,667,l)
+);
+}
+);
+width = 668;
+}
+);
+unicode = 65;
+},
+{
+glyphname = space;
+lastChange = "2023-03-23 13:10:46 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "9DF3CCAA-57F5-4938-AE55-ABF45B80491E";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+instances = (
+{
+axesValues = (
+100
+);
+instanceInterpolations = {
+m01 = 1;
+};
+name = Thin;
+weightClass = 100;
+},
+{
+axesValues = (
+400
+);
+instanceInterpolations = {
+"9DF3CCAA-57F5-4938-AE55-ABF45B80491E" = 0.375;
+m01 = 0.625;
+};
+name = Regular;
+},
+{
+axesValues = (
+900
+);
+instanceInterpolations = {
+"9DF3CCAA-57F5-4938-AE55-ABF45B80491E" = 1;
+};
+name = Black;
+weightClass = 900;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/data/test/builder/recipeprovider_noto/config.yaml
+++ b/data/test/builder/recipeprovider_noto/config.yaml
@@ -1,0 +1,14 @@
+sources:
+  - TestFamily.glyphs
+familyName: Test Family
+autohintTTF: false
+autohintOTF: false
+recipeProvider: noto
+googleFonts: true
+includeSubsets:
+- from: Noto Sans Devanagari
+  layoutHandling: closure
+  force: true
+  ranges:
+    - start: 0x900
+      end: 0x97F

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -4,6 +4,8 @@ import shutil
 import os
 import subprocess
 
+from gftools.builder import GFBuilder
+
 
 CWD = os.path.dirname(__file__)
 TEST_DIR = os.path.join(CWD, "..", "data", "test", "builder")
@@ -43,6 +45,14 @@ TEST_DIR = os.path.join(CWD, "..", "data", "test", "builder")
                 os.path.join("webfonts", "TestFamily-Thin.woff2"),
             ],
         ),
+        # Testing a custom recipe provider
+        (
+            os.path.join(TEST_DIR, "recipeprovider_noto"),
+            [
+                os.path.join("TestFamily", "unhinted", "slim-variable-ttf", "TestFamily[wght].ttf"),
+                os.path.join("TestFamily", "googlefonts", "variable", "TestFamily[wght].ttf")
+            ],
+        )
     ],
 )
 def test_builder(fp, font_paths):
@@ -55,3 +65,10 @@ def test_builder(fp, font_paths):
         for font_path in font_paths:
             font_path = os.path.join(font_dir, font_path)
             assert os.path.exists(font_path), f"{font_path} is missing"
+
+def test_bad_configs():
+    config = {
+        "Sources": ["foo.glyphs"]
+    }
+    with pytest.raises(ValueError):
+        GFBuilder(config)


### PR DESCRIPTION
Its strongly typed YAML objects are a pain in the neck, and are constantly tripping us up with having to add `.data` everywhere. We don't want that, we only want to use it to check the schema and then move on with handling Python dicts as normal.