### PR TITLE
Support for fontc and crater

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -58,6 +58,8 @@ class GFBuilder:
         # TODO(colin) we also want to suppress instancing when running fontmake
         # if we're using it to compare with fontc
         if use_fontc:
+            # we stash this flag here to pass it down to the recipe provider
+            self.config["use_fontc"] = use_fontc
             self.config["buildWebfont"] = False
             # override config to turn not build instances if we're variable
             if self.config.get("buildVariable", True):

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from os import chdir
 from pathlib import Path
 from tempfile import NamedTemporaryFile, gettempdir
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from gftools.builder.fontc import FontcArgs
 import networkx as nx
@@ -399,6 +399,12 @@ def main(args=None):
         "--experimental-simple-output",
         help="generate a reduced set of targets, and copy them to the provided directory",
         type=Path,
+    )
+
+    parser.add_argument(
+        "--experimental-single-source",
+        help="only compile the single named source file",
+        type=str,
     )
 
     parser.add_argument("config", help="Path to config file or source file", nargs="+")

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -58,9 +58,15 @@ class GFBuilder:
         # TODO(colin) we also want to suppress instancing when running fontmake
         # if we're using it to compare with fontc
         if use_fontc:
+            self.config["buildWebfont"] = False
             # override config to turn not build instances if we're variable
             if self.config.get("buildVariable", True):
                 self.config["buildStatic"] = False
+            # if the font doesn't explicitly request CFF, just built TT outlines
+            # if the font _only_ wants CFF outlines, we will try to build them
+            # ( but fail on fontc for now )
+            elif self.config.get("buildTTF", True):
+                self.config["buildOTF"] = False
 
         self.known_operations = OperationRegistry(use_fontc=use_fontc)
         self.writer = Writer(open("build.ninja", "w"))

--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile, gettempdir
 from typing import Any, Dict, List, Union
 
+from gftools.builder.operations.fontc import set_global_fontc_path
 import networkx as nx
 import strictyaml
 import yaml
