### PR TITLE
[gftools-fix] Restructuring

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -460,6 +460,20 @@ def fix_italic_angle(ttFont) -> FixResult:
     return False, []
 
 
+def fix_hhea_caret_slope_run(ttFont: TTFont) -> FixResult:
+    if ttFont["post"].italicAngle == 0:
+        return False, []
+
+    expected_rise = ttFont["head"].unitsPerEm
+    expected_run = round(
+        math.tan(math.radians(-1 * ttFont["post"].italicAngle))
+        * ttFont["head"].unitsPerEm
+    )
+    return _combine_results(
+        _expect(ttFont, "hhea", "caretSlopeRise", expected_rise),
+        _expect(ttFont, "hhea", "caretSlopeRun", expected_run),
+    )
+
 
 def fix_ascii_fontmetadata(font: TTFont) -> FixResult:
     """Fixes TTF 'name' table strings to be ascii only"""

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -3,6 +3,7 @@ Functions to fix fonts so they conform to the Google Fonts
 specification:
 https://github.com/googlefonts/gf-docs/tree/main/Spec
 """
+
 from fontTools.misc.fixedTools import otRound
 from fontTools.ttLib import TTFont, newTable, getTableModule
 from fontTools.ttLib.tables import ttProgram
@@ -26,13 +27,14 @@ from axisregistry import (
     build_filename,
     build_name_table,
     build_fvar_instances,
-    build_variations_ps_name
+    build_variations_ps_name,
 )
 from gftools.stat import gen_stat_tables
 
 from os.path import basename, splitext
 from copy import deepcopy
 import logging
+import math
 import subprocess
 import os
 import tempfile
@@ -67,7 +69,7 @@ __all__ = [
     "fix_font",
     "fix_family",
     "rename_font",
-    "fix_filename"
+    "fix_filename",
 ]
 
 
@@ -173,7 +175,7 @@ def fix_hinted_font(ttFont):
     Args:
         ttFont: a TTFont instance
     """
-    if not 'fpgm' in ttFont:
+    if not "fpgm" in ttFont:
         return False, ["Skipping. Font is not hinted."]
     old = ttFont["head"].flags
     ttFont["head"].flags |= 1 << 3
