### PR TITLE
Check for ital axis in config file

### DIFF
--- a/Lib/gftools/stat.py
+++ b/Lib/gftools/stat.py
@@ -88,7 +88,7 @@ def gen_stat_tables_from_config(stat, varfonts, has_italic=None, locations=None)
             has_italic = any(font_is_italic(f) for f in varfonts)
         if has_italic:
             for ax in stat:
-                if ax["name"] == "ital":
+                if ax["tag"] == "ital":
                     raise ValueError("ital axis should not appear in stat config")
             ital_stat_for_roman = {
                 "name": "Italic",


### PR DESCRIPTION
We have a check for this already, but it never fires because it looks for an axis with *name* `ital` and it should look for one with *tag* `ital`. Fixes #976, in a way.