### PR TITLE
[fontc] Only crater needs unique build file names

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from os import chdir
 from pathlib import Path
 from tempfile import NamedTemporaryFile, gettempdir
-import time
 from typing import Any, Dict, List, Union
 
 from gftools.builder.fontc import FontcArgs
@@ -64,7 +63,7 @@ class GFBuilder:
         fontc_args.modify_config(self.config)
 
         self.known_operations = OperationRegistry(use_fontc=fontc_args.use_fontc)
-        self.ninja_file_name = f"build-{time.time_ns()}.ninja"
+        self.ninja_file_name = fontc_args.build_file_name()
         self.writer = Writer(open(self.ninja_file_name, "w"))
         self.named_files = {}
         self.used_operations = set([])

--- a/Lib/gftools/builder/fontc.py
+++ b/Lib/gftools/builder/fontc.py
@@ -10,6 +10,7 @@ dirty up everything else.
 from argparse import Namespace
 from pathlib import Path
 from typing import Union
+import time
 
 from gftools.builder.file import File
 from gftools.builder.operations.fontc import set_global_fontc_path
@@ -35,6 +36,15 @@ class FontcArgs:
     def use_fontc(self) -> bool:
         return self.fontc_bin_path is not None
 
+    def build_file_name(self) -> str:
+        if self.fontc_bin_path or self.simple_output_path:
+            # if we're running for fontc we want uniquely named build files,
+            # to ensure they don't collide
+            return f"build-{time.time_ns()}.ninja"
+        else:
+            # otherwise just ues the default name
+            return "build.ninja"
+
     # update the config dictionary based on our special needs
     def modify_config(self, config: dict):
         if self.single_source:
@@ -52,6 +62,7 @@ class FontcArgs:
             config["buildWebfont"] = False
             config["buildSmallCap"] = False
             config["splitItalic"] = False
+            config["cleanUp"] = True
             # disable running ttfautohint, because we had a segfault
             config["autohintTTF"] = False
             # set --no-production-names, because it's easier to debug


### PR DESCRIPTION
When running in the context of crater, gftools builder may be invoked multiple times in parallel, which can cause the generated ninja.build files to overwrite each other.

To fix this, I implemented a scheme where we generate a unique name for the generated build file, so that multiple could exist and be in use for the same project, at the same time.

These files can pile up, though; I had initially thought they were cleaned up by default, but that doesn't seem to be the case.

This patch makes it so we only use this new naming scheme if we're running for crater, and uses the old names otherwise.

It also makes it so we always set the cleanup flag if we're running for crater.