### PR TITLE
Smallcap family builder

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -346,9 +346,30 @@ def main(args=None):
         help="Just generate and output recipe from recipe builder",
         action="store_true",
     )
-    parser.add_argument("config", help="Path to config file")
+    parser.add_argument("config", help="Path to config file or source file", nargs="+")
     args = parser.parse_args(args)
-    pd = GFBuilder(args.config)
+    yaml_files = []
+    source_files = []
+    for config in args.config:
+        if config.endswith(".yaml") or config.endswith(".yml"):
+            yaml_files.append(config)
+        else:
+            source_files.append(config)
+    if yaml_files and source_files:
+        raise ValueError(
+            "Cannot mix YAML config files and font source files on command line"
+        )
+    if source_files:
+        config = {
+            "sources": source_files,
+            "outputDir": "fonts/",
+        }
+    else:
+        if len(args.config) > 1:
+            raise ValueError("Only one config file can be given for now")
+        config = args.config[0]
+
+    pd = GFBuilder(config)
     if args.generate:
         config = pd.config
         config["recipe"] = pd.recipe

--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -79,10 +79,10 @@ class File:
     def family_name(self):
         # Figure out target name
         if self.is_glyphs:
-            name = self.gsfont.familyName.replace(" ", "")
+            name = self.gsfont.familyName
         elif self.designspace.sources[0].familyName:
             return self.designspace.sources[0].familyName
         else:
             self.designspace.loadSourceFonts(open_ufo)
-            self.designspace.sources[0].font.info.familyName
+            return self.designspace.sources[0].font.info.familyName
         return name

--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -80,6 +80,9 @@ class File:
         # Figure out target name
         if self.is_glyphs:
             name = self.gsfont.familyName
+        elif self.is_ufo:
+            ufo = open_ufo(self.path)
+            name = ufo.info.familyName
         elif self.designspace.sources[0].familyName:
             return self.designspace.sources[0].familyName
         else:

--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -104,8 +104,14 @@ class GFBuilder(RecipeProviderBase):
         directory = self.config["vfDir"]
         if extension == "woff2":
             directory = self.config["woffDir"]
+        if suffix:
+            # Put any suffix before the -Italic element
+            if "-Italic" in sourcebase:
+                sourcebase = sourcebase.replace("-Italic", suffix + "-Italic")
+            else:
+                sourcebase += suffix
 
-        return os.path.join(directory, f"{sourcebase}{suffix}[{axis_tags}].{extension}")
+        return os.path.join(directory, f"{sourcebase}[{axis_tags}].{extension}")
 
     def _static_filename(self, instance, suffix="", extension="ttf"):
         """Determine the file name for a static font."""
@@ -120,7 +126,7 @@ class GFBuilder(RecipeProviderBase):
             # This is horrible; insert the suffix at the end of the family
             # name, before the style name.
             familyname, path = instancebase.rsplit("-", 1)
-            instancebase = familyname + suffix + path
+            instancebase = familyname + suffix + "-" + path
 
         return os.path.join(outdir, f"{instancebase}.{extension}")
 

--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -90,7 +90,41 @@ class GFBuilder(RecipeProviderBase):
         self.build_all_statics()
         return self.recipe
 
-    def fontmake_args(self, variable=False):
+    def _vf_filename(self, source, suffix="", extension="ttf"):
+        """Determine the file name for a variable font."""
+        sourcebase = os.path.splitext(source.basename)[0]
+        if source.is_glyphs:
+            tags = [ax.axisTag for ax in source.gsfont.axes]
+        elif source.is_designspace:
+            tags = [ax.tag for ax in source.designspace.axes]
+        else:
+            raise ValueError("Unknown source type")
+
+        axis_tags = ",".join(sorted(tags))
+        directory = self.config["vfDir"]
+        if extension == "woff2":
+            directory = self.config["woffDir"]
+
+        return os.path.join(directory, f"{sourcebase}{suffix}[{axis_tags}].{extension}")
+
+    def _static_filename(self, instance, suffix="", extension="ttf"):
+        """Determine the file name for a static font."""
+        if extension == "ttf":
+            outdir = self.config["ttDir"]
+        elif extension == "otf":
+            outdir = self.config["otDir"]
+        elif extension == "woff2":
+            outdir = self.config["woffDir"]
+        instancebase = os.path.splitext(os.path.basename(instance.filename))[0]
+        if suffix:
+            # This is horrible; insert the suffix at the end of the family
+            # name, before the style name.
+            familyname, path = instancebase.rsplit("-", 1)
+            instancebase = familyname + suffix + path
+
+        return os.path.join(outdir, f"{instancebase}.{extension}")
+
+    def fontmake_args(self, source, variable=False):
         args = "--filter ... "
         if self.config.get("flattenComponents", True):
             args += " --filter FlattenComponentsFilter"
@@ -108,11 +142,17 @@ class GFBuilder(RecipeProviderBase):
         if self.config.get("extraFontmakeArgs") is not None:
             args += " " + str(self.config["extraFontmakeArgs"])
         if variable:
