### PR TITLE
Disable JSON structure when using fontc

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -37,6 +37,7 @@ def edge_with_operation(node, operation):
 class GFBuilder:
     config: dict
     recipe: Recipe
+    fontc_args: FontcArgs
 
     def __init__(
         self,
@@ -60,6 +61,7 @@ class GFBuilder:
         else:
             self._orig_config = yaml.dump(config)
             self.config = config
+        self.fontc_args = fontc_args
         fontc_args.modify_config(self.config)
 
         self.known_operations = OperationRegistry(use_fontc=fontc_args.use_fontc)
@@ -150,6 +152,9 @@ class GFBuilder:
         glyph_data = self.config.get("glyphData")
         if glyph_data is not None:
             glyph_data = glyph_data
+        ufo_structure = "json"
+        if self.fontc_args.use_fontc:
+            ufo_structure = "package"
         FontProject().run_from_glyphs(
             str(source.resolve()),
             **{
@@ -157,7 +162,7 @@ class GFBuilder:
                 "output_dir": directory,
                 "master_dir": directory,
                 "designspace_path": output,
-                "ufo_structure": "json",
+                "ufo_structure": ufo_structure,
                 "glyph_data": glyph_data,
             },
         )

--- a/Lib/gftools/builder/operations/__init__.py
+++ b/Lib/gftools/builder/operations/__init__.py
@@ -173,6 +173,11 @@ class OperationRegistry:
 
                 return FontcBuildOTF
 
+            if operation_name == "addSubset":
+                from .fontc.fontcAddSubset import FontcAddSubset
+
+                return FontcAddSubset
+
         return self.known_operations.get(operation_name)
 
 

--- a/Lib/gftools/builder/operations/fontc/fontcAddSubset.py
+++ b/Lib/gftools/builder/operations/fontc/fontcAddSubset.py
@@ -1,0 +1,43 @@
+import os
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+import yaml
+
+from gftools.builder.file import File
+from gftools.builder.operations import OperationBase
+
+
+class FontcAddSubset(OperationBase):
+    description = "Add a subset from another font"
+    rule = "gftools-add-ds-subsets $args -y $yaml -o $out $in"
+
+    def validate(self):
+        # Ensure there is a new name
+        if not self.first_source.is_font_source:
+            raise ValueError("%s is not a font source file" % self.first_source)
+        if "subsets" not in self.original:
+            raise ValueError("No subsets defined")
+
+    def convert_dependencies(self, graph):
+        self._target = TemporaryDirectory()  # Stow object
+        self._orig = NamedTemporaryFile(delete=False, mode="w")
+        yaml.dump(self.original["subsets"], self._orig)
+        self._orig.close()
+
+    @property
+    def targets(self):
+        if "directory" in self.original:
+            target = self.original["directory"]
+        else:
+            target = self._target.name
+        dspath = os.path.join(
+            target, self.first_source.basename.rsplit(".", 1)[0] + ".designspace"
+        )
+        return [File(dspath)]
+
+    @property
+    def variables(self):
+        return {
+            "yaml": self._orig.name,
+            "args": self.original.get("args"),
+        }


### PR DESCRIPTION
Normally, gftools-builder uses a small optimisation - saving intermediate UFOs in ufoLib2's "JSON structure" which is faster to serialize and parse. However, we want to turn off this optimisation when running with `fontc` as it does not support this (undocumented, non-standard) UFO representation.