@@ -199,12 +201,10 @@ def fix_weight_class(ttFont):
     Args:
         ttFont: a TTFont instance
     """
-    old_weight_class = ttFont["OS/2"].usWeightClass
-
-    if 'fvar' in ttFont:
-        fvar = ttFont['fvar']
+    if "fvar" in ttFont:
+        fvar = ttFont["fvar"]
         default_axis_values = {a.axisTag: a.defaultValue for a in fvar.axes}
-        v = default_axis_values.get('wght', None)
+        v = default_axis_values.get("wght", None)
 
         if v is not None:
             ttFont["OS/2"].usWeightClass = int(v)
@@ -285,10 +285,18 @@ def fix_fvar_instances(ttFont, axis_dflts=None):
     if "fvar" not in ttFont:
         raise ValueError("ttFont is not a variable font")
 
-    fvar = ttFont['fvar']
-    old_instances = { (ttFont["name"].getDebugName(inst.subfamilyNameID) or "<removed>"): inst.coordinates for inst in fvar.instances }
+    fvar = ttFont["fvar"]
+    old_instances = {
+        (
+            ttFont["name"].getDebugName(inst.subfamilyNameID) or "<removed>"
+        ): inst.coordinates
+        for inst in fvar.instances
+    }
     build_fvar_instances(ttFont, axis_dflts)
-    new_instances = { ttFont["name"].getDebugName(inst.subfamilyNameID): inst.coordinates for inst in fvar.instances }
+    new_instances = {
+        ttFont["name"].getDebugName(inst.subfamilyNameID): inst.coordinates
+        for inst in fvar.instances
+    }
     if new_instances != old_instances:
         log.info("Set instances in fvar table to: %s", ", ".join(new_instances.keys()))
         log.info("(Old instances were: %s)", ", ".join(old_instances.keys()))
@@ -423,41 +431,44 @@ def fix_italic_angle(ttFont):
 
 def fix_ascii_fontmetadata(font):
     """Fixes TTF 'name' table strings to be ascii only"""
-    for name in font['name'].names:
+    for name in font["name"].names:
         title = name.string.decode(name.getEncoding())
         title = normalize_unicode_marks(title)
         name.string = title.encode(name.getEncoding())
 
 
 def convert_cmap_subtables_to_v4(font):
-  """Converts all cmap subtables to format 4.
+    """Converts all cmap subtables to format 4.
 
-  Returns a list of tuples (format, platformID, platEncID) of the tables
-  which needed conversion."""
-  cmap = font['cmap']
-  outtables = []
-  converted = []
-  for table in cmap.tables:
-    if table.format != 4:
-      converted.append((table.format, table.platformID, table.platEncID))
-    newtable = CmapSubtable.newSubtable(4)
-    newtable.platformID = table.platformID
-    newtable.platEncID = table.platEncID
-    newtable.language = table.language
-    newtable.cmap = table.cmap
-    outtables.append(newtable)
-  font['cmap'].tables = outtables
-  return converted
+    Returns a list of tuples (format, platformID, platEncID) of the tables
+    which needed conversion."""
+    cmap = font["cmap"]
+    outtables = []
+    converted = []
+    for table in cmap.tables:
+        if table.format != 4:
+            converted.append((table.format, table.platformID, table.platEncID))
+        newtable = CmapSubtable.newSubtable(4)
+        newtable.platformID = table.platformID
+        newtable.platEncID = table.platEncID
+        newtable.language = table.language
+        newtable.cmap = table.cmap
+        outtables.append(newtable)
+    font["cmap"].tables = outtables
+    return converted
 
 
 def drop_nonpid0_cmap(font, report=True):
-  keep, drop = partition_cmap(font, lambda table: table.platformID == 0, report)
-  return drop
+    keep, drop = partition_cmap(font, lambda table: table.platformID == 0, report)
+    return drop
 
 
 def drop_mac_cmap(font, report=True):
-  keep, drop = partition_cmap(font, lambda table: table.platformID != 1 or table.platEncID != 0, report)
-  return drop
+    keep, drop = partition_cmap(
+        font, lambda table: table.platformID != 1 or table.platEncID != 0, report
+    )
+    return drop
+
 
 def fix_pua(font):
     unencoded_glyphs = get_unencoded_glyphs(font)
@@ -476,7 +487,7 @@ def fix_pua(font):
     # unless UCS 4 cmap already exists
     ucs4cmap = cmap.getcmap(3, 10)
     if not ucs4cmap:
-        cmapModule = getTableModule('cmap')
+        cmapModule = getTableModule("cmap")
         ucs4cmap = cmapModule.cmap_format_12(12)
         ucs4cmap.platformID = 3
         ucs4cmap.platEncID = 10
@@ -490,76 +501,84 @@ def fix_pua(font):
     for glyphID, glyph in enumerate(font.getGlyphOrder()):
         if glyph in unencoded_glyphs:
             ucs4cmap.cmap[0xF0000 + glyphID] = glyph
-    font['cmap'] = cmap
+    font["cmap"] = cmap
     return True
 
 
 def fix_isFixedPitch(ttfont):
 
     same_width = set()
-    glyph_metrics = ttfont['hmtx'].metrics
+    glyph_metrics = ttfont["hmtx"].metrics
     messages = []
     changed = False
     for character in [chr(c) for c in range(65, 91)]:
         same_width.add(glyph_metrics[character][0])
 
     if len(same_width) == 1:
-        if ttfont['post'].isFixedPitch == 1:
+        if ttfont["post"].isFixedPitch == 1:
             messages.append("Skipping isFixedPitch is set correctly")
         else:
             messages.append("Font is monospace. Updating isFixedPitch to 0")
-            ttfont['post'].isFixedPitch = 1
+            ttfont["post"].isFixedPitch = 1
             changed = True
 
-        familyType = ttfont['OS/2'].panose.bFamilyType
+        familyType = ttfont["OS/2"].panose.bFamilyType
         if familyType == 2:
             expected = 9
         elif familyType == 3 or familyType == 5:
             expected = 3
         elif familyType == 0:
-            messages.append("Font is monospace but panose fields seems to be not set."
-                  " Setting values to defaults (FamilyType = 2, Proportion = 9).")
-            ttfont['OS/2'].panose.bFamilyType = 2
-            ttfont['OS/2'].panose.bProportion = 9
+            messages.append(
+                "Font is monospace but panose fields seems to be not set."
+                " Setting values to defaults (FamilyType = 2, Proportion = 9)."
+            )
+            ttfont["OS/2"].panose.bFamilyType = 2
+            ttfont["OS/2"].panose.bProportion = 9
             changed = True
             expected = None
         else:
             expected = None
 
         if expected:
-            if ttfont['OS/2'].panose.bProportion == expected:
+            if ttfont["OS/2"].panose.bProportion == expected:
                 messages.append("Skipping OS/2.panose.bProportion is set correctly")
             else:
-                messages.append(("Font is monospace."
-                       " Since OS/2.panose.bFamilyType is {}"
-                       " we're updating OS/2.panose.bProportion"
-                       " to {}").format(familyType, expected))
-                ttfont['OS/2'].panose.bProportion = expected
+                messages.append(
+                    (
+                        "Font is monospace."
+                        " Since OS/2.panose.bFamilyType is {}"
+                        " we're updating OS/2.panose.bProportion"
+                        " to {}"
+                    ).format(familyType, expected)
+                )
+                ttfont["OS/2"].panose.bProportion = expected
                 changed = True
 
-        widths = [m[0] for m in ttfont['hmtx'].metrics.values() if m[0] > 0]
+        widths = [m[0] for m in ttfont["hmtx"].metrics.values() if m[0] > 0]
         width_max = max(widths)
-        if ttfont['hhea'].advanceWidthMax == width_max:
+        if ttfont["hhea"].advanceWidthMax == width_max:
             messages.append("Skipping hhea.advanceWidthMax is set correctly")
         else:
-            messsages.append("Font is monospace. Updating hhea.advanceWidthMax to %i" %
-                  width_max)
-            ttfont['hhea'].advanceWidthMax = width_max
+            messsages.append(
+                "Font is monospace. Updating hhea.advanceWidthMax to %i" % width_max
+            )
+            ttfont["hhea"].advanceWidthMax = width_max
             changed = True
 
         avg_width = otRound(sum(widths) / len(widths))
-        if avg_width == ttfont['OS/2'].xAvgCharWidth:
+        if avg_width == ttfont["OS/2"].xAvgCharWidth:
             messages.append("Skipping OS/2.xAvgCharWidth is set correctly")
         else:
-            messages.append("Font is monospace. Updating OS/2.xAvgCharWidth to %i" %
-                  avg_width)
-            ttfont['OS/2'].xAvgCharWidth = avg_width
+            messages.append(
+                "Font is monospace. Updating OS/2.xAvgCharWidth to %i" % avg_width
+            )
+            ttfont["OS/2"].xAvgCharWidth = avg_width
             changed = True
     else:
-        if ttfont['post'].isFixedPitch != 0 or ttfont['OS/2'].panose.bProportion != 0:
+        if ttfont["post"].isFixedPitch != 0 or ttfont["OS/2"].panose.bProportion != 0:
             changed = True
-        ttfont['post'].isFixedPitch = 0
-        ttfont['OS/2'].panose.bProportion = 0
+        ttfont["post"].isFixedPitch = 0
+        ttfont["OS/2"].panose.bProportion = 0
     return changed, messages
 
 
@@ -589,10 +608,10 @@ def drop_superfluous_mac_names(ttfont):
     changed = False
     for n in range(255):
         if n not in keep_ids:
-            name = ttfont['name'].getName(n, 1, 0, 0)
+            name = ttfont["name"].getName(n, 1, 0, 0)
             if name:
                 changed = True
-                ttfont['name'].names.remove(name)
+                ttfont["name"].names.remove(name)
     return changed
 
 
@@ -600,9 +619,9 @@ def drop_mac_names(ttfont):
     """Drop all mac names"""
     changed = False
     for n in range(255):
-        name = ttfont['name'].getName(n, 1, 0, 0)
+        name = ttfont["name"].getName(n, 1, 0, 0)
         if name:
-            ttfont['name'].names.remove(name)
+            ttfont["name"].names.remove(name)
             changed = True
     return changed
 
@@ -626,13 +645,12 @@ def fix_colr_v0_gid1(ttfont):
 
 def _swap_empty_glyph_to_gid1(ttfont):
     from nanoemoji.reorder_glyphs import reorder_glyphs
-    from nanoemoji.util import load_fully
+
     glyf_table = ttfont["glyf"]
     ttfont = load_fully(ttfont)
     glyph_order = ttfont.getGlyphOrder()
     empty_glyph = next(
-        (g for g in glyph_order if glyf_table[g].numberOfContours == 0),
-        None
+        (g for g in glyph_order if glyf_table[g].numberOfContours == 0), None
     )
     if empty_glyph is None:
         raise ValueError(
@@ -649,6 +667,7 @@ def _add_empty_glyph_to_gid1(ttfont):
     from nanoemoji.util import load_fully
     from fontTools.ttLib.tables._g_l_y_f import Glyph
     from fontTools.ttLib.tables.otTables import NO_VARIATION_INDEX
+
     ttfont = load_fully(ttfont)
     glyph_order = ttfont.getGlyphOrder()
     glyf_table = ttfont["glyf"]
@@ -666,7 +685,7 @@ def _add_empty_glyph_to_gid1(ttfont):
         if hvar.LsbMap:
             hvar.LsbMap.mapping[empty_name] = NO_VARIATION_INDEX
         if hvar.RsbMap:
-           hvar.RsbMap.mapping[empty_name] = NO_VARIATION_INDEX
+            hvar.RsbMap.mapping[empty_name] = NO_VARIATION_INDEX
 
     new_order = list(glyph_order)
     new_order.insert(1, empty_name)
@@ -683,8 +702,10 @@ def fix_colr_v1_add_svg(ttfont):
             [
                 "maximum_color",
                 ttfont.reader.file.name,
-                "--build_dir", build_dir,
-                "--output_file", font_filename,
+                "--build_dir",
+                build_dir,
+                "--output_file",
+                font_filename,
             ],
             check=True,
         )
@@ -720,13 +741,18 @@ def fix_nbspace_glyph(ttfont: TTFont):
 def fix_license_strings(ttfont: TTFont):
     """Update font's nametable license and license url strings"""
     from gftools.constants import OFL_LICENSE_URL, OFL_LICENSE_INFO