+            if self.config.get("checkCompatibility") == False:
+                args += " --no-check-compatibility"
             if self.config.get("extraVariableFontmakeArgs") is not None:
                 args += " " + str(self.config["extraVariableFontmakeArgs"])
         else:
             if self.config.get("extraStaticFontmakeArgs") is not None:
                 args += " " + str(self.config["extraStaticFontmakeArgs"])
+
+        if source.is_glyphs:
+            for gd in self.config.get("glyphData", []):
+                args += " --glyph-data " + gd
         return args
 
     def fix_args(self):
@@ -161,51 +201,31 @@ class GFBuilder(RecipeProviderBase):
                 build_stat_step["needs"] = other_variables
             self.recipe[last_target].append(build_stat_step)
 
-    def build_a_variable(self, source):
-        # Figure out target name
-        sourcebase = os.path.splitext(source.basename)[0]
-        vf_args = ""
-
-        if self.config.get("checkCompatibility") == False:
-            vf_args += "--no-check-compatibility "
-
-        if source.is_glyphs:
-            tags = [ax.axisTag for ax in source.gsfont.axes]
-        elif source.is_designspace:
-            tags = [ax.tag for ax in source.designspace.axes]
-        else:
-            raise ValueError("Unknown source type")
-
-        axis_tags = ",".join(sorted(tags))
-
-        if source.is_glyphs:
-            for gd in self.config.get("glyphData", []):
-                vf_args += " --glyph-data " + gd
-
-        target = os.path.join(self.config["vfDir"], f"{sourcebase}[{axis_tags}].ttf")
-        steps = [
-            {"source": source.path},
-            {
-                "operation": "buildVariable",
-                "args": vf_args + self.fontmake_args(variable=True),
-            },
-        ]
+    def _vtt_steps(self, target):
         if os.path.basename(target) in self.config.get("vttSources", {}):
