### PR TITLE
Builder subset operation: exclude glyphs by name/codepoint/file

### DIFF
--- a/Lib/gftools/scripts/add_ds_subsets.py
+++ b/Lib/gftools/scripts/add_ds_subsets.py
@@ -81,6 +81,14 @@ Example usage:
     parser.add_argument(
         "--json", "-j", action="store_true", help="Use JSON structured UFOs"
     )
+    parser.add_argument(
+        "--exclude-codepoints", help="Space-delimited unicodes to exclude"
+    )
+    parser.add_argument(
+        "--exclude-codepoints-file",
+        help="Newline delimited file with unicodes to exclude. "
+        "Allows for comments with either # or //",
+    )
 
     parser.add_argument("--output", "-o", help="Output designspace file")
 
@@ -107,6 +115,8 @@ Example usage:
                 "from": {
                     "repo": args.repo,
                     "path": args.file,
+                    "exclude_codepoints": args.exclude_codepoints,
+                    "exclude_codepoints_file": args.exclude_codepoints_file,
                 }
             }
         ]

--- a/Lib/gftools/scripts/add_ds_subsets.py
+++ b/Lib/gftools/scripts/add_ds_subsets.py
@@ -89,6 +89,14 @@ Example usage:
         help="Newline delimited file with unicodes to exclude. "
         "Allows for comments with either # or //",
     )
+    parser.add_argument(
+        "--exclude-glyphs", help="Space-delimited glyph names to exclude"
+    )
+    parser.add_argument(
+        "--exclude-glyphs-file",
+        help="Newline delimited file with glyph names to exclude. "
+        "Allows for comments with either # or //",
+    )
 
     parser.add_argument("--output", "-o", help="Output designspace file")
 
@@ -117,6 +125,8 @@ Example usage:
                     "path": args.file,
                     "exclude_codepoints": args.exclude_codepoints,
                     "exclude_codepoints_file": args.exclude_codepoints_file,
+                    "exclude_glyphs": args.exclude_glyphs,
+                    "exclude_glyphs_file": args.exclude_glyphs_file,
                 }
             }
         ]

--- a/Lib/gftools/subsetmerger.py
+++ b/Lib/gftools/subsetmerger.py
@@ -47,7 +47,9 @@ subsets_schema = Seq(
             ),
             Optional("layoutHandling"): Str(),
             Optional("force"): Str(),
+            Optional("exclude_glyphs"): Str(),
             Optional("exclude_codepoints"): Str(),
+            Optional("exclude_glyphs_file"): Str(),
             Optional("exclude_codepoints_file"): Str(),
         }
     )
@@ -59,7 +61,15 @@ def prepare_minimal_subsets(subsets):
     # codepoints with the same "donor" font and options. This allows the
     # user to specify multiple subsets from the same font, and they will
     # be merged into a single merge operation.
-    unicodes_by_donor = defaultdict(set)
+    incl_excl_by_donor: dict[
+        tuple[str, str, str],
+        tuple[
+            # Unicodes to include
+            set[int],
+            # Glyph names to exclude
+            set[str],
+        ],
+    ] = defaultdict(lambda: (set(), set()))
     for subset in subsets:
         # Resolved named subsets to a set of Unicode using glyphsets data
         if "name" in subset:
@@ -96,18 +106,49 @@ def prepare_minimal_subsets(subsets):
             unicode for unicode in unicodes if unicode not in excluded_codepoints
         ]
 
+        # Load excluded glyphs by name
+        exclude_glyphs = set()
+        if exclude_inline := subset.get("exclude_glyphs"):
+            for glyph_name in exclude_inline.split():
+                glyph_name = glyph_name.strip()
+                if glyph_name == "":
+                    continue
+                exclude_glyphs.add(glyph_name)
+        if exclude_file := subset.get("exclude_glyphs_file"):
+            for line in Path(exclude_file).read_text().splitlines():
+                line = line.strip()
+                if line != "" and not line.startswith(("#", "//")):
+                    continue
+                # Remove in-line comments
+                line = line.split("#", 1)[0]
+                line = line.split("//", 1)[0]
+                line = line.rstrip()
+                exclude_glyphs.add(line)
+
+        # Update incl_excl_by_donor
         key = (
             yaml.dump(subset["from"]),
             subset.get("layoutHandling"),
             subset.get("force"),
         )
-        unicodes_by_donor[key] |= set(unicodes)
+        unicodes_incl, glyph_names_excl = incl_excl_by_donor[key]
+        unicodes_incl |= set(unicodes)
+        glyph_names_excl |= exclude_glyphs
 
     # Now rebuild the subset dictionary, but this time with the codepoints
     # amalgamated into minimal sets.
     newsubsets = []
-    for (donor, layouthandling, force), unicodes in unicodes_by_donor.items():
-        newsubsets.append({"from": yaml.safe_load(donor), "unicodes": list(unicodes)})
+    for (donor, layouthandling, force), (
+        unicodes_incl,
+        glyph_names_excl,
+    ) in incl_excl_by_donor.items():
+        newsubsets.append(
+            {
+                "from": yaml.safe_load(donor),
+                "unicodes": list(unicodes_incl),
+                "exclude_glyphs": list(glyph_names_excl),
+            }
+        )
         if layouthandling:
             newsubsets[-1]["layoutHandling"] = layouthandling
         if force:
