### PR TITLE
[builder] add --experimental-extra-arg flag to pass down extra arguments to compilers

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -418,6 +418,13 @@ def main(args=None):
         type=str,
     )
 
+    parser.add_argument(
+        "--experimental-extra-arg",
+        dest="experimental_extra_args",
+        help="pass extra argument(s) to fontc or fontmake. Can be used multiple times",
+        action="append",
+    )
+
     parser.add_argument("config", help="Path to config file or source file", nargs="+")
     args = parser.parse_args(args)
     fontc_args = FontcArgs(args)

--- a/Lib/gftools/builder/fontc.py
+++ b/Lib/gftools/builder/fontc.py
@@ -27,6 +27,7 @@ class FontcArgs:
         self.simple_output_path = abspath(args.experimental_simple_output)
         self.fontc_bin_path = abspath(args.experimental_fontc)
         self.single_source = args.experimental_single_source
+        self.extra_args = args.experimental_extra_args or []
         if self.fontc_bin_path:
             if not self.fontc_bin_path.is_file():
                 raise ValueError(f"fontc does not exist at {self.fontc_bin_path}")
@@ -65,9 +66,8 @@ class FontcArgs:
             config["cleanUp"] = True
             # disable running ttfautohint, because we had a segfault
             config["autohintTTF"] = False
-            # set --no-production-names, because it's easier to debug
             extra_args = config.get("extraFontmakeArgs") or ""
-            extra_args += " --no-production-names --drop-implied-oncurves"
+            extra_args += " ".join([" --drop-implied-oncurves"] + self.extra_args)
             config["extraFontmakeArgs"] = extra_args
             # override config to turn not build instances if we're variable
             if self.will_build_variable_font(config):

--- a/Lib/gftools/builder/operations/fontc/__init__.py
+++ b/Lib/gftools/builder/operations/fontc/__init__.py
@@ -53,6 +53,8 @@ def rewrite_one_arg(args: List[str]) -> str:
             next_ = f"{next_} {filter_}"
     elif next_ == "--no-production-names":
         return next_
+    elif next_ == "--keep-direction":
+        return next_
     elif next_ == "--verbose":
         log_level = python_to_rust_log_level(args.pop().strip())
         return f"--log={log_level}"


### PR DESCRIPTION
In ttx_diff.py we'd like control whether to pass the `--no-production-names` flag down to fontc and fontmake or not..

Which means, renaming glyphs to their final production names by default, but sometimes when useful keep original human-readable glyph names for debugging.

I added a catch-all flag which means we won't need extra flags if we'd like to support any additional options.