### PR TITLE
Manage traffic jam: improvements

### DIFF
--- a/Lib/gftools/push/servers.py
+++ b/Lib/gftools/push/servers.py
@@ -199,7 +199,10 @@ class GFServers(Itemer):
 
     def update(self, family_name):
         for server in self:
-            server.update(family_name)
+            try:
+                server.update(family_name)
+            except Exception as e:
+                log.error(f"Error updating {family_name} on {server.name}: {e}")
 
     def compare_item(self, item: Items):
         res = item.to_json()

--- a/tests/push/test_trafficjam.py
+++ b/tests/push/test_trafficjam.py
@@ -110,6 +110,9 @@ def test_push_item_set(items, expected_size):
             PushItems(
                 [
                     PushItem(
+                        Path("ofl/mavenpro"), PushCategory.NEW, PushStatus.IN_DEV, "1"
+                    ),
+                    PushItem(
                         Path("ofl/mavenpro"),
                         PushCategory.NEW,
                         PushStatus.IN_SANDBOX,
@@ -451,7 +454,7 @@ def test_push_items_operators(operator, item1, item2, expected):
                 ]
             ),
         ),
-        # ensure latest push item is used
+        # ensure both items are added
         (
             [
                 PushItem(
@@ -463,6 +466,9 @@ def test_push_items_operators(operator, item1, item2, expected):
             ],
             PushItems(
                 [
+                    PushItem(
+                        Path("ofl/mavenpro"), PushCategory.NEW, PushStatus.IN_DEV, "1"
+                    ),
                     PushItem(
                         Path("ofl/mavenpro"),
                         PushCategory.UPGRADE,


### PR DESCRIPTION
This PR does the following:

Allow multiple items with the same path. This means we can track multiple versions of say Maven Pro, which may be in different servers.

Each time a family loads, repull the version number, designer info etc. We're currently experiencing caching issues. To work around this, we simply repull the data for each family upon loading.