### PR TITLE
Raise an error when an unknown fontmake filter is provided to fontc

### DIFF
--- a/Lib/gftools/builder/operations/fontc/__init__.py
+++ b/Lib/gftools/builder/operations/fontc/__init__.py
@@ -43,7 +43,7 @@ def rewrite_one_arg(args: List[str]) -> str:
         # this means 'retain filters defined in UFO', which... do we even support
         # that in fontc?
         if filter_ == "...":
-            pass
+            return ""
         elif filter_ == "FlattenComponentsFilter":
             return "--flatten-components"
         elif filter_ == "DecomposeTransformedComponentsFilter":
@@ -58,13 +58,11 @@ def rewrite_one_arg(args: List[str]) -> str:
         return f"--log={log_level}"
     elif next_ == "--drop-implied-oncurves" or next_ == "--keep-overlaps":
         # this is our default behaviour so no worries
-        pass
+        return ""
     elif next_ == "--no-check-compatibility":
         # we don't have an equivalent
-        pass
-    else:
-        raise ValueError(f"unknown fontmake arg '{next_}'")
-    return ""
+        return ""
+    raise ValueError(f"unknown fontmake arg '{next_}'")
 
 
 def python_to_rust_log_level(py_level: str):


### PR DESCRIPTION
My understanding is that this was the original intention of the code, but that the fall-through case performs the task of skipping too. (cc @cmyr would benefit from your know-how here, is this indeed what we want to support? :mag_right: )

Merging would lead to additional fails on crater, but in at least some cases (e.g. the Jersey family) for families that have a low % match already owing to an unsupported filter; this would become more explicit.

<sub>Note: this is a personal contribution independent of my employer, and so I've submitted from a fork under my personal profile and email to make this distinction</sub>