### PR TITLE
Enforce code kwalitee

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,11 @@ jobs:
       - name: Install packages
         run: |
           pip install '.[qa]'
-          pip install mypy pytest
+          pip install mypy pytest black pylint
+      - name: Lint checks
+        run: |
+          black . --check --diff --color Lib tests
+          pylint Lib
       - name: Run Tests
         env:
           DEV_FAMILY_DOWNLOAD: ${{ secrets.DEV_FAMILY_DOWNLOAD }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,3 +165,16 @@ where = ["Lib"]
 
 [tool.setuptools_scm]
 write_to = "Lib/gftools/_version.py"
+
+[tool.pylint.'MESSAGES CONTROL']
+max-line-length = 120
+disable = [
+  "R",  # Disable all recommendations for now
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+  "duplicate-code",
+  "protected-access",
+  "attribute-defined-outside-init",
+  "invalid-name",  # For now, we would like to fix these
+]


### PR DESCRIPTION
("Kwalitee" is an old Perl joke -it's Michael Schwern's name for code quality that is automatically measurable; it's not actually a reflection of the *quality* of the code at all, but it's better than nothing.)

This adds black and pylint checks with a reasonable subset of pylint errors that we really should fix to get us going.