### PR TITLE
fix: retain user instances for families that do not have a wght axis

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -326,6 +326,9 @@ def fix_fvar_instances(ttFont, axis_dflts=None) -> FixResult:
     if "fvar" not in ttFont:
         return False, []
 
+    if "wght" not in [a.axisTag for a in ttFont["fvar"].axes]:
+        return False, []
+
     fvar = ttFont["fvar"]
     old_instances = {
         (


### PR DESCRIPTION
We allow families that don't have a weight axis such as Kablammo to have user defined fvar instances.