### PR TITLE
[packager] Improve error message when branch could not be created

### DIFF
--- a/Lib/gftools/packager.py
+++ b/Lib/gftools/packager.py
@@ -343,7 +343,7 @@ def _create_git_branch(
         repo_url = f"git@github.com:{head_repo}/fonts.git"
     else:
         repo_url = f"https://github.com/{head_repo}/fonts.git"
-    subprocess.run(
+    result = subprocess.run(
         [
             "git",
             "-C",
@@ -353,10 +353,18 @@ def _create_git_branch(
             f"main:{branch_name}",
             "--force",
         ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    return repo.branches.get(branch_name)
+    branch = repo.branches.get(branch_name)
+    if not branch:
+        raise ValueError(
+            "Could not create a git branch "
+            + branch_name
+            + ": \n"
+            + result.stderr.decode("utf-8")
+        )
+    return branch
 
 
 def commit_family(


### PR DESCRIPTION
If the git branch command failed for any reason, you would get the error `'NoneType' object has no attribute 'name'` when the code tried to use the (None) `branch` variable. This gives you the output from git.