### PR TITLE
packager: pin pygit2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   'unidecode',
   'opentype-sanitizer',
   'vttlib',
-  'pygit2',
+  'pygit2<1.15.0',
   'strictyaml',
   'fontmake[json]>=3.3.0',
   'skia-pathops',


### PR DESCRIPTION
Pygit 1.15.0 has breaking api changes. It also doesn't support py3.8. Once py3.8 is EOL, I'll update to the latest version.

Thanks @simoncozens for the report.