### PR TITLE
[builder] Meaningfully named temporary files

### DIFF
--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -141,7 +141,7 @@ class GFBuilder(RecipeProviderBase):
             args += " --filter DecomposeTransformedComponentsFilter"
 
         if self.config.get("logLevel") != "WARN":
-            args += " --verbose " + self.config["logLevel"].value
+            args += " --verbose " + self.config["logLevel"]
         if self.config.get("reverseOutlineDirection"):
             args += " --keep-direction"
         if self.config.get("removeOutlineOverlaps") is False:


### PR DESCRIPTION
The builder uses a *lot* of temporary files, and when debugging a problem, it's a pain to trace through the `build.ninja` file to determine how `/tmp/4p0m9zvx2l739` was produced from `/tmp/tdpflm38kv4`. With this PR, when the builder config `logLevel` is `DEBUG`, files are named `builder-<target>-<source>-<steps>`. e.g. when you see:

```
/tmp/builder-PlaywriteAUNSW[wght].ttf-Playwrite_MM.glyphspackage-buildVariable-fix-buildStat-subspace
```

you know you are building `PlaywriteAUNSW[wght].ttf` and so far you have started with `Playwrite_MM.glyphspackage` and run the steps `buildVariable`, `fix`, `buildStat` and `subspace`.