### PR TITLE
Unbreak fontc

### DIFF
--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -401,11 +401,12 @@ class GFBuilder(RecipeProviderBase):
             source,
             instance,
         )
-        # We skip conversion to UFO if there's only one instance or we're running fontc
+        # We skip conversion to UFO if we're running fontc
+        use_fontc = self.config.get("use_fontc", False)
         if (
             not source.is_ufo
             and not self.config.get("includeSubsets")
-            and (not self.config.get("use_fontc", False) or len(source.instances) > 1)
+            and not use_fontc
         ):
             instancename = instance.name
             if instancename is None:


### PR DESCRIPTION
~Apparently it is fairly common for there two be duplicate entries in source.instances, which caused the length check to fail which led to us to convert to ufo, and fontc cannot read JSON-format ufo files.~

**edit**:
Okay so on further review I'm not sure about the issue above? The problem here was actually that the boolean logic was incorrect, and we were doing the conversion if there were multiple instances, even if fontc was active.

but fwiw if I was debug printing `source.instances` before this check while compiling `CalSans` it showed two duplicate instances.

(`gftools builder ~/.fontc_crater_cache/calcom/font/sources/config.yaml`),  from https://github.com/calcom/font.

-----

There may be a better fix than this one, but this is the simplest.

I'm not sure how best to test this? Ideally we would have a test that passed the various fontc-related args and actually invoked fontc, but that doesn't seem really viable to do from pytest. Would it be worth adding something like this in CI?