### PR TITLE
Split Italic and Roman VFs in builder

### DIFF
--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -108,5 +108,6 @@ GOOGLEFONTS_SCHEMA = Map(
         Optional("extraVariableFontmakeArgs"): Str(),
         Optional("extraStaticFontmakeArgs"): Str(),
         Optional("buildSmallCap"): Bool(),
+        Optional("splitItalic"): Bool(),
     }
 )

--- a/docs/gftools-builder/README.md
+++ b/docs/gftools-builder/README.md
@@ -200,6 +200,10 @@ The build can be customized by adding the following keys to the YAML file:
 -   `buildSmallCap`: Automatically build smallcap families from source with a
     `smcp` feature. Defaults to true.
 
+-   `splitItalic`: For variable fonts containing a `slnt` or `ital` axis,
+    subspace them into separate roman and italic VF files to comply with
+    Google Fonts' specification. Defaults to true.
+
 ## *Really* customizing the build process
 
 If the options above aren't enough for you - let's say you want to run your


### PR DESCRIPTION
Fixes #957.

We sometimes have source files containing an `ital` or `slnt` axis, but we require the onboarding of two separate fonts with Roman and Italic joined by style linking and STAT axis. This PR uses `varLib.instancer` to partially instance them along the relevant italic axis and then fixes them up accordingly.

Requires #963.