### PR TITLE
Allow sparse subsets in add-ds-subsets

### DIFF
--- a/Lib/gftools/builder/operations/addSubset.py
+++ b/Lib/gftools/builder/operations/addSubset.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import yaml
@@ -10,7 +9,7 @@ from gftools.builder.operations import OperationBase
 
 class AddSubset(OperationBase):
     description = "Add a subset from another font"
-    rule = "gftools-add-ds-subsets -j -y $yaml -o $out $in"
+    rule = "gftools-add-ds-subsets $args -j -y $yaml -o $out $in"
 
     def validate(self):
         # Ensure there is a new name
@@ -19,7 +18,7 @@ class AddSubset(OperationBase):
         if "subsets" not in self.original:
             raise ValueError("No subsets defined")
 
-    def convert_dependencies(self, builder):
+    def convert_dependencies(self, graph):
         self._target = TemporaryDirectory()  # Stow object
         self._orig = NamedTemporaryFile(delete=False, mode="w")
         yaml.dump(self.original["subsets"], self._orig)
@@ -40,4 +39,5 @@ class AddSubset(OperationBase):
     def variables(self):
         return {
             "yaml": self._orig.name,
+            "args": self.original.get("args"),
         }

--- a/Lib/gftools/builder/recipeproviders/noto.py
+++ b/Lib/gftools/builder/recipeproviders/noto.py
@@ -141,6 +141,7 @@ class NotoBuilder(GFBuilder):
                     "operation": "addSubset",
                     "subsets": self.config["includeSubsets"],
                     "directory": "full-designspace",
+                    "args": "--allow-sparse",
                 },
                 {
                     "operation": "buildVariable",
@@ -164,6 +165,7 @@ class NotoBuilder(GFBuilder):
                     "operation": "addSubset",
                     "subsets": self.config["includeSubsets"],
                     "directory": "full-designspace",
+                    "args": "--allow-sparse",
                 },
                 {
                     "operation": "buildVariable",
@@ -268,6 +270,7 @@ class NotoBuilder(GFBuilder):
                     "operation": "addSubset",
                     "subsets": self.config["includeSubsets"],
                     "directory": "full-designspace",
+                    "args": "--allow-sparse",
                 },
                 {
                     "operation": "instantiateUfo",

--- a/Lib/gftools/scripts/add_ds_subsets.py
+++ b/Lib/gftools/scripts/add_ds_subsets.py
@@ -77,6 +77,11 @@ Example usage:
     parser.add_argument("--repo", "-r", help="GitHub repository to use for subsetting")
     parser.add_argument("--file", "-f", help="Source file within GitHub repository")
     parser.add_argument("--name", "-n", help="Name of subset to use from glyphset")
+    parser.add_argument(
+        "--allow-sparse",
+        help="Allow skipping a non-default master missing from the donor designspace",
+        action="store_true",
+    )
     parser.add_argument("--codepoints", "-c", help="Range of codepoints to subset")
     parser.add_argument(
         "--json", "-j", action="store_true", help="Use JSON structured UFOs"
@@ -125,7 +130,12 @@ Example usage:
                     }
                 )
     SubsetMerger(
-        args.input, args.output, subsets, googlefonts=args.googlefonts, json=args.json
+        args.input,
+        args.output,
+        subsets,
+        googlefonts=args.googlefonts,
+        json=args.json,
+        allow_sparse=args.allow_sparse,
     ).add_subsets()
 
 


### PR DESCRIPTION
Sometimes when you're merging one designspace into another, you don't have the same set of masters, and sometimes that's OK - if you have all the corner masters, you can allow the internal masters to go sparse. This allows `add-ds-subsets` to optionally proceed without a full set of matching masters.