### PR TITLE
Use fontc as alternative gftools.builder compiler

### DIFF
--- a/Lib/gftools/builder/operations/buildOTF.py
+++ b/Lib/gftools/builder/operations/buildOTF.py
@@ -3,21 +3,5 @@ from gftools.builder.operations import FontmakeOperationBase
 
 class BuildOTF(FontmakeOperationBase):
     description = "Build a OTF from a source file"
-    rule = "fontmake --output-path $out -o otf $fontmake_type $in $args"
-
-    def validate(self):
-        if not self.first_source.exists():
-            # We can't check this file (assume it was generated as part of the
-            # build), so user is on their own.
-            return
-        if self.first_source.is_glyphs and len(self.first_source.gsfont.masters) > 1:
-            raise ValueError(
-                f"Cannot build a static font from {self.first_source.path}"
-            )
-        if (
-            self.first_source.designspace
-            and len(self.first_source.designspace.sources) > 1
-        ):
-            raise ValueError(
-                f"Cannot build a static font from {self.first_source.path}"
-            )
+    format = "otf"
+    static = True

--- a/Lib/gftools/builder/operations/buildTTF.py
+++ b/Lib/gftools/builder/operations/buildTTF.py
@@ -3,21 +3,5 @@ from gftools.builder.operations import FontmakeOperationBase
 
 class BuildTTF(FontmakeOperationBase):
     description = "Build a TTF from a source file"
-    rule = "fontmake --output-path $out -o ttf $fontmake_type $in $args"
-
-    def validate(self):
-        if not self.first_source.exists():
-            # We can't check this file (assume it was generated as part of the
-            # build), so user is on their own.
-            return
-        if self.first_source.is_glyphs and len(self.first_source.gsfont.masters) > 1:
-            raise ValueError(
-                f"Cannot build a static font from {self.first_source.path}"
-            )
-        if (
-            self.first_source.designspace
-            and len(self.first_source.designspace.sources) > 1
-        ):
-            raise ValueError(
-                f"Cannot build a static font from {self.first_source.path}"
-            )
+    static = True
+    format = "ttf"

--- a/Lib/gftools/builder/operations/buildVariable.py
+++ b/Lib/gftools/builder/operations/buildVariable.py
@@ -3,4 +3,5 @@ from gftools.builder.operations import FontmakeOperationBase
 
 class BuildVariable(FontmakeOperationBase):
     description = "Build a variable font from a source file"
-    rule = "fontmake --output-path $out -o variable $fontmake_type $in $args"
+    format = "variable"
+    static = False

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -109,5 +109,6 @@ GOOGLEFONTS_SCHEMA = Map(
         Optional("extraStaticFontmakeArgs"): Str(),
         Optional("buildSmallCap"): Bool(),
         Optional("splitItalic"): Bool(),
+        Optional("localMetadata"): Any(),
     }
 )

--- a/docs/gftools-builder/README.md
+++ b/docs/gftools-builder/README.md
@@ -204,6 +204,9 @@ The build can be customized by adding the following keys to the YAML file:
     subspace them into separate roman and italic VF files to comply with
     Google Fonts' specification. Defaults to true.
 
+-   `localMetadata`: A field that's ignored so you can put whatever you like in it.
+
+
 ## *Really* customizing the build process
 
 If the options above aren't enough for you - let's say you want to run your


### PR DESCRIPTION
Implements #1045, if you set `GFTOOLS_COMPILER=fontc` environment variable. Some caveats:

- Any `args` that invoke `--filter` are dropped on the floor. Ideally these should be converted, ie. `--filter FlattenComponentsFilter` should become `--flatten-components`, etc.
- `instantiateUFO` -> `buildTTF` pipelines won't quite work yet as we assume JSON UFO structures in instantiated UFOs, which `fontc` doesn't support. Maybe we could make the JSON-ness dependent on `FontmakeOperationBase.compiler != "fontc"`.