### PR TITLE
Support Git references in subset merger

### DIFF
--- a/Lib/gftools/gfgithub.py
+++ b/Lib/gftools/gfgithub.py
@@ -88,6 +88,9 @@ class GitHubClient:
         """https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release"""
         return self._get(self.rest_url("releases/latest"))
 
+    def get_latest_release_tag(self) -> str:
+        return self.get_latest_release()["tag_name"]
+
     def open_prs(self, pr_head: str, pr_base_branch: str) -> typing.List:
         return self._get(
             self.rest_url("pulls", state="open", head=pr_head, base=pr_base_branch)

--- a/Lib/gftools/gfgithub.py
+++ b/Lib/gftools/gfgithub.py
@@ -85,6 +85,7 @@ class GitHubClient:
         return response
 
     def get_latest_release(self):
+        """https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release"""
         return self._get(self.rest_url("releases/latest"))
 
     def open_prs(self, pr_head: str, pr_base_branch: str) -> typing.List:

--- a/Lib/gftools/scripts/add_ds_subsets.py
+++ b/Lib/gftools/scripts/add_ds_subsets.py
@@ -13,6 +13,16 @@ def rewrap(text):
     return "\n\n".join("\n".join(wrap(dedent(para), width=72)) for para in paras)
 
 
+def get_repo_from_args(args):
+    # Build objects to match REPO_SCHEMA in ..subsetmerger
+    if args.repo is None:
+        return None
+    elif args.git_ref is None:
+        return {"slug": args.repo}
+    else:
+        return {"slug": args.repo, "ref": args.git_ref}
+
+
 EXAMPLES = """
 
 gftools-add-ds-subsets \\
@@ -75,6 +85,10 @@ Example usage:
     parser.add_argument("--yaml", "-y", help="YAML file describing subsets")
 
     parser.add_argument("--repo", "-r", help="GitHub repository to use for subsetting")
+    parser.add_argument(
+        "--git-ref",
+        help="Git commit, tag, or branch to use from the --repo",
+    )
     parser.add_argument("--file", "-f", help="Source file within GitHub repository")
     parser.add_argument("--name", "-n", help="Name of subset to use from glyphset")
     parser.add_argument("--codepoints", "-c", help="Range of codepoints to subset")
@@ -102,10 +116,11 @@ Example usage:
             print("Must specify --name or --codepoints")
             sys.exit(1)
         # And then construct the YAML-like object ourselves
+        # See subsets_schema in ..subsetmerger
         subsets = [
             {
                 "from": {
-                    "repo": args.repo,
+                    "repo": get_repo_from_args(args),
                     "path": args.file,
                 }
             }

--- a/Lib/gftools/scripts/add_ds_subsets.py
+++ b/Lib/gftools/scripts/add_ds_subsets.py
@@ -77,7 +77,7 @@ Example usage:
     parser.add_argument(
         "--repo",
         "-r",
-        help="GitHub repository slug to use for subsetting. Use @ after slug to specify branch/tag/commit, e.g. org/repo@v0.1.0",
+        help="GitHub repository slug to use for subsetting. Use @ after slug to specify branch/tag/commit, e.g. org/repo@v0.1.0; 'latest' is supported for latest release",
     )
     parser.add_argument("--file", "-f", help="Source file within GitHub repository")
     parser.add_argument("--name", "-n", help="Name of subset to use from glyphset")

--- a/Lib/gftools/scripts/add_ds_subsets.py
+++ b/Lib/gftools/scripts/add_ds_subsets.py
@@ -13,16 +13,6 @@ def rewrap(text):
     return "\n\n".join("\n".join(wrap(dedent(para), width=72)) for para in paras)
 
 
-def get_repo_from_args(args):
-    # Build objects to match REPO_SCHEMA in ..subsetmerger
-    if args.repo is None:
-        return None
-    elif args.git_ref is None:
-        return {"slug": args.repo}
-    else:
-        return {"slug": args.repo, "ref": args.git_ref}
-
-
 EXAMPLES = """
 
 gftools-add-ds-subsets \\
@@ -84,10 +74,10 @@ Example usage:
 
     parser.add_argument("--yaml", "-y", help="YAML file describing subsets")
 
-    parser.add_argument("--repo", "-r", help="GitHub repository to use for subsetting")
     parser.add_argument(
-        "--git-ref",
-        help="Git commit, tag, or branch to use from the --repo",
+        "--repo",
+        "-r",
+        help="GitHub repository slug to use for subsetting. Use @ after slug to specify branch/tag/commit, e.g. org/repo@v0.1.0",
     )
     parser.add_argument("--file", "-f", help="Source file within GitHub repository")
     parser.add_argument("--name", "-n", help="Name of subset to use from glyphset")
@@ -120,7 +110,7 @@ Example usage:
         subsets = [
             {
                 "from": {
-                    "repo": get_repo_from_args(args),
+                    "repo": args.repo,
                     "path": args.file,
                 }
             }

--- a/Lib/gftools/subsetmerger.py
+++ b/Lib/gftools/subsetmerger.py
@@ -146,7 +146,7 @@ class SubsetMerger:
 
         ds.write(self.output)
 
-    def add_subset(self, target_ufo, ds, ds_source, subset):
+    def add_subset(self, target_ufo, ds, ds_source, subset) -> bool:
         # First, we find a donor UFO that matches the location of the
         # UFO to merge.
         location = dict(ds_source.location)
@@ -174,7 +174,9 @@ class SubsetMerger:
         )
         return True
 
-    def obtain_upstream(self, upstream: str | dict[str, Any], location):
+    def obtain_upstream(
+        self, upstream: str | dict[str, Any], location
+    ) -> ufoLib2.Font | None:
         # Either the upstream is a string, in which case we try looking
         # it up in the SUBSET_SOURCES table, or it's a dict, in which
         # case it's a repository / path pair.
@@ -217,7 +219,7 @@ class SubsetMerger:
             return open_ufo(source_ufo.path)
         return None
 
-    def glyphs_to_ufo(self, source, directory=None):
+    def glyphs_to_ufo(self, source: str, directory: Path | None = None) -> str:
         source = Path(source)
         if directory is None:
             directory = source.resolve().parent


### PR DESCRIPTION
Closes #986 

In YAML, you can now do:

```yml
- operation: addSubset
  directory: latin-sources
  subsets:
    - from:
        repo: googlefonts/some-font@latest # <- the @ bit is new!
        path: source/some-font/SomeFont.designspace
      force: true
      name: GF_Latin_Core
```

Which can take any git reference, or the special value "latest" which grabs the tag from the latest GitHub release

These are appropriately cached in separate folders for org/repo/ref

Support for this is has also been incorporated into `add-ds-subsets`, and I've sprinkled in some type hints in parts of the codebase I've visited

<details>
<summary>Old PR description (outdated)</summary>

In YAML, you can now do:

```yml
repo:
  slug: notofonts/latin-greek-cyrillic
  ref: e7f1736c5ad0dc2abfc4dcd49ebca50abf612b29
```

Where before repo could only take a string (being the repo slug). This is still supported with the old behaviour of assuming you want the latest of the branch

The cache path was previously just the repo slug, but is now the slug + ref, e.g. `notofonts/latin-greek-cyrillic/main`

I've added a corresponding `--git-ref` to `gftools-add-ds-subsets` to expose this feature to the CLI as well

Opening this PR early without tests etc. to make sure the approach & code style are acceptable - such as the smidge of type hinting I added

Let me know your thoughts!
</details>