### PR TITLE
Cut instances in the Noto recipe provider

### DIFF
--- a/Lib/gftools/builder/operations/hbsubset.py
+++ b/Lib/gftools/builder/operations/hbsubset.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 import logging
 import os
 import shutil
@@ -10,9 +11,9 @@ SUBSETTER_ENV_KEY = "GFTOOLS_SUBSETTER"
 
 class HbSubset(OperationBase):
     description = "Run a subsetter to slim down a font"
-    rule = "$subsetter --output-file=$in.subset --notdef-outline --unicodes=* --name-IDs=* --layout-features=* --glyph-names $args $in && mv $in.subset $out"
+    rule = "$subsetter --output-file=$out --notdef-outline --unicodes=* --name-IDs=* --layout-features=* --glyph-names $args $in"
 
-    @property
+    @cached_property
     def subsetter(self):
         subsetter = self.original.get(
             "subsetter", os.environ.get(SUBSETTER_ENV_KEY, "auto")


### PR DESCRIPTION
Now I've done various bits of optimisation, a good chunk of the time of a Noto build is caught up in instantiating UFOs in order to build static TTFs. I'd like to move towards cutting instances from VFs (that's what the front-end does, so it should be acceptable)...

However, this is currently draft because there are some differences between the cut instances and the UFO-instantiated builds, listed below. So we probably need a `gftools-cut-instance` which fixes up the problems, and use that instead of purely calling `hb-subset`.

* `winAscent` and `winDescent` are not updated, neither with `fontTools varLib.instancer` or `hb-subset`.
* `hb-subset` does not correct the macStyle and fsSelection bits for bold weights, leading to problems with style linking.  (fontTools OK here)
* I got multiple `.notdef` glyphs with `hb-subset`. (fontTools OK here)
* `hb-subset` does not update the name table (fontTools does).

