### PR TITLE
Parse github urls better

### DIFF
--- a/Lib/gftools/gfgithub.py
+++ b/Lib/gftools/gfgithub.py
@@ -4,7 +4,7 @@ import requests
 import typing
 import urllib
 import time
-
+from gftools.utils import github_user_repo
 
 GITHUB_GRAPHQL_API = "https://api.github.com/graphql"
 GITHUB_V3_REST_API = "https://api.github.com"
@@ -17,6 +17,11 @@ class GitHubClient:
         self.gh_token = os.environ["GH_TOKEN"]
         self.repo_owner = repo_owner
         self.repo_name = repo_name
+
+    @classmethod
+    def from_url(cls, url):
+        user, repo = github_user_repo(url)
+        return cls(user, repo)
 
     def _post(self, url, payload: typing.Dict):
         headers = {"Authorization": f"bearer {self.gh_token}"}
@@ -85,6 +90,11 @@ class GitHubClient:
     def open_prs(self, pr_head: str, pr_base_branch: str) -> typing.List:
         return self._get(
             self.rest_url("pulls", state="open", head=pr_head, base=pr_base_branch)
+        )
+
+    def get_commit(self, ref: str):
+        return self._get(
+            self.rest_url(f"commits/{ref}")
         )
 
     def create_pr(self, title: str, body: str, head: str, base: str, draft: bool = False):

--- a/Lib/gftools/gfgithub.py
+++ b/Lib/gftools/gfgithub.py
@@ -93,11 +93,11 @@ class GitHubClient:
         )
 
     def get_commit(self, ref: str):
-        return self._get(
-            self.rest_url(f"commits/{ref}")
-        )
+        return self._get(self.rest_url(f"commits/{ref}"))
 
-    def create_pr(self, title: str, body: str, head: str, base: str, draft: bool = False):
+    def create_pr(
+        self, title: str, body: str, head: str, base: str, draft: bool = False
+    ):
         return self._post(
             self.rest_url("pulls"),
             {
@@ -106,7 +106,7 @@ class GitHubClient:
                 "head": head,
                 "base": base,
                 "maintainer_can_modify": True,
-                "draft": draft
+                "draft": draft,
             },
         )
 

--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -173,12 +173,6 @@ def load_metadata(fp: "Path | str"):
                     item.source_file = src
                     item.dest_file = dst
                     metadata.source.files.append(item)
-
-    metadata.source.repository_url = re.sub(
-        r"\.git$", "", metadata.source.repository_url
-    )
-    if metadata.source.repository_url.endswith("/"):
-        metadata.source.repository_url = metadata.source.repository_url[:-1]
     return metadata
 
 

--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -219,8 +219,7 @@ def download_assets(
     metadata: fonts_pb2.FamilyProto, out: Path, latest_release: bool = False
 ) -> List[str]:
     """Download assets listed in the metadata's source field"""
-    _, _, _, owner, repo = metadata.source.repository_url.split("/")
-    upstream = GitHubClient(owner, repo)
+    upstream = GitHubClient.from_url(metadata.source.repository_url)
     res = []
     # Getting files from an archive always takes precedence over a
     # repo dir

--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -184,11 +184,9 @@ def load_metadata(fp: "Path | str"):
 
 def save_metadata(fp: Path, metadata: fonts_pb2.FamilyProto):
     """Save METADATA.pb file and delete old upstream.yaml file."""
-    _, _, _, user, repo = metadata.source.repository_url.split("/")
-    github = GitHubClient(user, repo)
-    url = github.rest_url(f"commits/{metadata.source.branch}")
-    resp = github._get(url)
-    git_commit = resp["sha"]
+    github = GitHubClient.from_url(metadata.source.repository_url)
+    commit = github.get_commit(metadata.source.branch)
+    git_commit = commit["sha"]
     metadata.source.commit = git_commit
     language_comments = fonts.LanguageComments(LoadLanguages())
     fonts.WriteProto(metadata, fp, comments=language_comments)

--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -177,6 +177,8 @@ def load_metadata(fp: "Path | str"):
     metadata.source.repository_url = re.sub(
         r"\.git$", "", metadata.source.repository_url
     )
+    if metadata.source.repository_url.endswith("/"):
+        metadata.source.repository_url = metadata.source.repository_url[:-1]
     return metadata
 
 

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -646,7 +646,7 @@ def shell_quote(s: Union[str, Path]) -> str:
 
 
 def github_user_repo(github_url):
-    pattern = r'https?://github\.com/(?P<user>[^/]+)/(?P<repo>[^/]+)'
+    pattern = r'https?://github\.com/(?P<user>[^/]+)/(?P<repo>[^/^.]+)'
     match = re.search(pattern, github_url)
     if not match:
         raise ValueError(

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -643,3 +643,13 @@ def shell_quote(s: Union[str, Path]) -> str:
         return subprocess.list2cmdline([s])
     else:
         return shlex.quote(s)
+
+
+def github_user_repo(github_url):
+    pattern = r'https?://github\.com/(?P<user>[^/]+)/(?P<repo>[^/]+)'
+    match = re.search(pattern, github_url)
+    if not match:
+        raise ValueError(
+            f"Cannot extract github user and repo name from url '{github_url}'."
+        )
+    return match.group('user'), match.group('repo')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,6 +64,7 @@ He was referred to H.R. Giger, who headed the H.R. department at the time, then 
         ("https://github.com/SorkinType/SASchoolHandAustralia", ("SorkinType", "SASchoolHandAustralia")),
         ("https://github.com/SorkinType/SASchoolHandAustralia/", ("SorkinType", "SASchoolHandAustralia")),
         ("https://github.com/googlefonts/MavenPro//", ("googlefonts", "MavenPro")),
+        ("https://github.com/googlefonts/MavenPro.git", ("googlefonts", "MavenPro")),
     ]
 )
 def test_github_user_repo(url, want):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,3 +56,16 @@ He was referred to H.R. Giger, who headed the H.R. department at the time, then 
 </p>
 """
     assert format_html(input) == output
+
+
+@pytest.mark.parametrize(
+    """url,want""",
+    [
+        ("https://github.com/SorkinType/SASchoolHandAustralia", ("SorkinType", "SASchoolHandAustralia")),
+        ("https://github.com/SorkinType/SASchoolHandAustralia/", ("SorkinType", "SASchoolHandAustralia")),
+        ("https://github.com/googlefonts/MavenPro//", ("googlefonts", "MavenPro")),
+    ]
+)
+def test_github_user_repo(url, want):
+    from gftools.utils import github_user_repo
+    assert github_user_repo(url) == want


### PR DESCRIPTION
@simoncozens I've made a better github url parser and added some tests. I've also added a nifty classmethod so you can instantiate `gfgithub` using just a github url.

Fixes #889 