### PR TITLE
Replace pkg_resources with importlib_resources

### DIFF
--- a/Lib/gftools/scripts/add_font.py
+++ b/Lib/gftools/scripts/add_font.py
@@ -58,7 +58,6 @@ from gftools.utils import cmp
 from axisregistry import AxisRegistry
 from gfsubsets import SubsetsInFont
 from google.protobuf import text_format
-from pkg_resources import resource_filename
 from gftools.utils import remove_url_prefix, primary_script
 
 

--- a/Lib/gftools/scripts/lang_support.py
+++ b/Lib/gftools/scripts/lang_support.py
@@ -20,10 +20,8 @@ from gflanguages import LoadLanguages, LoadScripts
 from gftools import fonts_public_pb2
 from gftools.util import google_fonts as fonts
 from google.protobuf import text_format
-from pkg_resources import resource_filename
 import csv
 import os
-from pkg_resources import resource_filename
 
 parser = argparse.ArgumentParser(
     description="Add language support metadata to METADATA.pb files"

--- a/Lib/gftools/scripts/push_stats.py
+++ b/Lib/gftools/scripts/push_stats.py
@@ -11,7 +11,7 @@ gftools push-stats path/to/google/fonts/repo out.html
 """
 from gftools.push.trafficjam import PushItems
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-import importlib_resources
+import importlib.resources
 from datetime import datetime
 import pygit2
 from github import Github
@@ -76,7 +76,7 @@ def main(args=None):
     parser.add_argument("out")
     args = parser.parse_args(args)
 
-    push_template_dir = importlib_resources.files("gftools.push-templates")
+    push_template_dir = importlib.resources.files("gftools.push-templates")
     env = Environment(
         loader=FileSystemLoader(str(push_template_dir)),
         autoescape=select_autoescape(),

--- a/Lib/gftools/scripts/push_stats.py
+++ b/Lib/gftools/scripts/push_stats.py
@@ -11,7 +11,7 @@ gftools push-stats path/to/google/fonts/repo out.html
 """
 from gftools.push.trafficjam import PushItems
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-from pkg_resources import resource_filename
+import importlib_resources
 from datetime import datetime
 import pygit2
 from github import Github
@@ -76,9 +76,9 @@ def main(args=None):
     parser.add_argument("out")
     args = parser.parse_args(args)
 
-    push_template_dir = resource_filename("gftools", "push-templates")
+    push_template_dir = importlib_resources.files('gftools.push-templates')
     env = Environment(
-        loader=FileSystemLoader(push_template_dir),
+        loader=FileSystemLoader(str(push_template_dir)),
         autoescape=select_autoescape(),
     )
 

--- a/Lib/gftools/scripts/push_stats.py
+++ b/Lib/gftools/scripts/push_stats.py
@@ -76,7 +76,7 @@ def main(args=None):
     parser.add_argument("out")
     args = parser.parse_args(args)
 
-    push_template_dir = importlib_resources.files('gftools.push-templates')
+    push_template_dir = importlib_resources.files("gftools.push-templates")
     env = Environment(
         loader=FileSystemLoader(str(push_template_dir)),
         autoescape=select_autoescape(),

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -28,7 +28,7 @@ from unidecode import unidecode
 from collections import namedtuple
 from gflanguages import LoadLanguages
 from github import Github
-import importlib_resources
+import importlib.resources
 from google.protobuf import text_format
 import json
 from PIL import Image
@@ -540,8 +540,8 @@ def font_sample_text(ttFont):
     that can be formed using the ttFont instance.
 
     UDHR has been chosen due to the many languages it covers"""
-    ref = importlib_resources.files("gftools") / "udhr_all.txt"
-    with importlib_resources.as_file(ref) as doc:
+    ref = importlib.resources.files("gftools") / "udhr_all.txt"
+    with importlib.resources.as_file(ref) as doc:
         uhdr = doc.read()
 
     cmap = set(ttFont.getBestCmap())

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -28,7 +28,7 @@ from unidecode import unidecode
 from collections import namedtuple
 from gflanguages import LoadLanguages
 from github import Github
-from pkg_resources import resource_filename
+import importlib_resources
 from google.protobuf import text_format
 import json
 from PIL import Image
@@ -540,7 +540,8 @@ def font_sample_text(ttFont):
     that can be formed using the ttFont instance.
 
     UDHR has been chosen due to the many languages it covers"""
-    with open(resource_filename("gftools", "udhr_all.txt"), encoding="utf-8") as doc:
+    ref = importlib_resources.files('gftools') / 'udhr_all.txt'
+    with importlib_resources.as_file(ref) as doc:
         uhdr = doc.read()
 
     cmap = set(ttFont.getBestCmap())

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -540,7 +540,7 @@ def font_sample_text(ttFont):
     that can be formed using the ttFont instance.
 
     UDHR has been chosen due to the many languages it covers"""
-    ref = importlib_resources.files('gftools') / 'udhr_all.txt'
+    ref = importlib_resources.files("gftools") / "udhr_all.txt"
     with importlib_resources.as_file(ref) as doc:
         uhdr = doc.read()
 

--- a/bin/gftools
+++ b/bin/gftools
@@ -16,7 +16,7 @@
 #
 from __future__ import print_function
 from argparse import RawTextHelpFormatter
-from gftools._version import __version__
+from gftools import __version__
 from warnings import warn
 import sys
 import os

--- a/bin/gftools
+++ b/bin/gftools
@@ -16,7 +16,7 @@
 #
 from __future__ import print_function
 from argparse import RawTextHelpFormatter
-from pkg_resources import get_distribution
+from gftools._version import __version__
 from warnings import warn
 import sys
 import os
@@ -47,7 +47,6 @@ def _get_subcommands():
 
 
 def print_menu():
-    __version__ = get_distribution('gftools').version
     print(" o-o              o     o--o")
     print("o                 |     |            o")
     print("| o-o o-o o-o o-o o o-o o-o o-o o-o -o- o-o")
@@ -64,7 +63,6 @@ def print_menu():
 
 subcommands = _get_subcommands()
 
-__version__ = get_distribution('gftools').version
 
 description = "Run gftools subcommands:{0}".format(''.join(
               ['\n    {0}'.format(sc) for sc in sorted(subcommands.keys())]))

--- a/tests/push/test_items.py
+++ b/tests/push/test_items.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from gftools.push.items import Family, FamilyMeta, Designer, Axis, AxisFallback
-import importlib.resources
+from importlib.resources import files, as_file
 import json
 import atexit
 from contextlib import ExitStack
@@ -18,7 +18,7 @@ SERVER_DIR = os.path.join(CWD, "..", "..", "data", "test", "servers")
 TEST_FAMILY_DIR = Path(TEST_DIR) / "ofl" / "mavenpro"
 DESIGNER_DIR = Path(TEST_DIR) / "joeprince"
 WEIGHT_AXIS = file_manager.enter_context(
-    importlib.resources.path("axisregistry.data", "weight.textproto")
+    files("axisregistry") / "data" / "weight.textproto"
 )
 FAMILY_JSON = json.load(open(os.path.join(SERVER_DIR, "family.json"), encoding="utf8"))
 FONTS_JSON = json.load(open(os.path.join(SERVER_DIR, "fonts.json"), encoding="utf8"))

--- a/tests/push/test_items.py
+++ b/tests/push/test_items.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from gftools.push.items import Family, FamilyMeta, Designer, Axis, AxisFallback
 import importlib.resources
 import json
+import atexit
+from contextlib import ExitStack
+
+file_manager = ExitStack()
+atexit.register(file_manager.close)
 
 
 CWD = os.path.dirname(__file__)
@@ -12,7 +17,7 @@ TEST_DIR = os.path.join(CWD, "..", "..", "data", "test", "gf_fonts")
 SERVER_DIR = os.path.join(CWD, "..", "..", "data", "test", "servers")
 TEST_FAMILY_DIR = Path(TEST_DIR) / "ofl" / "mavenpro"
 DESIGNER_DIR = Path(TEST_DIR) / "joeprince"
-AXES_DIR = importlib.resources.files("axisregistry.data")
+WEIGHT_AXIS = file_manager.enter_context(importlib.resources.path("axisregistry.data", "weight.textproto"))
 FAMILY_JSON = json.load(open(os.path.join(SERVER_DIR, "family.json"), encoding="utf8"))
 FONTS_JSON = json.load(open(os.path.join(SERVER_DIR, "fonts.json"), encoding="utf8"))
 
@@ -68,7 +73,7 @@ FONTS_JSON = json.load(open(os.path.join(SERVER_DIR, "fonts.json"), encoding="ut
         ),
         (
             Axis,
-            AXES_DIR / "weight.textproto",
+            WEIGHT_AXIS,
             next(a for a in FONTS_JSON["axisRegistry"] if a["tag"] == "wght"),
             Axis(
                 tag="wght",

--- a/tests/push/test_items.py
+++ b/tests/push/test_items.py
@@ -18,7 +18,7 @@ SERVER_DIR = os.path.join(CWD, "..", "..", "data", "test", "servers")
 TEST_FAMILY_DIR = Path(TEST_DIR) / "ofl" / "mavenpro"
 DESIGNER_DIR = Path(TEST_DIR) / "joeprince"
 WEIGHT_AXIS = file_manager.enter_context(
-    files("axisregistry") / "data" / "weight.textproto"
+    as_file(files("axisregistry") / "data" / "weight.textproto")
 )
 FAMILY_JSON = json.load(open(os.path.join(SERVER_DIR, "family.json"), encoding="utf8"))
 FONTS_JSON = json.load(open(os.path.join(SERVER_DIR, "fonts.json"), encoding="utf8"))

--- a/tests/push/test_items.py
+++ b/tests/push/test_items.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from gftools.push.items import Family, FamilyMeta, Designer, Axis, AxisFallback
-import importlib_resources
+import importlib.resources
 import json
 
 
@@ -12,7 +12,7 @@ TEST_DIR = os.path.join(CWD, "..", "..", "data", "test", "gf_fonts")
 SERVER_DIR = os.path.join(CWD, "..", "..", "data", "test", "servers")
 TEST_FAMILY_DIR = Path(TEST_DIR) / "ofl" / "mavenpro"
 DESIGNER_DIR = Path(TEST_DIR) / "joeprince"
-AXES_DIR = importlib_resources.files("axisregistry.data")
+AXES_DIR = importlib.resources.files("axisregistry.data")
 FAMILY_JSON = json.load(open(os.path.join(SERVER_DIR, "family.json"), encoding="utf8"))
 FONTS_JSON = json.load(open(os.path.join(SERVER_DIR, "fonts.json"), encoding="utf8"))
 

--- a/tests/push/test_items.py
+++ b/tests/push/test_items.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from gftools.push.items import Family, FamilyMeta, Designer, Axis, AxisFallback
-from pkg_resources import resource_filename
+import importlib_resources
 import json
 
 
@@ -12,7 +12,7 @@ TEST_DIR = os.path.join(CWD, "..", "..", "data", "test", "gf_fonts")
 SERVER_DIR = os.path.join(CWD, "..", "..", "data", "test", "servers")
 TEST_FAMILY_DIR = Path(TEST_DIR) / "ofl" / "mavenpro"
 DESIGNER_DIR = Path(TEST_DIR) / "joeprince"
-AXES_DIR = Path(resource_filename("axisregistry", "data"))
+AXES_DIR = importlib_resources.files('axisregistry.data')
 FAMILY_JSON = json.load(open(os.path.join(SERVER_DIR, "family.json"), encoding="utf8"))
 FONTS_JSON = json.load(open(os.path.join(SERVER_DIR, "fonts.json"), encoding="utf8"))
 

--- a/tests/push/test_items.py
+++ b/tests/push/test_items.py
@@ -12,7 +12,7 @@ TEST_DIR = os.path.join(CWD, "..", "..", "data", "test", "gf_fonts")
 SERVER_DIR = os.path.join(CWD, "..", "..", "data", "test", "servers")
 TEST_FAMILY_DIR = Path(TEST_DIR) / "ofl" / "mavenpro"
 DESIGNER_DIR = Path(TEST_DIR) / "joeprince"
-AXES_DIR = importlib_resources.files('axisregistry.data')
+AXES_DIR = importlib_resources.files("axisregistry.data")
 FAMILY_JSON = json.load(open(os.path.join(SERVER_DIR, "family.json"), encoding="utf8"))
 FONTS_JSON = json.load(open(os.path.join(SERVER_DIR, "fonts.json"), encoding="utf8"))
 

--- a/tests/push/test_items.py
+++ b/tests/push/test_items.py
@@ -17,7 +17,9 @@ TEST_DIR = os.path.join(CWD, "..", "..", "data", "test", "gf_fonts")
 SERVER_DIR = os.path.join(CWD, "..", "..", "data", "test", "servers")
 TEST_FAMILY_DIR = Path(TEST_DIR) / "ofl" / "mavenpro"
 DESIGNER_DIR = Path(TEST_DIR) / "joeprince"
-WEIGHT_AXIS = file_manager.enter_context(importlib.resources.path("axisregistry.data", "weight.textproto"))
+WEIGHT_AXIS = file_manager.enter_context(
+    importlib.resources.path("axisregistry.data", "weight.textproto")
+)
 FAMILY_JSON = json.load(open(os.path.join(SERVER_DIR, "family.json"), encoding="utf8"))
 FONTS_JSON = json.load(open(os.path.join(SERVER_DIR, "fonts.json"), encoding="utf8"))
 


### PR DESCRIPTION
pkg_resources has been removed in python 3.12+.

Maybe I'm getting old but I hate this type of change. There's obviously a good reason for it but I'm just tired.

The migration guide was super handy, https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename