### PR TITLE
Make it easier to build variant families

### DIFF
--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -280,17 +280,26 @@ class GFBuilder(RecipeProviderBase):
     def build_a_variable(
         self, source: File, italic_ds: Italic = None, roman: bool = False
     ):
+        suffix = self.config.get("filenameSuffix", "")
         if roman:
-            target = self._vf_filename(source, italic_ds=italic_ds, roman=True)
+            target = self._vf_filename(
+                source, suffix=suffix, italic_ds=italic_ds, roman=True
+            )
         else:
-            target = self._vf_filename(source, italic_ds=italic_ds, roman=False)
-        steps = [
-            {"source": source.path},
-            {
-                "operation": "buildVariable",
-                "args": self.fontmake_args(source, variable=True),
-            },
-        ] + self._vtt_steps(target)
+            target = self._vf_filename(
+                source, suffix=suffix, italic_ds=italic_ds, roman=False
+            )
+        steps = (
+            [
+                {"source": source.path},
+                {
+                    "operation": "buildVariable",
+                    "args": self.fontmake_args(source, variable=True),
+                },
+            ]
+            + self.config.get("postCompile", [])
+            + self._vtt_steps(target)
+        )
         if italic_ds:
             desired_slice = italic_ds[0] + "="
             if roman:
@@ -322,7 +331,8 @@ class GFBuilder(RecipeProviderBase):
                     self.build_a_static(source, instance, output="otf")
 
     def build_a_static(self, source: File, instance: InstanceDescriptor, output):
-        target = self._static_filename(instance, extension=output)
+        suffix = self.config.get("filenameSuffix", "")
+        target = self._static_filename(instance, suffix=suffix, extension=output)
 
         steps = [
             {"source": source.path},
@@ -349,6 +359,7 @@ class GFBuilder(RecipeProviderBase):
                     "args": self.fontmake_args(source, variable=False),
                 }
             ]
+            + self.config.get("postCompile", [])
             + self._autohint_steps(target)
             + self._vtt_steps(target)
             + self._fix_step()

--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -66,6 +66,8 @@ stat_format4_schema = Seq(
 GOOGLEFONTS_SCHEMA = Map(
     {
         Optional("recipe"): MapPattern(Str(), Seq(Any())),
+        Optional("postCompile"): Seq(Any()),
+        Optional("filenameSuffix"): Str(),
         Optional("recipeProvider"): Str(),
         "sources": Seq(Str()),
         Optional("vttSources"): MapPattern(Str(), Str()),

--- a/docs/gftools-builder/README.md
+++ b/docs/gftools-builder/README.md
@@ -206,6 +206,10 @@ The build can be customized by adding the following keys to the YAML file:
 
 -   `localMetadata`: A field that's ignored so you can put whatever you like in it.
 
+-   `filenameSuffix`: A suffix appended to the family name part of filenames.
+
+-   `postCompile`: A list of operations to be run after the font compilation step; you can use this (together with the above option) to build variant fonts, rename families, bake in stylistic sets, etc.
+
 
 ## *Really* customizing the build process
 


### PR DESCRIPTION
We currently have support in the builder for building small cap variant families; this generalises that idea, with a new configuration option to run a list of operations after the initial font compile. It also adds an option to add a suffix to the output filenames.

Now instead of having to cook up a custom recipe from scratch to handle, say "Cormorant Garamond" (Cormorant + baked-in ss02 feature), you can instead create a separate configuration file like so:

```yaml
sources:
  - Cormorant.glyphs
  - Cormorant-Italic.glyphs
filenameSuffix: Garamond
postCompile:
    - args: '''ss02 -> ccmp'''
      operation: remapLayout
    - args: --just-family
      name: Cormorant Garamond
      operation: rename
```