### PR TITLE
Do not add Mac names when populating the STAT table

### DIFF
--- a/Lib/gftools/stat.py
+++ b/Lib/gftools/stat.py
@@ -127,4 +127,4 @@ def gen_stat_tables_from_config(stat, varfonts, has_italic=None, locations=None)
             if filename not in locations:
                 raise ValueError("Filename %s not found in locations" % filename)
             locations = locations[filename]
-        buildStatTable(ttFont, this_stat, locations=locations)
+        buildStatTable(ttFont, this_stat, locations=locations, macNames=False)


### PR DESCRIPTION
See #469

As of the latest Font Bakery release, [the `no_mac_entries` check has been promoted to the Universal profile](https://github.com/fonttools/fontbakery/blob/main/CHANGELOG.md#0130a0-2024-sep-13); by default, gftools and axisregistry insert Mac names when populating `STAT` and `fvar`, and so boilerplate gftools repositories are FAIL'ing this check out-of-the-box.

This PR makes a partial fix, by preventing Mac names from being added to `STAT`.

This is the right approach for the particular project I am looking at, but I would like to confirm that this is the right fix - as opposed to, e.g., making the Mac names opt-out - to make sure that this will not have unintended consequences for static TTFs destined for legacy environments, or similar.