### PR TITLE
[builder] Choose subsetter

### DIFF
--- a/Lib/gftools/builder/operations/hbsubset.py
+++ b/Lib/gftools/builder/operations/hbsubset.py
@@ -1,6 +1,36 @@
+import logging
+import os
+import shutil
+
 from gftools.builder.operations import OperationBase
+
+log = logging.getLogger(__name__)
+SUBSETTER_ENV_KEY = "GFTOOLS_SUBSETTER"
 
 
 class HbSubset(OperationBase):
-    description = "Run hb-subset to slim down a font"
-    rule = "hb-subset --output-file=$in.subset --notdef-outline --unicodes=* --name-IDs=* --layout-features=* --glyph-names $args $in && mv $in.subset $out"
+    description = "Run a subsetter to slim down a font"
+    rule = "$subsetter --output-file=$in.subset --notdef-outline --unicodes=* --name-IDs=* --layout-features=* --glyph-names $args $in && mv $in.subset $out"
+
+    @property
+    def subsetter(self):
+        subsetter = self.original.get(
+            "subsetter", os.environ.get(SUBSETTER_ENV_KEY, "auto")
+        )
+        if subsetter == "python":
+            return "pyftsubset"
+        elif subsetter == "harfbuzz":
+            return "hb-subset"
+        else:  # hb-subset if installed, pyftsubset otherwise
+            if shutil.which("hb-subset"):
+                log.warning("Using hb-subset for subsetting")
+                return "hb-subset"
+            else:
+                log.info("Using pyftsubset for subsetting")
+                return "pyftsubset"
+
+    @property
+    def variables(self):
+        super_vars = super().variables
+        super_vars["subsetter"] = self.subsetter
+        return super_vars


### PR DESCRIPTION
This allows the user to choose between hb-subset and pyftsubset for subsetting. (The operation name now feels a bit stupid but I feel like it's probably too late to change that now.)

To determine the subsetter to use, it looks for "subsetter" in the operation step, and if it's not there, looks in the `GFTOOLS_SUBSETTER` environment variable. If that's "python" you get `pyftsubset`; if it's "harfbuzz" you get `hb-subset`; if it's "auto" (or not provided), you get `hb-subset` if it's installed and `pyftsubset` otherwise.