### PR TITLE
Document `autohintOTF` in gfbuilder docs

### DIFF
--- a/docs/gftools-builder/README.md
+++ b/docs/gftools-builder/README.md
@@ -138,6 +138,9 @@ The build can be customized by adding the following keys to the YAML file:
 -   `autohintTTF`: Whether or not to autohint TTF files. Defaults to
     `true`.
 
+-   `autohintOTF`: Whether or not to autohint OTF files. Defaults to
+    `false`.
+
 -   `ttfaUseScript`: Whether or not to detect a font\'s primary script
     and add a `-D<script>` flag to ttfautohint. Defaults to `false`.
 


### PR DESCRIPTION
`autohintTTF` is documented, and defaults to `true`, so I incorrectly thought that A) OTFs would be auto hinted by default, which I now see is [not the case for a reason](https://github.com/googlefonts/gftools/issues/838), and B) that it would be documented if it were an option.

This simply documents the option to autohint OTFs, and lets users know it’s off by default.

~Writing this, I’m realizing that it probably needs to a be documented in the `--help` flag of the CLI, too. I’ll try to do that next, and update this PR.~ Oh, never mind: I see that the `--help` flag doesn’t present config options, which makes sense in hindsight.

I welcome edits by maintainers – I’m mostly just trying to helpful in pointing this out with a potential patch.