### PR TITLE
Remove an unnecessary include directory argument

### DIFF
--- a/Lib/gftools/subsetmerger.py
+++ b/Lib/gftools/subsetmerger.py
@@ -359,7 +359,6 @@ class SubsetMerger:
             existing_handling=existing_handling,
             layout_handling=layout_handling,
             kern_handling=kern_handling,
-            include_dir=Path(donor_ufo.path).parent,
         )
         return True
 


### PR DESCRIPTION
When UFO1 and UFO2 are put in different directories and UFO2's directory is specified as an include directory, the inclusion by UFO1 fails because UFO1 and UFO2 share the specified include directory.

This PR fixes [the CI for Noto Sans Mongolian](https://github.com/notofonts/mongolian/actions/runs/18217347321/job/51869384583).