@@ -409,8 +410,8 @@ def main(args=None):
     )
     parser.add_argument(
         "--experimental-fontc",
-        help="Use fontc instead of fontmake",
-        action="store_true",
+        help=f"Use fontc instead of fontmake. Argument is path to the fontc executable",
+        type=Path,
     )
 
     parser.add_argument(
@@ -424,6 +425,10 @@ def main(args=None):
     if args.experimental_simple_output:
         # get the abs path because we use cwd later and relative paths will break
         args.experimental_simple_output = args.experimental_simple_output.absolute()
+    if args.experimental_fontc:
+        fontc_path = Path(args.experimental_fontc).resolve()
+        assert fontc_path.is_file(), f"{fontc_path} is not a file"
+        set_global_fontc_path(Path(fontc_path))
     yaml_files = []
     source_files = []
     for config in args.config:

--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -48,6 +48,12 @@ class File:
         return self.is_glyphs or self.is_ufo or self.is_designspace
 
     @cached_property
+    def is_variable(self) -> bool:
+        return (self.is_glyphs and len(self.gsfont.masters) > 1) or (
+            self.is_designspace and len(self.designspace.sources) > 1
+        )
+
+    @cached_property
     def gsfont(self):
         if self.is_glyphs:
             import glyphsLib

--- a/Lib/gftools/builder/fontc.py
+++ b/Lib/gftools/builder/fontc.py
@@ -52,6 +52,10 @@ class FontcArgs:
             config["buildWebfont"] = False
             config["buildSmallCap"] = False
             config["splitItalic"] = False
+            # set --no-production-names, because it's easier to debug
+            extra_args = config.get("extraFontmakeArgs") or ""
+            extra_args += " --no-production-names"
+            config["extraFontmakeArgs"] = extra_args
             # override config to turn not build instances if we're variable
             if self.will_build_variable_font(config):
                 config["buildStatic"] = False

--- a/Lib/gftools/builder/fontc.py
+++ b/Lib/gftools/builder/fontc.py
@@ -14,6 +14,7 @@ from gftools.builder.operations.fontc import set_global_fontc_path
 class FontcArgs:
     simple_output_path: Union[Path, None]
     fontc_bin_path: Union[Path, None]
+    single_source: Union[str, None]
 
     # init with 'None' returns a default obj where everything is None
     def __init__(self, args: Union[Namespace, None]) -> None:
@@ -21,6 +22,7 @@ class FontcArgs:
             return None
         self.simple_output_path = abspath(args.experimental_simple_output)
         self.fontc_bin_path = abspath(args.experimental_fontc)
+        self.single_source = args.experimental_single_source
         if self.fontc_bin_path:
             if not self.fontc_bin_path.is_file():
                 raise ValueError(f"fontc does not exist at {self.fontc_bin_path}")
@@ -51,6 +53,14 @@ class FontcArgs:
             config["outputDir"] = str(output_dir)
             config["ttDir"] = str(output_dir)
             config["otDir"] = str(output_dir)
+        if self.single_source:
+            filtered_sources = [s for s in config["sources"] if self.single_source in s]
+            n_sources = len(filtered_sources)
+            if n_sources != 1:
+                raise ValueError(
+                    f"--exerimental-single-source {self.single_source} must match exactly one of {config['sources']} (matched {n_sources}) "
+                )
+            config["sources"] = filtered_sources
 
 
 def abspath(path: Union[Path, None]) -> Union[Path, None]:

--- a/Lib/gftools/builder/fontc.py
+++ b/Lib/gftools/builder/fontc.py
@@ -1,7 +1,10 @@
 """functionality for running fontc via gftools
 
-This mostly exists so that we can keep as much of the fontc logic in one place,
-and not need to dirty up anything else.
+gftools has a few special flags that allow it to use fontc, an alternative
+font compiler (https://github.com/googlefonts/fontc).
+
+This module exists to keep the logic related to fontc in one place, and not
+dirty up everything else.
 """
 
 from argparse import Namespace
@@ -12,14 +15,13 @@ from gftools.builder.operations.fontc import set_global_fontc_path
 
 
 class FontcArgs:
-    simple_output_path: Union[Path, None]
-    fontc_bin_path: Union[Path, None]
-    single_source: Union[str, None]
-
     # init with 'None' returns a default obj where everything is None
     def __init__(self, args: Union[Namespace, None]) -> None:
         if not args:
-            return None
+            self.simple_output_path = None
+            self.fontc_bin_path = None
+            self.single_source = None
+            return
         self.simple_output_path = abspath(args.experimental_simple_output)
         self.fontc_bin_path = abspath(args.experimental_fontc)
         self.single_source = args.experimental_single_source

--- a/Lib/gftools/builder/fontc.py
+++ b/Lib/gftools/builder/fontc.py
@@ -51,6 +51,7 @@ class FontcArgs:
             config["use_fontc"] = self.fontc_bin_path
             config["buildWebfont"] = False
             config["buildSmallCap"] = False
+            config["splitItalic"] = False
             # override config to turn not build instances if we're variable
             if self.will_build_variable_font(config):
                 config["buildStatic"] = False
@@ -65,6 +66,7 @@ class FontcArgs:
             config["outputDir"] = str(output_dir)
             config["ttDir"] = str(output_dir)
             config["otDir"] = str(output_dir)
+            config["vfDir"] = str(output_dir)
 
     def will_build_variable_font(self, config: dict) -> bool:
         # if config explicitly says dont build variable, believe it

--- a/Lib/gftools/builder/fontc.py
+++ b/Lib/gftools/builder/fontc.py
@@ -1,0 +1,57 @@
+"""functionality for running fontc via gftools
+
+This mostly exists so that we can keep as much of the fontc logic in one place,
+and not need to dirty up anything else.
+"""
+
+from argparse import Namespace
+from pathlib import Path
+from typing import Union
+
+from gftools.builder.operations.fontc import set_global_fontc_path
+
+
+class FontcArgs:
+    simple_output_path: Union[Path, None]
+    fontc_bin_path: Union[Path, None]
+
+    # init with 'None' returns a default obj where everything is None
+    def __init__(self, args: Union[Namespace, None]) -> None:
+        if not args:
+            return None
+        self.simple_output_path = abspath(args.experimental_simple_output)
+        self.fontc_bin_path = abspath(args.experimental_fontc)
+        if self.fontc_bin_path:
+            if not self.fontc_bin_path.is_file():
+                raise ValueError(f"fontc does not exist at {self.fontc_bin_path}")
+            set_global_fontc_path(self.fontc_bin_path)
+
+    @property
+    def use_fontc(self) -> bool:
+        return self.fontc_bin_path is not None
+
+    # update the config dictionary based on our special needs
+    def modify_config(self, config: dict):
+        if self.fontc_bin_path or self.simple_output_path:
+            # we stash this flag here to pass it down to the recipe provider
+            config["use_fontc"] = self.fontc_bin_path
+            config["buildWebfont"] = False
+            config["buildSmallCap"] = False
+            # override config to turn not build instances if we're variable
+            if config.get("buildVariable", True):
+                config["buildStatic"] = False
+            # if the font doesn't explicitly request CFF, just build TT outlines
+            # if the font _only_ wants CFF outlines, we will try to build them
+            # ( but fail on fontc for now) (but is this even a thing?)
+            elif config.get("buildTTF", True):
+                config["buildOTF"] = False
+        if self.simple_output_path:
+            output_dir = str(self.simple_output_path)
+            # we dump everything into one dir in this case
+            config["outputDir"] = str(output_dir)
+            config["ttDir"] = str(output_dir)
+            config["otDir"] = str(output_dir)
+
+
+def abspath(path: Union[Path, None]) -> Union[Path, None]:
+    return path.resolve() if path else None

--- a/Lib/gftools/builder/fontc.py
+++ b/Lib/gftools/builder/fontc.py
@@ -54,7 +54,7 @@ class FontcArgs:
             config["splitItalic"] = False
             # set --no-production-names, because it's easier to debug
             extra_args = config.get("extraFontmakeArgs") or ""
-            extra_args += " --no-production-names"
+            extra_args += " --no-production-names --drop-implied-oncurves"
             config["extraFontmakeArgs"] = extra_args
             # override config to turn not build instances if we're variable
             if self.will_build_variable_font(config):

--- a/Lib/gftools/builder/operations/__init__.py
+++ b/Lib/gftools/builder/operations/__init__.py
@@ -166,7 +166,9 @@ class OperationRegistry:
             if operation_name == "buildTTF":
                 from .fontc.fontcBuildTTF import FontcBuildTTF
 
-                return FontcBuildTTF
+            if operation_name == "buildOTF":
+                from .fontc.fontcBuildOTF import FontcBuildOTF
+                return FontcBuildOTF
 
         return self.known_operations.get(operation_name)
 

--- a/Lib/gftools/builder/operations/__init__.py
+++ b/Lib/gftools/builder/operations/__init__.py
@@ -168,6 +168,7 @@ class OperationRegistry:
 
             if operation_name == "buildOTF":
                 from .fontc.fontcBuildOTF import FontcBuildOTF
+
                 return FontcBuildOTF
 
         return self.known_operations.get(operation_name)

--- a/Lib/gftools/builder/operations/__init__.py
+++ b/Lib/gftools/builder/operations/__init__.py
@@ -166,6 +166,8 @@ class OperationRegistry:
             if operation_name == "buildTTF":
                 from .fontc.fontcBuildTTF import FontcBuildTTF
 
+                return FontcBuildTTF
+
             if operation_name == "buildOTF":
                 from .fontc.fontcBuildOTF import FontcBuildOTF
 

--- a/Lib/gftools/builder/operations/fontc/__init__.py
+++ b/Lib/gftools/builder/operations/fontc/__init__.py
@@ -2,21 +2,22 @@ from pathlib import Path
 from typing import List
 from gftools.builder.operations import OperationBase
 
-FONTC_PATH = "FONTC_PATH_NOT_SET"
+_FONTC_PATH = None
 
 
 # should only be called once, from main, before doing anything else. This is a
 # relatively non-invasive way to smuggle this value into FontcOperationBase
 def set_global_fontc_path(path: Path):
-    global FONTC_PATH
-    FONTC_PATH = path
+    global _FONTC_PATH
+    assert _FONTC_PATH is None, "set_global_fontc_path should only be called once"
+    _FONTC_PATH = path
 
 
 class FontcOperationBase(OperationBase):
     @property
     def variables(self):
         vars = super().variables
-        vars["fontc_path"] = FONTC_PATH
+        vars["fontc_path"] = _FONTC_PATH
         args = vars.get("args")
         if args:
             vars["args"] = rewrite_fontmake_args_for_fontc(args)

--- a/Lib/gftools/builder/operations/fontc/__init__.py
+++ b/Lib/gftools/builder/operations/fontc/__init__.py
@@ -53,6 +53,9 @@ def rewrite_one_arg(args: List[str]) -> str:
             next_ = f"{next_} {filter_}"
     elif next_ == "--no-production-names":
         return next_
+    elif next_ == "--drop-implied-oncurves":
+        # this is our default behaviour so no worries
+        return ""
     else:
         raise ValueError(f"unknown fontmake arg '{next_}'")
     return ""

--- a/Lib/gftools/builder/operations/fontc/__init__.py
+++ b/Lib/gftools/builder/operations/fontc/__init__.py
@@ -1,0 +1,44 @@
+from typing import List
+from gftools.builder.operations import OperationBase
+
+
+class FontcOperationBase(OperationBase):
+    @property
+    def variables(self):
+        vars = super().variables
+        args = vars.get("args")
+        if args:
+            vars["args"] = rewrite_fontmake_args_for_fontc(args)
+
+        return vars
+
+
+def rewrite_fontmake_args_for_fontc(args: str) -> str:
+    out_args = []
+    arg_list = args.split()
+    # reverse so we can pop in order
+    arg_list.reverse()
+    while arg_list:
+        out_args.append(rewrite_one_arg(arg_list))
+    return " ".join(out_args)
+
+
+# remove next arg from the front of the list and return its fontc equivalent
+def rewrite_one_arg(args: List[str]) -> str:
+    next_ = args.pop()
+    if next_ == "--filter":
+        filter_ = args.pop()
+        # this means 'retain filters defined in UFO', which... do we even support
+        # that in fontc?
+        if filter_ == "...":
+            pass
+        elif filter_ == "FlattenComponentsFilter":
+            return "--flatten-components"
+        elif filter_ == "DecomposeTransformedComponentsFilter":
+            return "--decompose-transformed-components"
+        else:
+            # glue the filter back together for better reporting below
+            next_ = f"{next_} {filter_}"
+    else:
+        raise ValueError(f"unknown fontmake arg '{next_}'")
+    return ""

--- a/Lib/gftools/builder/operations/fontc/__init__.py
+++ b/Lib/gftools/builder/operations/fontc/__init__.py
@@ -51,6 +51,8 @@ def rewrite_one_arg(args: List[str]) -> str:
         else:
             # glue the filter back together for better reporting below
             next_ = f"{next_} {filter_}"
+    elif next_ == "--no-production-names":
+        return next_
     else:
         raise ValueError(f"unknown fontmake arg '{next_}'")
     return ""

--- a/Lib/gftools/builder/operations/fontc/__init__.py
+++ b/Lib/gftools/builder/operations/fontc/__init__.py
@@ -1,11 +1,22 @@
+from pathlib import Path
 from typing import List
 from gftools.builder.operations import OperationBase
+
+FONTC_PATH = "FONTC_PATH_NOT_SET"
+
+
+# should only be called once, from main, before doing anything else. This is a
+# relatively non-invasive way to smuggle this value into FontcOperationBase
+def set_global_fontc_path(path: Path):
+    global FONTC_PATH
+    FONTC_PATH = path
 
 
 class FontcOperationBase(OperationBase):
     @property
     def variables(self):
         vars = super().variables
+        vars["fontc_path"] = FONTC_PATH
         args = vars.get("args")
         if args:
             vars["args"] = rewrite_fontmake_args_for_fontc(args)

--- a/Lib/gftools/builder/operations/fontc/fontcBuildOTF.py
+++ b/Lib/gftools/builder/operations/fontc/fontcBuildOTF.py
@@ -1,0 +1,8 @@
+from gftools.builder.operations.fontc import FontcOperationBase
+
+
+class FontcBuildTTF(FontcOperationBase):
+    description = "Build an OTF from a source file (with fontc)"
+    # the '--cff-outlines' flag does not exit in fontc, so this will
+    # error, which we want
+    rule = "fontc -o $out $in $args --cff-outlines"

--- a/Lib/gftools/builder/operations/fontc/fontcBuildOTF.py
+++ b/Lib/gftools/builder/operations/fontc/fontcBuildOTF.py
@@ -1,7 +1,7 @@
 from gftools.builder.operations.fontc import FontcOperationBase
 
 
-class FontcBuildTTF(FontcOperationBase):
+class FontcBuildOTF(FontcOperationBase):
     description = "Build an OTF from a source file (with fontc)"
     # the '--cff-outlines' flag does not exit in fontc, so this will
     # error, which we want

--- a/Lib/gftools/builder/operations/fontc/fontcBuildOTF.py
+++ b/Lib/gftools/builder/operations/fontc/fontcBuildOTF.py
@@ -5,4 +5,4 @@ class FontcBuildTTF(FontcOperationBase):
     description = "Build an OTF from a source file (with fontc)"
     # the '--cff-outlines' flag does not exit in fontc, so this will
     # error, which we want
-    rule = "fontc -o $out $in $args --cff-outlines"
+    rule = "$fontc_path -o $out $in $args --cff-outlines"

--- a/Lib/gftools/builder/operations/fontc/fontcBuildTTF.py
+++ b/Lib/gftools/builder/operations/fontc/fontcBuildTTF.py
@@ -1,6 +1,6 @@
-from gftools.builder.operations import OperationBase
+from gftools.builder.operations.fontc import FontcOperationBase
 
 
-class FontcBuildTTF(OperationBase):
+class FontcBuildTTF(FontcOperationBase):
     description = "Build a TTF from a source file (with fontc)"
-    rule = "fontc -o $out $in"
+    rule = "fontc -o $out $in $args"

--- a/Lib/gftools/builder/operations/fontc/fontcBuildTTF.py
+++ b/Lib/gftools/builder/operations/fontc/fontcBuildTTF.py
@@ -1,0 +1,6 @@
+from gftools.builder.operations import OperationBase
+
+
+class FontcBuildTTF(OperationBase):
+    description = "Build a TTF from a source file (with fontc)"
+    rule = "fontc -o $out $in"

--- a/Lib/gftools/builder/operations/fontc/fontcBuildTTF.py
+++ b/Lib/gftools/builder/operations/fontc/fontcBuildTTF.py
@@ -3,4 +3,4 @@ from gftools.builder.operations.fontc import FontcOperationBase
 
 class FontcBuildTTF(FontcOperationBase):
     description = "Build a TTF from a source file (with fontc)"
-    rule = "fontc -o $out $in $args"
+    rule = "$fontc_path -o $out $in $args"

--- a/Lib/gftools/builder/operations/fontc/fontcBuildVariable.py
+++ b/Lib/gftools/builder/operations/fontc/fontcBuildVariable.py
@@ -3,4 +3,4 @@ from gftools.builder.operations.fontc import FontcOperationBase
 
 class FontcBuildVariable(FontcOperationBase):
     description = "Build a variable font from a source file (with fontc)"
-    rule = "fontc -o $out $in $args"
+    rule = f"$fontc_path -o $out $in $args"

--- a/Lib/gftools/builder/operations/fontc/fontcBuildVariable.py
+++ b/Lib/gftools/builder/operations/fontc/fontcBuildVariable.py
@@ -1,6 +1,6 @@
-from gftools.builder.operations import OperationBase
+from gftools.builder.operations.fontc import FontcOperationBase
 
 
-class FontcBuildVariable(OperationBase):
+class FontcBuildVariable(FontcOperationBase):
     description = "Build a variable font from a source file (with fontc)"
-    rule = "fontc -o $out $in"
+    rule = "fontc -o $out $in $args"

--- a/Lib/gftools/builder/operations/fontc/fontcBuildVariable.py
+++ b/Lib/gftools/builder/operations/fontc/fontcBuildVariable.py
@@ -1,0 +1,6 @@
+from gftools.builder.operations import OperationBase
+
+
+class FontcBuildVariable(OperationBase):
+    description = "Build a variable font from a source file (with fontc)"
+    rule = "fontc -o $out $in"

--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -227,11 +227,7 @@ class GFBuilder(RecipeProviderBase):
         if not self.config.get("buildVariable", True):
             return
         for source in self.sources:
-            if (
-                (source.is_glyphs and len(source.gsfont.masters) < 2)
-                or source.is_ufo
-                or (source.is_designspace and len(source.designspace.sources) < 2)
-            ):
+            if not source.is_variable:
                 continue
             italic_ds = None
             if self.config["splitItalic"]:

--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -324,7 +324,7 @@ class GFBuilder(RecipeProviderBase):
             {"source": source.path},
         ]
         # if we're running fontc we skip conversion to UFO
