### PR TITLE
Make fvarInstanceAxisDflts parameter work, see #1069

### DIFF
--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -218,7 +218,12 @@ class GFBuilder(RecipeProviderBase):
         if self.config.get("fvarInstanceAxisDflts"):
             args += (
                 " --fvar-instance-axis-dflts '"
-                + self.config["fvarInstanceAxisDflts"]
+                + " ".join(
+                    [
+                        f"{k}={v}"
+                        for k, v in self.config["fvarInstanceAxisDflts"].items()
+                    ]
+                )
                 + "'"
             )
         return args


### PR DESCRIPTION
The YAML schema wants this to be a map, but the gftools-fix-font command takes a string, so we need to convert.