### PR TITLE
fontsetter flexibility

### DIFF
--- a/Lib/gftools/scripts/fontsetter.py
+++ b/Lib/gftools/scripts/fontsetter.py
@@ -1,3 +1,12 @@
+"""
+This script is used to set values in a font file's tables using a YAML file.
+The yaml file should be formatted as follows:
+
+    name->setName: ["Hello world", 0, 3, 1, 0x409]
+    OS/2->sTypoAscender: 1200
+    head->macStyle: |= 0x01  # or with the current value
+"""
+
 from fontTools.misc.cliTools import makeOutputFileName
 from fontTools.ttLib import TTFont
 import types

--- a/Lib/gftools/scripts/fontsetter.py
+++ b/Lib/gftools/scripts/fontsetter.py
@@ -3,6 +3,7 @@ from fontTools.ttLib import TTFont
 import types
 import yaml
 import argparse
+import re
 
 
 def loads(string):
@@ -59,7 +60,12 @@ def setter(obj, path, val):
         if isinstance(key, str) and hasmethod(obj, key):
             getattr(obj, key)(*val)
         elif isinstance(key, str) and hasattr(obj, key):
-            setattr(obj, key, val)
+            if isinstance(val, str) and (m := re.match(r"\|=\s*(.*)", val)):
+                setattr(obj, key, getattr(obj, key) | int(m.group(1), 0))
+            else:
+                setattr(obj, key, val)
+        elif isinstance(val, str) and (m := re.match(r"\|=\s*(.*)", val)):
+            obj[key] = obj[key] | int(m.group(1), 0)
         else:
             obj[path[0]] = val
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ dependencies = [
   'rich',
   'packaging',
   'ninja',
-  'networkx'
+  'networkx',
+  'ruamel.yaml',
 ]
 
 [project.optional-dependencies]

--- a/tests/test_fontsetter.py
+++ b/tests/test_fontsetter.py
@@ -10,22 +10,13 @@ TEST_FONT = TTFont(os.path.join("data", "test", "Inconsolata[wdth,wght].ttf"))
 @pytest.mark.parametrize(
     """obj,path,val,res""",
     [
-        (
-            [10], [0], 100, [100]
-        ),
-        (
-            [10, [10]], [1, 0], 100, [10, [100]]
-        ),
-        (
-            [(0, [1, (2,)]), [1, 0], 100, (0, [100, (2,)])]
-        ),
-        (
-            [[0, (0, (0, ))], [1, 1, 0], 100, [0, (0, (100, ))]]
-        ),
-        (
-            {"A": {"B": [0, [10]]}}, ["A", "B", 1], [100], {"A": {"B": [0, [100]]}}
-        )
-    ]
+        ([10], [0], 100, [100]),
+        ([10, [10]], [1, 0], 100, [10, [100]]),
+        ([(0, [1, (2,)]), [1, 0], 100, (0, [100, (2,)])]),
+        ([[0, (0, (0,))], [1, 1, 0], 100, [0, (0, (100,))]]),
+        ({"A": {"B": [0, [10]]}}, ["A", "B", 1], [100], {"A": {"B": [0, [100]]}}),
+        ([0x1], [0], "|= 0x2", [0x3]),
+    ],
 )
 def test_setter(obj, path, val, res):
     setter(obj, path, val)
@@ -36,21 +27,13 @@ def test_setter(obj, path, val, res):
     """obj,path,val""",
     [
         # simple atttribs
-        (
-            TEST_FONT, ["OS/2", "fsSelection"], 64
-        ),
-        (
-            TEST_FONT, ["hhea", "ascender"], 1000
-        ),
+        (TEST_FONT, ["OS/2", "fsSelection"], 64),
+        (TEST_FONT, ["hhea", "ascender"], 1000),
         # attrib then dict
-        (
-            TEST_FONT, ["hmtx", "metrics", "A"], (10, 10)
-        ),
+        (TEST_FONT, ["hmtx", "metrics", "A"], (10, 10)),
         # attrib then attrib
-        (
-            TEST_FONT, ["OS/2", "panose", "bSerifStyle"], 10
-        )
-    ]
+        (TEST_FONT, ["OS/2", "panose", "bSerifStyle"], 10),
+    ],
 )
 def test_setter_on_fonts(obj, path, val):
     setter(obj, path, val)


### PR DESCRIPTION
This adds two new features to gftools-fontsetter:

* A value of the form `"|= 0x123"` will OR the current value of the field with the provided value.
* Multiple keys can be provided in the same configuration file. This allows for calling the same method (`name->setName`) multiple times. (Needed for making things italic.)