+
     name_table = ttfont["name"]
     for r in name_table.names:
         if r.nameID == 13:
             current_string = r.toUnicode()
             if "SIL Open Font License" in current_string:
-                name_table.setName(OFL_LICENSE_INFO, r.nameID, r.platformID, r.platEncID, r.langID)
-                name_table.setName(OFL_LICENSE_URL, 14, r.platformID, r.platEncID, r.langID)
+                name_table.setName(
+                    OFL_LICENSE_INFO, r.nameID, r.platformID, r.platEncID, r.langID
+                )
+                name_table.setName(
+                    OFL_LICENSE_URL, 14, r.platformID, r.platEncID, r.langID
+                )
 
 
 def fix_ofl_license(ttfont):
@@ -746,11 +772,18 @@ def fix_ofl_license(ttfont):
     git_url = re.search(r"(\()(.*)(\))", font_copyright)
     if not git_url:
         raise ValueError("Font copyright doesn't contain a git url")
-    first_line = f"Copyright {font_year} The {font_name} Project Authors ({git_url.group(2)})"
+    first_line = (
+        f"Copyright {font_year} The {font_name} Project Authors ({git_url.group(2)})"
+    )
     return f"{first_line}\n{OFL_BODY_TEXT}"
 
 
-def fix_font(font, include_source_fixes=False, new_family_name=None, fvar_instance_axis_dflts=None):
+def fix_font(
+    font,
+    include_source_fixes=False,
+    new_family_name=None,
+    fvar_instance_axis_dflts=None,
+):
     fixed_font = deepcopy(font)
     if new_family_name:
         rename_font(fixed_font, new_family_name)