-        if not source.is_ufo and not self.config.get('use_fontc', False):
+        if not source.is_ufo and not self.config.get("use_fontc", False):
             instancename = instance.name
             if instancename is None:
                 if not instance.familyName or not instance.styleName:

--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -323,7 +323,8 @@ class GFBuilder(RecipeProviderBase):
         steps = [
             {"source": source.path},
         ]
-        if not source.is_ufo:
+        # if we're running fontc we skip conversion to UFO
+        if not source.is_ufo and not self.config.get('use_fontc', False):
             instancename = instance.name
             if instancename is None:
                 if not instance.familyName or not instance.styleName:


### PR DESCRIPTION
Here is my attempt to add support in `gftools builder` for running `fontc`, and generally making it easier to use in the context of `fontc_crater`.

- adds the `--experimental-fontc` flag, which, if set:
    - replaces the `BuildVariable`, `BuildTTF`, and `BuildOTF` operations with alternatives that use `fontc`
    - modifies the config so that only _one_ of `buildVariable` and `buildStatic` is `true` (so do not instance variable fonts) and also so that only one of `buildTTF` and `buildOTF` are true (fontc does not currently build CFF outlines, so we turn `buildOTF` off if `buildTTF` is true)
- adds the `--experimental-simple-output=PATH` option, which:
    - if modifies the config so that all built fonts end up in one directory
    - and does the same config pruning as above, so that we can get the same set of outputs with both compilers.

Overall I've tried to make this as noninvasive as possible to the existing code, and I think that has been reasonably successful?