@@ -190,6 +231,7 @@ class SubsetMerger:
         merge_ufos(
             target_ufo,
             source_ufo,
+            exclude_glyphs=subset["exclude_glyphs"],
             codepoints=subset["unicodes"],
             existing_handling=existing_handling,
             layout_handling=layout_handling,

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -685,3 +685,11 @@ def has_gh_token():
     if "GH_TOKEN" in os.environ:
         return True
     return False
+
+
+def parse_codepoint(codepoint: str) -> int:
+    # https://github.com/googlefonts/ufomerge/blob/2257a1d3807a4eec9b515aa98e059383f7814d9a/Lib/ufomerge/cli.py#L118-L126
+    if codepoint.startswith(("U+", "u+", "0x", "0X")):
+        return int(codepoint[2:], 16)
+    else:
+        return int(codepoint)

--- a/docs/gftools-builder/README.md
+++ b/docs/gftools-builder/README.md
@@ -328,6 +328,21 @@ build process by leaving a `graph.png` file in the `sources` directory:
 - *subspace*: Runs `fonttools varLib.instancer` to subspace a variable font according to the values in `axes`. `args` are added to the command line.
 - *hbsubset*: Uses `hb-subset` to slim down a font binary.
 - *addSubset*: Adds a subset from another font using `gftools-add-ds-subsets`
+    - `directory`: the intermediary folder used to store the source(s) the subset(s) is taken from
+    - `subsets`: a list of subset configurations to merge in
+        - `from` (required): can be a pre-configured Noto source ("Noto Sans", "Noto Serif", "Noto Sans Devanagari", "Noto Sans Linear B"), or:
+            - `repo`: the GitHub slug for the repository, e.g. `googlefonts/gftools`. You can specify a git revision by suffixing this with `@v1.0.0`, or use `@latest` for the latest *published* release
+            - `path`: the path within the repo that has the source file
+        - `name`: a named Google Fonts subset, e.g. `GF_Latin_Core`
+        - `ranges`: a list unicode codepoint range to include
+            - `start`: the start of the range (as hex or decimal)
+            - `end`: the end of the range (as hex or decimal)
+        - `layoutHandling`: "subset", "closure" or "ignore" ([further reading](https://github.com/googlefonts/ufomerge/blob/bb9a82ff3039b8aa0cba58372158bd3c0e5cb770/Lib/ufomerge/__init__.py#L512-L521))
+        - `force`: replace existing glyphs in your sources, instead of skipping them
+        - `exclude_glyphs`: whitespace-delimited glyph names to exclude from merging
+        - `exclude_glyphs_file`: path to a file with glyphs names to exclude from merging, one per line (comments using `#` or `//` allowed)
+        - `exclude_codepoints`: whitespace-delimited unicode codepoints to exclude from merging
+        - `exclude_codepoints_file`: path to a file with with unicode codepoints to exclude from merging, one per line (comments using `#` or `//` allowed)
 - *buildVTT*: Uses `gftools-build-vtt` with the configuration file provided in `vttfile` to add VTT hinting to a font binary.
 - *remap*: Uses `gftools-remap-font` to alter a font binary's `cmap` table.
 - *paintcompiler*: Runs paintcompiler on a font to add a COLRv1 table.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ dependencies = [
   'ninja',
   'networkx',
   'ruamel.yaml',
+  # Used for subset merging, and preferred over the home-grown UFO merge script,
+  # which is deprecated.
+  # Pin avoids bug googlefonts/ufomerge#28.
+  'ufomerge>=1.8.1'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Adds support both on commandline and through YAML for glyphs to be excluded by either their name or codepoint.

All of the following now work (and yes, they would work together if something possessed you to do so):

```yml
# -- snip --
subsets:
  - from:
      repo: myorg/myfont
      path: source/myfont.designspace
    force: true
    name: GF_Latin_Core
    # ✨ new ✨ 👇
    exclude_codepoints: U+0032 U+0033  # space delimited
    exclude_codepoints_file: exclude_codepoints.txt
    exclude_glyphs: space a b c  # space delimited
    exclude_glyphs_file: exclude_glyph_names.txt
```

Usage docs for the CLI:

```
options:
  --exclude-codepoints EXCLUDE_CODEPOINTS
                        Space-delimited unicodes to exclude
  --exclude-codepoints-file EXCLUDE_CODEPOINTS_FILE
                        Newline delimited file with unicodes to exclude. Allows for comments with either #
                        or //
  --exclude-glyphs EXCLUDE_GLYPHS
                        Space-delimited glyph names to exclude
  --exclude-glyphs-file EXCLUDE_GLYPHS_FILE
                        Newline delimited file with glyph names to exclude. Allows for comments with
                        either # or //
```

The file format I've tried to be considerate/flexible: it's newline delimited, allowing either `//` or `#` style comments (both in-line and on thier own line)


---

Considerations:
* Should the YAML inline syntax instead be comma separated, to match `ufomerge`'s own CLI convention?
* There's a bug in `ufomerge` that means excluding a glyph by name when using a named glyphset will remove its unicode: https://github.com/googlefonts/ufomerge/issues/28
* Improving the documentation of the subset operation in the builder docs

Happy to hear thoughts, feedback, emotions