@@ -770,8 +803,10 @@ def fix_font(font, include_source_fixes=False, new_family_name=None, fvar_instan
         if not variation_ps_name:
             build_variations_ps_name(fixed_font)
             var_ps_name = fixed_font["name"].getName(25, 3, 1, 0x409).toUnicode()
-            log.info(f"Added a Variations PostScript Name Prefix (NameID 25) '{var_ps_name}'")
-    
+            log.info(
+                f"Added a Variations PostScript Name Prefix (NameID 25) '{var_ps_name}'"
+            )
+
     if "COLR" in fixed_font:
         log.info("Fixing COLR font")
         fixed_font = fix_colr_font(fixed_font)
@@ -781,18 +816,30 @@ def fix_font(font, include_source_fixes=False, new_family_name=None, fvar_instan
         fix_nametable(fixed_font)
         if fix_fs_type(fixed_font):
             log.info("Changed OS/2 table's fsType flag to 0 (Installable embedding)")
-            log.info("Consider fixing in the source (e.g. adding a 'fsType' custom parameter in Glyphs)\n")
+            log.info(
+                "Consider fixing in the source (e.g. adding a 'fsType' custom parameter in Glyphs)\n"
+            )
         if fix_fs_selection(fixed_font):
-            log.info("Changed OS/2 table's fsSelection flag to %i", fixed_font["OS/2"].fsSelection)
-            log.info("Consider fixing in the source (e.g. adding an 'openTypeOS2Selection' or 'Use Typo Metrics' custom parameter in Glyphs)\n")
+            log.info(
+                "Changed OS/2 table's fsSelection flag to %i",
+                fixed_font["OS/2"].fsSelection,
+            )
+            log.info(
+                "Consider fixing in the source (e.g. adding an 'openTypeOS2Selection' or 'Use Typo Metrics' custom parameter in Glyphs)\n"
+            )
         if fix_mac_style(fixed_font):
             log.info("Changed head table's macStyle to %i", fixed_font["head"].macStyle)
             log.info("Consider fixing in the source\n")
         if fix_weight_class(fixed_font):
-            log.info("Changed OS/2 table's usWeightClass to %i", fixed_font["OS/2"].usWeightClass)
+            log.info(
+                "Changed OS/2 table's usWeightClass to %i",
+                fixed_font["OS/2"].usWeightClass,
+            )
             log.info("Consider fixing in the source\n")
         if fix_italic_angle(fixed_font):
-            log.info("Changed post table's italicAngle to %f", fixed_font["post"].italicAngle)
+            log.info(
+                "Changed post table's italicAngle to %f", fixed_font["post"].italicAngle
+            )
             log.info("Consider fixing in the source\n")
 
         if "fvar" in fixed_font:
@@ -800,7 +847,12 @@ def fix_font(font, include_source_fixes=False, new_family_name=None, fvar_instan
     return fixed_font
 
 
-def fix_family(fonts, include_source_fixes=False, new_family_name=None, fvar_instance_axis_dflts=None):
+def fix_family(
+    fonts,
+    include_source_fixes=False,
+    new_family_name=None,
+    fvar_instance_axis_dflts=None,
+):
     """Fix all fonts in a family"""
     validate_family(fonts)
 
@@ -810,7 +862,7 @@ def fix_family(fonts, include_source_fixes=False, new_family_name=None, fvar_ins
             font,
             include_source_fixes=include_source_fixes,
             new_family_name=new_family_name,
-            fvar_instance_axis_dflts=fvar_instance_axis_dflts
+            fvar_instance_axis_dflts=fvar_instance_axis_dflts,
         )
         fixed_fonts.append(fixed_font)
     family_name = font_familyname(fixed_fonts[0])
@@ -834,7 +886,7 @@ def fix_family(fonts, include_source_fixes=False, new_family_name=None, fvar_ins
     return fixed_fonts
 
 
-class FontFixer():
+class FontFixer:
     def __init__(self, path, report=True, verbose=False, **kwargs):
         self.font = TTFont(path)
         self.path = path
@@ -853,10 +905,10 @@ class FontFixer():
             print("\n".join(self.messages))
         if self.saveit:
             if self.verbose:
-                print('Saving %s to %s.fix' % (self.font_filename, self.path))
+                print("Saving %s to %s.fix" % (self.font_filename, self.path))
             self.font.save(self.path + ".fix")
         elif self.verbose:
-            print('There were no changes needed on %s!' % self.font_filename)
+            print("There were no changes needed on %s!" % self.font_filename)
 
     def show(self):
         pass
@@ -877,26 +929,26 @@ class GaspFixer(FontFixer):
 
     def fix(self, value=15):
         try:
-            table = self.font.get('gasp')
+            table = self.font.get("gasp")
             table.gaspRange[65535] = value
             self.saveit = True
         except:
-            print(('ER: {}: no table gasp... '
-                  'Creating new table. ').format(self.path))
-            table = ttLib.newTable('gasp')
+            print(
+                ("ER: {}: no table gasp... " "Creating new table. ").format(self.path)
+            )
+            table = ttLib.newTable("gasp")
             table.gaspRange = {65535: value}
-            self.font['gasp'] = table
+            self.font["gasp"] = table
             self.saveit = True
 
     def show(self):
         try:
-            self.font.get('gasp')
+            self.font.get("gasp")
         except:
-            print('ER: {}: no table gasp'.format(self.path))
+            print("ER: {}: no table gasp".format(self.path))
             return
 
         try:
-            print(self.font.get('gasp').gaspRange[65535])
+            print(self.font.get("gasp").gaspRange[65535])
         except IndexError:
-            print('ER: {}: no index 65535'.format(self.path))
-
+            print("ER: {}: no index 65535".format(self.path))

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -100,7 +100,27 @@ UNWANTED_TABLES = frozenset(
 )
 
 
-def remove_tables(ttFont, tables=None):
+def _expect(
+    ttFont: TTFont, table: str, field: str, value: any, getter=None, setter=None
+) -> FixResult:
+    """Check that a table has a field with the expected value"""
+    if getter is not None:
+        previous = getter(ttFont)
+    else:
+        previous = getattr(ttFont[table], field)
+    if previous == value:
+        return ttFont, []
+    if setter is not None:
+        setter(ttFont, value)
+    else:
+        setattr(ttFont[table], field, value)
+    return True, [f"Set {table}.{field} to {value} (was {previous})"]
+
+
+def _combine_results(*results: List[FixResult]) -> FixResult:
+    """Combine multiple FixResults into a single FixResult"""
+    return any(r[0] for r in results), itertools.chain(*[r[1] for r in results])
+
     """Remove unwanted tables from a font. The unwanted tables must belong
     to the UNWANTED_TABLES set.
 

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -735,10 +735,10 @@ def fix_colr_font(ttfont: TTFont) -> TTFont:
         raise NotImplementedError(f"COLR version '{colr_version}' not supported.")
 
 
-def fix_nbspace_glyph(ttfont: TTFont):
-    cmap = ttfont.getBestCmap()
-    if 0x00A0 in cmap:
-        return
+# def fix_nbspace_glyph(ttfont: TTFont):
+#     cmap = ttfont.getBestCmap()
+#     if 0x00A0 in cmap:
+#         return
 
 
 def fix_license_strings(ttfont: TTFont):

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -828,6 +828,20 @@ def fix_ofl_license(ttfont):
     return f"{first_line}\n{OFL_BODY_TEXT}"
 
 
+def fix_no_varpsname(ttFont: TTFont) -> FixResult:
+    if "fvar" not in ttFont:
+        return ttFont, []
+    name_table = ttFont["name"]
+    variation_ps_name = name_table.getName(25, 3, 1, 0x409)
+    if not variation_ps_name:
+        build_variations_ps_name(ttFont)
+        var_ps_name = ttFont["name"].getName(25, 3, 1, 0x409).toUnicode()
+        return ttFont, [
+            f"Added a Variations PostScript Name Prefix (NameID 25) '{var_ps_name}'"
+        ]
+    return ttFont, []
+
+
 def fix_font(
     font,
     include_source_fixes=False,

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -4,6 +4,8 @@ specification:
 https://github.com/googlefonts/gf-docs/tree/main/Spec
 """
 
+import itertools
+from typing import List, Sequence, Tuple
 from fontTools.misc.fixedTools import otRound
 from fontTools.ttLib import TTFont, newTable, getTableModule
 from fontTools.ttLib.tables import ttProgram
@@ -81,6 +83,7 @@ WEIGHT_NAMES["Hairline"] = 1
 WEIGHT_NAMES["ExtraBlack"] = 1000
 WEIGHT_VALUES = {v: k for k, v in WEIGHT_NAMES.items()}
 
+FixResult = Tuple[bool, List[str]]
 
 UNWANTED_TABLES = frozenset(
     [

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -444,13 +444,20 @@ def copy_vertical_metrics(src_font, dst_font):
         setattr(dst_font[table], key, val)
 
 
-def fix_italic_angle(ttFont):
+def fix_italic_angle(ttFont) -> FixResult:
     style_name = font_stylename(ttFont)
-    if "Italic" not in style_name and ttFont["post"].italicAngle != 0:
-        ttFont["post"].italicAngle = 0
-        return True
-    # TODO (Marc F) implement for italic fonts
-    return False
+    if "Italic" not in style_name:
+        return _expect(ttFont, "post", "italicAngle", 0)
+    if "Italic" in style_name and ttFont["hhea"].caretSlopeRun != 0:
+        return _expect(
+            ttFont,
+            "post",
+            "italicAngle",
+            -math.degrees(
+                math.atan(ttFont["hhea"].caretSlopeRun / ttFont["hhea"].caretSlopeRise)
+            ),
+        )
+    return False, []
 
 
 

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -255,10 +255,10 @@ def test_fix_colr_v0_font(font_path):
     gid1 = font.getGlyphOrder()[1]
     assert font["glyf"][gid1].numberOfContours != 0
 
-    fixed = fix_colr_font(font)
-    gid1 = fixed.getGlyphOrder()[1]
-    assert fixed["glyf"][gid1].numberOfContours == 0
-    assert "SVG " not in fixed
+    fix_colr_font(font)
+    gid1 = font.getGlyphOrder()[1]
+    assert font["glyf"][gid1].numberOfContours == 0
+    assert "SVG " not in font
 
 
 @pytest.fixture
@@ -272,8 +272,8 @@ def test_fix_colr_v1_font(colr_v1_font):
 
     assert "SVG " not in colr_v1_font
     colr_v1_font["COLR"].version = 1
-    fixed = fix_colr_font(colr_v1_font)
-    assert "SVG " in fixed
+    fix_colr_font(colr_v1_font)
+    assert "SVG " in colr_v1_font
 
 
 def test_ofl_license_strings(static_font):


### PR DESCRIPTION
This started off as a simple PR (add a fix for the [hhea.caretSlopeRun](https://github.com/TypeTogether/Playwrite/issues/43#issuecomment-2076079076) issue caused by interpolating an MVAR table), but it's turned into a bit of rewrite:

* All fix functions are now expected to have a consistent interface: take a TTFont, return a tuple `changed, messages`. Typing has been added to ensure this.
* The "check if the current value of a field is what we expect, and if not, update it, emitting a message" pattern has been abstracted out into a function and used consistently.
* All fix functions check if they are appropriate (have all the tables they need etc.) and return `False, []` if not.

With this in place, `fix_font` becomes a matter of iterating over a list of fix functions.

Additionally, I added metadata to the functions linking them to a Fontbakery fix. Currently this metadata isn't used, but it would be helpful eventually to keep things automatically in sync, and to automatically apply fixes to failing FB checks.