### PR TITLE
Fix bad escapes in string for `AutohintOTF`

### DIFF
--- a/Lib/gftools/builder/operations/autohintOTF.py
+++ b/Lib/gftools/builder/operations/autohintOTF.py
@@ -3,4 +3,4 @@ from gftools.builder.operations import OperationBase
 
 class AutohintOTF(OperationBase):
     description = "Run otfautohint"
-    rule = "otfautohint $args -o $out $in \|\| otfautohint $args -o $out $in --no-zones-stems"
+    rule = r"otfautohint $args -o $out $in \|\| otfautohint $args -o $out $in --no-zones-stems"


### PR DESCRIPTION
Saves a `SyntaxWarning` in Python 3.12:

![image](https://github.com/user-attachments/assets/dbd88c88-1011-4ae9-bbfc-414fd4ffa104)
