### PR TITLE
Check all name records for Mac IDs

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -671,18 +671,10 @@ def drop_superfluous_mac_names(ttfont) -> FixResult:
     such as Word 2011. IDs 1-6 are very common, > 16 are edge cases.
 
     https://www.microsoft.com/typography/otspec/name.htm"""
-    keep_ids = [1, 2, 3, 4, 5, 6, 16, 17, 18, 20, 21, 22, 25]
-    messages = []
-    for n in range(255):
-        if n not in keep_ids:
-            name = ttfont["name"].getName(n, 1, 0, 0)
-            if name:
-                messages.append(f"Removed nameID {n}: {name.toStr()}")
-                ttfont["name"].names.remove(name)
-    return ttfont, messages
+    drop_mac_names(ttfont, keep_ids=[1, 2, 3, 4, 5, 6, 16, 17, 18, 20, 21, 22, 25])
 
 
-def drop_mac_names(ttfont) -> FixResult:
+def drop_mac_names(ttfont, keep_ids=[]) -> FixResult:
     """Drop all mac names"""
     messages = []
     for n in range(255):

--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -677,11 +677,17 @@ def drop_superfluous_mac_names(ttfont) -> FixResult:
 def drop_mac_names(ttfont, keep_ids=[]) -> FixResult:
     """Drop all mac names"""
     messages = []
-    for n in range(255):
-        name = ttfont["name"].getName(n, 1, 0, 0)
-        if name:
-            ttfont["name"].names.remove(name)
-            messages.append(f"Removed nameID {n}: {name.toStr()}")
+    for namerecord in list(  # list() to avoid removing while iterating
+        ttfont["name"].names
+    ):
+        if namerecord.nameID not in keep_ids:
+            messages.append(f"Removed nameID {namerecord.nameID}: {namerecord.toStr()}")
+            if (
+                namerecord.platformID == 1
+                and namerecord.platEncID == 0
+                and namerecord.langID == 0
+            ):
+                ttfont["name"].names.remove(namerecord)
     return ttfont, messages
 
 

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -520,10 +520,12 @@ def has_mac_names(ttfont):
     """Check if a font has Mac names. Mac names have the following
     field values:
     platformID: 1, encodingID: 0, LanguageID: 0"""
-    for i in range(255):
-        if ttfont["name"].getName(i, 1, 0, 0):
-            return True
-    return False
+    return any(
+        namerecord.platformID == 1
+        and namerecord.platEncID == 0
+        and namerecord.langID == 0
+        for namerecord in ttfont["name"].names
+    )
 
 
 def font_is_italic(ttfont):


### PR DESCRIPTION
In non-VF days we could just look at all name records up to 255. But there's no upper limit these days, so we look at them all. Fixes #1035