### PR TITLE
Keep glyph names when subsetting

### DIFF
--- a/Lib/gftools/builder/operations/hbsubset.py
+++ b/Lib/gftools/builder/operations/hbsubset.py
@@ -3,4 +3,4 @@ from gftools.builder.operations import OperationBase
 
 class HbSubset(OperationBase):
     description = "Run hb-subset to slim down a font"
-    rule = "hb-subset --output-file=$in.subset --notdef-outline --unicodes=* --name-IDs=* --layout-features=* $in && mv $in.subset $out"
+    rule = "hb-subset --output-file=$in.subset --notdef-outline --unicodes=* --name-IDs=* --layout-features=* --glyph-names $args $in && mv $in.subset $out"


### PR DESCRIPTION
See https://github.com/TypeTogether/Playwrite/issues/38. Running hbsubset causes the post table to be upgraded to version 3.0, but we warn against using that.