### PR TITLE
Add custom GFArgumentParser

### DIFF
--- a/Lib/gftools/argparse.py
+++ b/Lib/gftools/argparse.py
@@ -1,0 +1,10 @@
+from argparse import ArgumentParser
+
+
+class GFArgumentParser(ArgumentParser):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_argument(
+            "--show-tracebacks", action="store_true", help="Show tracebacks"
+        )

--- a/Lib/gftools/scripts/manage_traffic_jam.py
+++ b/Lib/gftools/scripts/manage_traffic_jam.py
@@ -12,6 +12,7 @@ https://hub.github.com/
 import subprocess
 from rich.pretty import pprint
 from gftools.logging import setup_logging
+from gftools.argparse import GFArgumentParser
 from gftools.push.utils import branch_matches_google_fonts_main
 from gftools.push.servers import GFServers, Items
 from gftools.push.items import Family, FamilyMeta
@@ -223,7 +224,7 @@ class ItemChecker:
 
 
 def main(args=None):
-    parser = argparse.ArgumentParser()
+    parser = GFArgumentParser()
     parser.add_argument("fonts_repo", type=Path)
     parser.add_argument(
         "-f",


### PR DESCRIPTION
@simoncozens I've been toying with the idea of having our own `ArgumentParser` class. By default, it'll have the `--show-tracebacks` and `--log-level` commands set to sensible defaults. Once fully implemented, I could replace all ArgumentParsers with our one quite easily.

Still WIP since this may be a footgun idea.