### PR TITLE
deps: downgrade pygit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   'unidecode',
   'opentype-sanitizer',
   'vttlib',
-  'pygit2<1.15.2',
+  'pygit2<=1.14.1',
   'strictyaml',
   'fontmake[json]>=3.3.0',
   'skia-pathops',


### PR DESCRIPTION
Viv reported that installing gftools on her new machine added pygit 1.15.0, which has the same issue as #952. 