### PR TITLE
[subset-merger] Skip sparse masters

### DIFF
--- a/Lib/gftools/subsetmerger.py
+++ b/Lib/gftools/subsetmerger.py
@@ -106,6 +106,8 @@ class SubsetMerger:
         for master in ds.sources:
             newpath = os.path.join(outpath, os.path.basename(master.path))
             target_ufo = open_ufo(master.path)
+            if master.layerName is not None:
+                continue
 
             master.path = newpath
 


### PR DESCRIPTION
`ufomerge` doesn't handle sparse masters (glyphs in layers other than the default) yet, so we need to be careful not to merge two targets at different locations into the same source.