### PR TITLE
[fontc] Disable autohinting

### DIFF
--- a/Lib/gftools/builder/fontc.py
+++ b/Lib/gftools/builder/fontc.py
@@ -52,6 +52,8 @@ class FontcArgs:
             config["buildWebfont"] = False
             config["buildSmallCap"] = False
             config["splitItalic"] = False
+            # disable running ttfautohint, because we had a segfault
+            config["autohintTTF"] = False
             # set --no-production-names, because it's easier to debug
             extra_args = config.get("extraFontmakeArgs") or ""
             extra_args += " --no-production-names --drop-implied-oncurves"


### PR DESCRIPTION
If we're identical before autohinting that should be enough for our purposes, and there was a non-deterministic crash in ttfautohint that was causing noise in our crater results.