### PR TITLE
SubsetMerger: check extraneous donor axes are at their default location

### DIFF
--- a/Lib/gftools/subsetmerger.py
+++ b/Lib/gftools/subsetmerger.py
@@ -255,9 +255,10 @@ def is_compatible(
 ) -> bool:
     input_userspace_location = input_descriptor.userspace_location
     my_userspace_location = descriptor.userspace_location
-    common_axis_tags = set(input_userspace_location.keys()).intersection(
-        set(my_userspace_location.keys())
-    )
+    input_axis_tags = set(input_userspace_location.keys())
+    donor_axis_tags = set(my_userspace_location.keys())
+    common_axis_tags = input_axis_tags.intersection(donor_axis_tags)
+    extraneous_donor_axis_tags = donor_axis_tags - input_axis_tags
     # Assume a source is good for this location unless proved otherwise.
     # This is useful for merging single-master donors into a multiple
     # master font.
@@ -268,7 +269,10 @@ def is_compatible(
                 f"{input_userspace_location[axis_tag]} != {my_userspace_location[axis_tag]}"
             )
             return False
-    return True
+    return all(
+        my_userspace_location[axis_tag] == descriptor.ds.getAxisByTag(axis_tag).default
+        for axis_tag in extraneous_donor_axis_tags
+    )
 
 
 class SubsetMerger:

--- a/tests/test_subset_merger.py
+++ b/tests/test_subset_merger.py
@@ -1,0 +1,37 @@
+from fontTools.designspaceLib import DesignSpaceDocument
+from gftools import subsetmerger
+from gftools.subsetmerger import DonorMasterDescriptor, InputDescriptor
+from ufoLib2 import Font
+
+
+def test_descriptor_compatibility():
+    input_ds = DesignSpaceDocument()
+    input_ds.addAxisDescriptor(
+        name="Weight", tag="wght", minimum=100, maximum=300, default=200
+    )
+    master = input_ds.addSourceDescriptor(location={"Weight": 100})
+    input_descriptor = InputDescriptor(input_ds, master, Font())
+
+    donor_ds_incompat = DesignSpaceDocument()
+    donor_ds_incompat.addAxisDescriptor(
+        name="Weight", tag="wght", minimum=100, maximum=300, default=200
+    )
+    donor_ds_incompat.addAxisDescriptor(
+        name="Width", tag="wdth", minimum=100, maximum=300, default=200
+    )
+    master = donor_ds_incompat.addSourceDescriptor(
+        # Width is at non-default location
+        location={"Weight": 100, "Width": 100}
+    )
+
+    assert not subsetmerger.is_compatible(
+        DonorMasterDescriptor(donor_ds_incompat, master, Font()),
+        input_descriptor,
+    )
+
+    # Width is now at default location
+    master.location["Width"] = 200
+    assert subsetmerger.is_compatible(
+        DonorMasterDescriptor(donor_ds_incompat, master, Font()),
+        input_descriptor,
+    )


### PR DESCRIPTION
For example, I was merging a font with a GRAD axis into a font that doesn't have a GRAD axis. Because of the Designspace's ordering, I was getting a non-zero GRAD merged in, making the appearance of the two sources mismatch. By ensuring extra axes like GRAD are at their default locations, we mitigate unexpected sub-optimal matching.

Per the comment about this method's intentional permissiveness, this has no impact on single-master donors getting merged in.

I'll get a unit test thrown together shortly.