-            steps.append(
+            return [
                 {
                     "operation": "buildVTT",
                     "vttfile": self.config["vttSources"][os.path.basename(target)],
                 }
-            )
-        steps.append(
-            {"operation": "fix", "args": self.fix_args()},
+            ]
+        return []
+
+    def build_a_variable(self, source):
+        target = self._vf_filename(source)
+        steps = (
+            [
+                {"source": source.path},
+                {
+                    "operation": "buildVariable",
+                    "args": self.fontmake_args(source, variable=True),
+                },
+            ]
+            + self._vtt_steps(target)
+            + self._fix_step()
         )
         self.recipe[target] = steps
-        if self.config["buildWebfont"]:
-            target = os.path.join(
-                self.config["woffDir"], f"{sourcebase}[{axis_tags}].woff2"
-            )
-            self.recipe[target] = copy.deepcopy(steps) + [{"operation": "compress"}]
+        self.build_a_webfont(target, self._vf_filename(source, extension="woff2"))
 
     def build_all_statics(self):
         if not self.config.get("buildStatic", True):
@@ -218,17 +238,7 @@ class GFBuilder(RecipeProviderBase):
                     self.build_a_static(source, instance, output="otf")
 
     def build_a_static(self, source, instance, output):
-        if output == "ttf":
-            outdir = self.config["ttDir"]
-        else:
-            outdir = self.config["otDir"]
-        instancebase = os.path.splitext(os.path.basename(instance.filename))[0]
-        target = os.path.join(outdir, f"{instancebase}.{output}")
-
-        static_args = ""
-        if source.is_glyphs:
-            for gd in self.config.get("glyphData", []):
-                static_args += " --glyph-data " + gd
+        target = self._static_filename(instance, extension=output)
 
         steps = [
             {"source": source.path},
@@ -237,29 +247,38 @@ class GFBuilder(RecipeProviderBase):
             steps.append(
                 {"operation": "instantiateUfo", "instance_name": instance.name}
             )
-        steps.append(
-            {
-                "operation": "buildTTF" if output == "ttf" else "buildOTF",
-                "args": self.fontmake_args(variable=False) + static_args,
-            }
+        steps += (
+            [
+                {
+                    "operation": "buildTTF" if output == "ttf" else "buildOTF",
+                    "args": self.fontmake_args(source, variable=False),
+                }
+            ]
+            + self._autohint_steps(target)
+            + self._vtt_steps(target)
+            + self._fix_step()
         )
-        if bool(self.config.get("autohintTTF")) and output == "ttf":
+        self.recipe[target] = steps
+        self.build_a_webfont(target, self._static_filename(instance, extension="woff2"))
+
+    def build_a_webfont(self, original_target, wf_filename):
+        if not self.config["buildWebfont"]:
+            return
+        if not original_target.endswith(".ttf"):
+            return
+        self.recipe[wf_filename] = copy.deepcopy(self.recipe[original_target]) + [
+            {"operation": "compress"}
+        ]
+
+    def _autohint_steps(self, target):
+        if bool(self.config.get("autohintTTF")) and target.endswith("ttf"):
             args = "--fail-ok "
             if self.config.get("ttfaUseScript"):
                 args += " --auto-script"
-            steps.append({"operation": "autohint", "args": args})
-        if bool(self.config.get("autohintOTF")) and output == "otf":
-            steps.append({"operation": "autohintOTF"})
-        if os.path.basename(target) in self.config.get("vttSources", {}):
-            steps.append(
-                {
-                    "operation": "buildVTT",
-                    "vttfile": self.config["vttSources"][os.path.basename(target)],
-                }
-            )
-        steps.append({"operation": "fix", "args": self.fix_args()})
-        self.recipe[target] = steps
+            return [{"operation": "autohint", "args": args}]
+        if bool(self.config.get("autohintOTF")) and target.endswith("otf"):
+            return [{"operation": "autohintOTF"}]
+        return []
 
-        if self.config["buildWebfont"] and output == "ttf":
-            target = os.path.join(self.config["woffDir"], f"{instancebase}.woff2")
-            self.recipe[target] = copy.deepcopy(steps) + [{"operation": "compress"}]
+    def _fix_step(self):
+        return [{"operation": "fix", "args": self.fix_args()}]

--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -7,8 +7,11 @@ import yaml
 from strictyaml import load, YAMLValidationError
 
 from gftools.builder.recipeproviders import RecipeProviderBase
-from gftools.builder.schema import (GOOGLEFONTS_SCHEMA, stat_schema,
-                                    stat_schema_by_font_name)
+from gftools.builder.schema import (
+    GOOGLEFONTS_SCHEMA,
+    stat_schema,
+    stat_schema_by_font_name,
+)
 
 logger = logging.getLogger("GFBuilder")
 
@@ -65,7 +68,9 @@ class GFBuilder(RecipeProviderBase):
         self.revalidate()
         self.config = {**DEFAULTS, **self.config}
         for field in ["vfDir", "ttDir", "otDir", "woffDir"]:
-            self.config[field] = self.config[field].replace("$outputDir", self.config["outputDir"])
+            self.config[field] = self.config[field].replace(
+                "$outputDir", self.config["outputDir"]
+            )
         self.config["buildWebfont"] = self.config.get(
             "buildWebfont", self.config.get("buildStatic", True)
         )

--- a/Lib/gftools/builder/recipeproviders/noto.py
+++ b/Lib/gftools/builder/recipeproviders/noto.py
@@ -85,7 +85,10 @@ class NotoBuilder(GFBuilder):
         )
         self.recipe[target] = [
             {"source": source.path},
-            {"operation": "buildVariable", "args": self.fontmake_args(variable=True)},
+            {
+                "operation": "buildVariable",
+                "args": self.fontmake_args(source, variable=True),
+            },
             {"operation": "fix"},
         ]
 
@@ -107,7 +110,7 @@ class NotoBuilder(GFBuilder):
                 {"source": source.path},
                 {
                     "operation": "buildVariable",
-                    "args": self.fontmake_args(variable=True),
+                    "args": self.fontmake_args(source, variable=True),
                 },
                 {"operation": "fix"},
                 {
@@ -140,7 +143,7 @@ class NotoBuilder(GFBuilder):
                 },
                 {
                     "operation": "buildVariable",
-                    "args": self.fontmake_args(variable=True),
+                    "args": self.fontmake_args(source, variable=True),
                 },
             ]
             self.slim(target, tags)
@@ -163,7 +166,7 @@ class NotoBuilder(GFBuilder):
                 },
                 {
                     "operation": "buildVariable",
-                    "args": self.fontmake_args(variable=True),
+                    "args": self.fontmake_args(source, variable=True),
                 },
                 {"operation": "fix", "args": "--include-source-fixes"},
             ]
@@ -181,7 +184,7 @@ class NotoBuilder(GFBuilder):
                 {"source": source.path},
                 {
                     "operation": "buildVariable",
-                    "args": self.fontmake_args(variable=True),
+                    "args": self.fontmake_args(source, variable=True),
                 },
                 {"operation": "fix", "args": "--include-source-fixes"},
             ]
@@ -215,7 +218,7 @@ class NotoBuilder(GFBuilder):
             },
             {
                 "operation": "buildTTF" if output == "ttf" else "buildOTF",
-                "args": self.fontmake_args(variable=False),
+                "args": self.fontmake_args(source, variable=False),
             },
         ]
 
@@ -274,7 +277,7 @@ class NotoBuilder(GFBuilder):
                 },
                 {
                     "operation": "buildTTF" if output == "ttf" else "buildOTF",
-                    "args": self.fontmake_args(variable=False),
+                    "args": self.fontmake_args(source, variable=False),
                 },
             ]
             if output == "ttf":
@@ -318,7 +321,10 @@ class NotoBuilder(GFBuilder):
                     "operation": "instantiateUfo",
                     "instance_name": instance.name,
                 },
-                {"operation": "buildTTF", "args": self.fontmake_args(variable=False)},
+                {
+                    "operation": "buildTTF",
+                    "args": self.fontmake_args(source, variable=False),
+                },
                 {
                     "operation": "autohint",
                     "args": "--fail-ok --auto-script --discount-latin",


### PR DESCRIPTION
This refactors the googlefonts recipe provider to make it more maintainable and share common code; and then it adds a few methods on the end which work out whether or not to generate small cap variants and then builds them.

It's currently experimental, I want to try it on most of the catalogue before merging.