### PR TITLE
[servers] Don’t die on 404

### DIFF
--- a/Lib/gftools/push/items.py
+++ b/Lib/gftools/push/items.py
@@ -21,6 +21,8 @@ from google.protobuf.json_format import MessageToDict  # type: ignore
 from typing import Optional
 import re
 
+import requests
+
 
 log = logging.getLogger("gftools.push")
 
@@ -73,7 +75,7 @@ class Family(Itemer):
             version = font_version(ttFont)
             name = ttFont["name"].getBestFamilyName()
             return cls(name, version)
-        except (zipfile.BadZipFile, TTLibError):
+        except (zipfile.BadZipFile, TTLibError, requests.exceptions.HTTPError):
             return None
 
 


### PR DESCRIPTION
Sometimes a server claims to have a family, but it doesn't, so we can't download it. If we fail to download it, don't crash, but just return emptiness.