### PR TITLE
Two quick fixes

### DIFF
--- a/Lib/gftools/builder/operations/glyphs2ds.py
+++ b/Lib/gftools/builder/operations/glyphs2ds.py
@@ -1,0 +1,30 @@
+import os
+from tempfile import TemporaryDirectory
+
+from gftools.builder.file import File
+from gftools.builder.operations import OperationBase
+
+
+class Glyphs2DS(OperationBase):
+    description = "Turn a Glyphs file into a Designspace file"
+    rule = "fontmake -o ufo -g $in --output-dir $outdir $fontmake_args"
+
+    def convert_dependencies(self, builder):
+        self._target = TemporaryDirectory()  # Stow object
+
+    @property
+    def targets(self):
+        target = self._target.name
+        if "directory" in self.original:
+            target = self.original["directory"]
+
+        dspath = os.path.join(
+            target, self.first_source.basename.rsplit(".", 1)[0] + ".designspace"
+        )
+        return [File(dspath)]
+
+    @property
+    def variables(self):
+        return {
+            "outdir": os.path.dirname(self.targets[0].path),
+        }

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -234,7 +234,13 @@ def download_files_from_archive(url, dst):
 def download_file(url, dst_path=None):
     """Download a file from a url. If no dst_path is specified, store the file
     as a BytesIO object"""
-    request = requests.get(url, stream=True)
+    if os.environ.get("GH_TOKEN") and re.match(r"^https://(\w+\.)?github.com", url):
+        headers = {"Authorization": f"token {os.environ['GH_TOKEN']}"}
+    else:
+        headers = {}
+
+    request = requests.get(url, stream=True, headers=headers)
+    request.raise_for_status()
     if not dst_path:
         return BytesIO(request.content)
     with open(dst_path, "wb") as downloaded_file:


### PR DESCRIPTION
A secret project needs:

* An operation to convert Glyphs files to designspace files in the builder
* The ability to pass GitHub credentials to access private repositories while downloading files (eg during `add-ds-subset`)