### PR TITLE
transfer-vtt-hints: Fixes

### DIFF
--- a/Lib/gftools/scripts/transfer_vtt_hints.py
+++ b/Lib/gftools/scripts/transfer_vtt_hints.py
@@ -137,7 +137,7 @@ def _update_tsi1(instructions: list[SimpleNamespace], gid_map, glyf):
             instruction.args[1] = component.x
             instruction.args[2] = component.y
             component_idx += 1
-    new_instructions.append(instruction)
+        new_instructions.append(instruction)
     return new_instructions
 
 

--- a/Lib/gftools/scripts/transfer_vtt_hints.py
+++ b/Lib/gftools/scripts/transfer_vtt_hints.py
@@ -18,7 +18,7 @@ from pyparsing import (
     Optional,
     cppStyleComment,
     Literal,
-    Combine
+    Combine,
 )
 import fontTools
 from fontTools.ttLib import TTFont
@@ -44,7 +44,7 @@ MAXP_ATTRS = {
 
 # TSI3 parser
 tsi3_func_name = Word(alphas)  # Function name consists of alphabetic characters
-integer = Combine(Optional('-') + Word(nums)).setParseAction(
+integer = Combine(Optional("-") + Word(nums)).setParseAction(
     lambda t: int(t[0])
 )  # Define integers and convert them to int
 tsi3_args = (
@@ -200,7 +200,9 @@ def transfer_hints(source_font: TTFont, target_font: TTFont, skip_components=Fal
         setattr(target_font[tbl], "extraPrograms", {})
 
     target_gid = {name: idx for idx, name in enumerate(target_font.getGlyphOrder())}
-    matched_glyphs = source_font["TSI1"].glyphPrograms.keys() & target_font.getGlyphSet().keys()
+    matched_glyphs = (
+        source_font["TSI1"].glyphPrograms.keys() & target_font.getGlyphSet().keys()
+    )
     unmatched_glyphs = (
         target_font.getGlyphSet().keys() - source_font.getGlyphSet().keys()
     )
@@ -245,7 +247,7 @@ def transfer_hints(source_font: TTFont, target_font: TTFont, skip_components=Fal
 
     # Copy over extraPrograms
     for tbl in ("TSI1", "TSI3"):
-        target_font[tbl].extraPrograms= source_font[tbl].extraPrograms
+        target_font[tbl].extraPrograms = source_font[tbl].extraPrograms
 
     transferred = len(matched_glyphs) - len(missing_hints)
     total = len(target_font.getGlyphSet().keys())
@@ -257,7 +259,12 @@ def main(args=None):
     parser = argparse.ArgumentParser(description="Transfer VTT hints between two fonts")
     parser.add_argument("source", type=str, help="Source font file")
     parser.add_argument("target", type=str, help="Target font file")
-    parser.add_argument("--skip-components", action="store_true", default=False, help="Skip component hints")
+    parser.add_argument(
+        "--skip-components",
+        action="store_true",
+        default=False,
+        help="Skip component hints",
+    )
     output = parser.add_mutually_exclusive_group(required=False)
     output.add_argument("-o", "--out", type=str, help="Output file")
     output.add_argument(

--- a/Lib/gftools/scripts/transfer_vtt_hints.py
+++ b/Lib/gftools/scripts/transfer_vtt_hints.py
@@ -235,12 +235,17 @@ def transfer_hints(source_font: TTFont, target_font: TTFont, skip_components=Fal
             missing_hints,
         )
 
-    # copy over other hinting tables
+    # Copy over other hinting tables
     for tbl in ("TSI5", "fpgm", "prep", "TSIC", "cvt "):
         target_font[tbl] = deepcopy(source_font[tbl])
 
+    # Copy over relevant maxp attributes
     for maxp_attr in MAXP_ATTRS:
         setattr(target_font["maxp"], maxp_attr, getattr(source_font["maxp"], maxp_attr))
+
+    # Copy over extraPrograms
+    for tbl in ("TSI1", "TSI3"):
+        target_font[tbl].extraPrograms= source_font[tbl].extraPrograms
 
     transferred = len(matched_glyphs) - len(missing_hints)
     total = len(target_font.getGlyphSet().keys())

--- a/Lib/gftools/scripts/transfer_vtt_hints.py
+++ b/Lib/gftools/scripts/transfer_vtt_hints.py
@@ -190,7 +190,7 @@ def printer(msg, items):
     print(f"{msg}:\nGID,Glyph_Name:\n{item_list}\n")
 
 
-def transfer_hints(source_font: TTFont, target_font: TTFont):
+def transfer_hints(source_font: TTFont, target_font: TTFont, skip_components=False):
     target_font["TSI0"] = fontTools.ttLib.newTable("TSI0")
     target_font["TSI2"] = fontTools.ttLib.newTable("TSI2")
     # Add a blank TSI1 and TSI3 table
@@ -210,7 +210,7 @@ def transfer_hints(source_font: TTFont, target_font: TTFont):
     for glyph_name in matched_glyphs:
         source_is_composite = source_font["glyf"][glyph_name].isComposite()
         target_is_composite = target_font["glyf"][glyph_name].isComposite()
-        if source_is_composite and target_is_composite:
+        if source_is_composite and target_is_composite and not skip_components:
             transfer_tsi1(source_font, target_font, glyph_name)
         elif source_is_composite and not target_is_composite:
             missing_hints.add((target_gid[glyph_name], glyph_name))
@@ -252,6 +252,7 @@ def main(args=None):
     parser = argparse.ArgumentParser(description="Transfer VTT hints between two fonts")
     parser.add_argument("source", type=str, help="Source font file")
     parser.add_argument("target", type=str, help="Target font file")
+    parser.add_argument("--skip-components", action="store_true", default=False, help="Skip component hints")
     output = parser.add_mutually_exclusive_group(required=False)
     output.add_argument("-o", "--out", type=str, help="Output file")
     output.add_argument(
@@ -262,7 +263,7 @@ def main(args=None):
     source_font = TTFont(args.source)
     target_font = TTFont(args.target)
 
-    transfer_hints(source_font, target_font)
+    transfer_hints(source_font, target_font, args.skip_components)
 
     if args.inplace:
         target_font.save(args.target)


### PR DESCRIPTION
This PR fixes the following:

- Fix TSI1 table transfers
- Fix TSI3 table transfers by starting with a blank TSI3 table
- Add option to skip TSI1 (component) hints
- Transfer maxp attributes