### PR TITLE
chore(deps): "setuptools" is not required at runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
   'Programming Language :: Python :: 3.14',
 ]
 dependencies = [
-  'setuptools',
   'FontTools[ufo]>=4.60.0', # Needed due to api changes in the avar module
   'axisregistry>=0.4.9', # Needed for "aggressive" param to build_name_table
   'absl-py',


### PR DESCRIPTION
Hi,

We applied this patch on Debian today:

https://salsa.debian.org/fonts-team/gftools/-/commit/4c607d70fda6ddcc65a77e2c472b8313d5a2d77c