### PR TITLE
builder: restore previous googlefonts recipe

### DIFF
--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -122,14 +122,6 @@ class GFBuilder(RecipeProviderBase):
         else:
             self.fvarInstancesFile = None
 
-        if "fontsetter" in self.config:
-            self.fontsetterfiles = {}
-            for font in list(self.config["fontsetter"].keys()):
-                tmp_file = NamedTemporaryFile(delete=False, mode="w+")
-                self.config["fontsetter"][font] = self.config["fontsetter"][font]
-                yaml.dump(self.config["fontsetter"][font], tmp_file)
-                self.fontsetterfiles[font] = tmp_file
-
         # Find variable fonts
         self.recipe = {}
         self.build_all_variables()
@@ -285,8 +277,6 @@ class GFBuilder(RecipeProviderBase):
             self.build_avar2()
         if "fvarInstances" in self.config:
             self.build_fvar_instances()
-        if "fontsetter" in self.config:
-            self.build_fontsetter()
 
     def build_spacing_axis(self):
         vfs = [x for x in self.recipe.keys() if x.endswith("ttf")]
@@ -340,18 +330,6 @@ class GFBuilder(RecipeProviderBase):
             for vf in vfs:
                 self.recipe[vf].append(args)
             self.fvarInstancesFile.close()
-
-    def build_fontsetter(self):
-        vfs = [x for x in self.recipe.keys() if x.endswith("ttf")]
-        for vf in vfs:
-            filename = os.path.basename(vf)
-            if filename not in self.fontsetterfiles:
-                continue
-            args = {
-                "args": self.fontsetterfiles[filename].name,
-                "postprocess": "fontsetter",
-            }
-            self.recipe[vf].append(args)
 
     def _vtt_steps(self, target: str):
         if os.path.basename(target) in self.config.get("vttSources", {}):
@@ -452,8 +430,6 @@ class GFBuilder(RecipeProviderBase):
                     self.build_a_static(source, instance, output="ttf")
                 if self.config["buildOTF"]:
                     self.build_a_static(source, instance, output="otf")
-        if "fontsetter" in self.config:
-            self.build_fontsetter()
 
     def build_a_static(self, source: File, instance: InstanceDescriptor, output):
         suffix = self.config.get("filenameSuffix", "")
@@ -585,17 +561,25 @@ class GFBuilder(RecipeProviderBase):
         # "italic enough" to convince gftools-fix-font to apply all its italic
         # font fixes (post.italicAngle etc.) when we call it with
         # --include-source-fixes.
+        configfile = NamedTemporaryFile(delete=False, mode="w+")
         family_name = self.sources[0].family_name.replace(" ", "")
+        # Since this is mad YAML, we can't use the normal YAML library
+        # to write this. We'll just write it out manually.
+        configfile.write(
+            f"""
+OS/2->fsSelection: 129
+head->macStyle: "|= 0x02"
+name->setName: ["{family_name}Italic", 25, 3, 1, 0x409]
+name->setName: ["Italic", 2, 3, 1, 0x409]
+name->setName: ["Italic", 17, 3, 1, 0x409]
+        """
+        )
+        configfile.close()
         return [
             {
-                "operation": "fontsetter",
-                "values": [
-                    ["OS/2->fsSelection", 129],
-                    ["head->macStyle", "|= 0x02"],
-                    ["name->setName", [f"{family_name}Italic", 25, 3, 1, 0x409]],
-                    ["name->setName", ["Italic", 2, 3, 1, 0x409]],
-                    ["name->setName", ["Italic", 17, 3, 1, 0x409]],
-                ],
+                "operation": "exec",
+                "exe": "gftools-fontsetter",
+                "args": "-o $out $in " + configfile.name,
             },
             {
                 "operation": "fix",

--- a/data/test/builder/split_italic/TestFamily.glyphs
+++ b/data/test/builder/split_italic/TestFamily.glyphs
@@ -1,0 +1,1622 @@
+{
+.appVersion = "3406";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Italic;
+tag = ital;
+}
+);
+customParameters = (
+{
+name = "Use Typo Metrics";
+value = 1;
+},
+{
+name = fsType;
+value = (
+);
+},
+{
+name = "Use Line Breaks";
+value = 1;
+},
+{
+name = "Use Extension Kerning";
+value = 1;
+},
+{
+name = "Write DisplayStrings";
+value = 0;
+},
+{
+name = "Variable Font Origin";
+value = m019;
+}
+);
+date = "2025-07-16 23:44:39 +0000";
+familyName = "Test Family";
+fontMaster = (
+{
+axesValues = (
+200,
+0
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 200;
+},
+{
+Axis = "Optical size";
+Location = 0;
+},
+{
+Axis = Italic;
+Location = 0;
+}
+);
+},
+{
+name = hheaAscender;
+value = 1090;
+},
+{
+name = hheaDescender;
+value = -320;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = typoAscender;
+value = 1090;
+},
+{
+name = typoDescender;
+value = -320;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1090;
+},
+{
+name = winDescent;
+value = 320;
+},
+{
+name = underlinePosition;
+value = -140;
+},
+{
+name = underlineThickness;
+value = 25;
+},
+{
+name = strikeoutPosition;
+value = 280;
+},
+{
+name = strikeoutSize;
+value = 70;
+},
+{
+name = "Master Icon Glyph Name";
+value = n;
+},
+{
+name = paramArea;
+value = 438;
+},
+{
+name = paramDepth;
+value = 14;
+}
+);
+guides = (
+{
+pos = (293,976);
+},
+{
+pos = (301,836);
+}
+);
+iconName = Light;
+id = m019;
+metricValues = (
+{
+pos = 759;
+},
+{
+over = 10;
+pos = 729;
+},
+{
+over = 10;
+pos = 517;
+},
+{
+over = -10;
+},
+{
+over = -10;
+pos = -182;
+},
+{
+}
+);
+name = ExtraLight;
+stemValues = (
+36,
+35,
+36,
+38
+);
+userData = {
+GSOffsetAutoStroke = 1;
+GSOffsetHorizontal = 16;
+GSOffsetKeepCompatible = 1;
+GSOffsetMakeStroke = 1;
+GSOffsetVertical = 17;
+KernOnModels = (
+"quotedblleft A",
+"T o",
+"L Y",
+"A V",
+"T u",
+"seven four",
+"parenleft n",
+"fraction zero.dnom",
+"T i",
+"w quoteright",
+"r s",
+"F i",
+"f o",
+"H colon",
+"one four",
+"o v",
+"P T",
+"O G",
+"hyphen s",
+"l l",
+"l n",
+"s l",
+"f l",
+"f n",
+"f f",
+"r n",
+"v n",
+"n n",
+"o n",
+"l period",
+"l colon",
+"l exclam",
+"l question",
+"l quoteright",
+"l slash",
+"l hyphen",
+"l endash",
+"l underscore",
+"l at",
+"H l",
+"H s",
+"H x",
+"H n",
+"H o",
+"I I",
+"one two",
+"one three",
+"one seven",
+"one one",
+"L H",
+"H Z",
+"E H",
+"H T",
+"H V",
+"H O",
+"H period",
+"H comma",
+"H exclam",
+"one percent",
+"H question",
+"H slash",
+"H hyphen",
+"H endash",
+"H ampersand",
+"one equal",
+"oneinferior zeroinferior",
+"oneinferior twoinferior",
+"oneinferior oneinferior",
+"one.dnom zero.dnom",
+"one.dnom two.dnom",
+"one.dnom one.dnom",
+"one.numr fraction",
+"period period",
+"slash l",
+"hyphen S",
+"endash endash",
+"parenleft l",
+"bracketleft l",
+"parenleft H",
+"parenleft T",
+"equal equal",
+"t t",
+"g j",
+"s hyphen",
+"z v",
+"t v",
+"z z",
+"v v",
+"quotedbl W",
+"T V",
+"lcaron l",
+"E T",
+"A Z"
+);
+};
+},
+{
+axesValues = (
+900,
+0
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 900;
+},
+{
+Axis = "Optical size";
+Location = 0;
+},
+{
+Axis = Italic;
+Location = 0;
+}
+);
+},
+{
+name = hheaAscender;
+value = 1090;
+},
+{
+name = hheaDescender;
+value = -320;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = typoAscender;
+value = 1090;
+},
+{
+name = typoDescender;
+value = -320;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1090;
+},
+{
+name = winDescent;
+value = 320;
+},
+{
+name = underlinePosition;
+value = -140;
+},
+{
+name = underlineThickness;
+value = 160;
+},
+{
+name = strikeoutPosition;
+value = 280;
+},
+{
+name = strikeoutSize;
+value = 70;
+},
+{
+name = "Master Icon Glyph Name";
+value = n;
+},
+{
+name = paramArea;
+value = 290;
+},
+{
+name = paramDepth;
+value = 10;
+}
+);
+iconName = Bold;
+id = m020;
+metricValues = (
+{
+pos = 759;
+},
+{
+over = 10;
+pos = 729;
+},
+{
+over = 10;
+pos = 544;
+},
+{
+over = -10;
+},
+{
+over = -10;
+pos = -182;
+},
+{
+}
+);
+name = Black;
+stemValues = (
+172,
+153,
+191,
+193
+);
+userData = {
+HTLSManagerMasterRules = {
+};
+KernOnModels = (
+"L Y",
+"A V",
+"T o",
+"quotedblleft A",
+"seven four",
+"parenleft n",
+"T u",
+"fraction zero.dnom",
+"o v",
+"T i",
+"w quoteright",
+"parenleft l",
+"l l",
+"l n",
+"s l",
+"f l",
+"f n",
+"f o",
+"r n",
+"r s",
+"z z",
+"v n",
+"o n",
+"n n",
+"l period",
+"l colon",
+"l exclam",
+"l question",
+"l quoteright",
+"l slash",
+"l hyphen",
+"s hyphen",
+"l endash",
+"l underscore",
+"l at",
+"F i",
+"H l",
+"H s",
+"H o",
+"H n",
+"H x",
+"I I",
+"one seven",
+"one three",
+"one four",
+"one one",
+"L H",
+"E H",
+"H T",
+"P T",
+"H V",
+"O G",
+"H O",
+"H period",
+"H colon",
+"H exclam",
+"one percent",
+"H question",
+"H slash",
+"H hyphen",
+"H endash",
+"H ampersand",
+"one equal",
+"oneinferior zeroinferior",
+"oneinferior twoinferior",
+"oneinferior oneinferior",
+"one.dnom zero.dnom",
+"one.dnom two.dnom",
+"one.dnom one.dnom",
+"one.numr fraction",
+"period period",
+"slash l",
+"hyphen s",
+"endash endash",
+"bracketleft l",
+"parenleft H",
+"parenleft T",
+"equal equal",
+"one two",
+"H comma",
+"t v",
+"z v",
+"t t",
+"E T",
+"A Z",
+"hyphen S",
+"H Z",
+"f f",
+"T V",
+"v v",
+"g j",
+"quotedbl W",
+"lcaron l"
+);
+};
+},
+{
+axesValues = (
+200,
+1
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 200;
+},
+{
+Axis = "Optical size";
+Location = 0;
+},
+{
+Axis = Italic;
+Location = 1;
+}
+);
+},
+{
+name = hheaAscender;
+value = 1090;
+},
+{
+name = hheaDescender;
+value = -320;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = typoAscender;
+value = 1090;
+},
+{
+name = typoDescender;
+value = -320;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1090;
+},
+{
+name = winDescent;
+value = 320;
+},
+{
+name = underlinePosition;
+value = -140;
+},
+{
+name = underlineThickness;
+value = 25;
+},
+{
+name = strikeoutPosition;
+value = 280;
+},
+{
+name = strikeoutSize;
+value = 70;
+},
+{
+name = "Master Icon Glyph Name";
+value = n;
+},
+{
+name = paramArea;
+value = 438;
+},
+{
+name = paramDepth;
+value = 14;
+}
+);
+guides = (
+{
+pos = (285,793);
+}
+);
+iconName = Light;
+id = "095FE76F-1953-440B-9108-AA0678D151F9";
+metricValues = (
+{
+pos = 729;
+},
+{
+over = 10;
+pos = 729;
+},
+{
+over = 10;
+pos = 517;
+},
+{
+over = -10;
+},
+{
+pos = -167;
+},
+{
+pos = 11.7;
+}
+);
+name = "ExtraLight Italic";
+stemValues = (
+36,
+35,
+36,
+35
+);
+userData = {
+GSOffsetHorizontal = 20;
+GSOffsetKeepCompatible = 1;
+GSOffsetMakeStroke = 1;
+GSOffsetVertical = 18;
+KernOnModels = (
+"A V",
+"T o",
+"L Y",
+"T u",
+"quotedblleft A",
+"seven four",
+"parenleft n",
+"P T",
+"T i",
+"o v",
+"w quoteright",
+"F i",
+"equal equal",
+"one.dnom zero.dnom",
+"oneinferior zeroinferior",
+"s hyphen",
+"H n",
+"f o",
+"fraction zero.dnom",
+"l n",
+"f n",
+"H o",
+"l l",
+"s l",
+"f l",
+"t t",
+"r n",
+"r s",
+"v n",
+"n n",
+"o n",
+"l period",
+"l colon",
+"l exclam",
+"l question",
+"l quoteright",
+"l slash",
+"l endash",
+"l underscore",
+"l at",
+"H l",
+"H s",
+"H x",
+"I I",
+"one three",
+"one seven",
+"one two",
+"one four",
+"one one",
+"L H",
+"H T",
+"E H",
+"H Z",
+"H V",
+"H O",
+"H period",
+"H comma",
+"H colon",
+"H exclam",
+"one percent",
+"H question",
+"H slash",
+"H hyphen",
+"H endash",
+"H ampersand",
+"one equal",
+"oneinferior twoinferior",
+"oneinferior oneinferior",
+"one.dnom two.dnom",
+"one.dnom one.dnom",
+"one.numr fraction",
+"period period",
+"slash l",
+"hyphen s",
+"endash endash",
+"parenleft l",
+"bracketleft l",
+"parenleft H",
+"g j",
+"E T",
+"hyphen S",
+"z v",
+"l hyphen",
+"parenleft T",
+"quotedbl W",
+"t v",
+"f f",
+"O G",
+"T V",
+"z z",
+"v v",
+"lcaron l",
+"A Z"
+);
+};
+},
+{
+axesValues = (
+900,
+1
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Width;
+Location = 100;
+},
+{
+Axis = Weight;
+Location = 900;
+},
+{
+Axis = "Optical size";
+Location = 0;
+},
+{
+Axis = Italic;
+Location = 1;
+}
+);
+},
+{
+name = hheaAscender;
+value = 1090;
+},
+{
+name = hheaDescender;
+value = -320;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = typoAscender;
+value = 1090;
+},
+{
+name = typoDescender;
+value = -320;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1090;
+},
+{
+name = winDescent;
+value = 320;
+},
+{
+name = underlinePosition;
+value = -140;
+},
+{
+name = underlineThickness;
+value = 160;
+},
+{
+name = strikeoutPosition;
+value = 280;
+},
+{
+name = strikeoutSize;
+value = 70;
+},
+{
+name = "Master Icon Glyph Name";
+value = n;
+},
+{
+name = paramArea;
+value = 290;
+},
+{
+name = paramDepth;
+value = 10;
+}
+);
+guides = (
+{
+angle = 78.1644;
+pos = (-175,729);
+},
+{
+pos = (369,793);
+}
+);
+iconName = Bold;
+id = "63AAE8D6-1DFF-4DD4-BD9A-49272FE52904";
+metricValues = (
+{
+pos = 729;
+},
+{
+over = 10;
+pos = 729;
+},
+{
+over = 10;
+pos = 544;
+},
+{
+over = -10;
+},
+{
+pos = -167;
+},
+{
+pos = 11.7;
+}
+);
+name = "Black Italic";
+stemValues = (
+172,
+153,
+191,
+193
+);
+userData = {
+KernOnModels = (
+"L Y",
+"A V",
+"quotedblleft A",
+"T o",
+"parenleft n",
+"seven four",
+"o v",
+"T u",
+"one percent",
+"T i",
+"P T",
+"fraction zero.dnom",
+"l l",
+"l n",
+"s l",
+"f n",
+"f o",
+"r n",
+"r s",
+"t v",
+"z z",
+"v n",
+"o n",
+"n n",
+"l period",
+"l colon",
+"l exclam",
+"l question",
+"l quoteright",
+"l slash",
+"l hyphen",
+"s hyphen",
+"l endash",
+"l underscore",
+"l at",
+"H l",
+"F i",
+"H s",
+"H o",
+"H n",
+"H x",
+"I I",
+"one two",
+"one seven",
+"one three",
+"one one",
+"one four",
+"L H",
+"E H",
+"H Z",
+"H T",
+"H V",
+"H O",
+"H period",
+"H comma",
+"H colon",
+"H exclam",
+"H question",
+"H slash",
+"H hyphen",
+"H endash",
+"H ampersand",
+"one equal",
+"oneinferior zeroinferior",
+"oneinferior twoinferior",
+"oneinferior oneinferior",
+"one.dnom zero.dnom",
+"one.dnom two.dnom",
+"one.dnom one.dnom",
+"one.numr fraction",
+"period period",
+"slash l",
+"hyphen s",
+"endash endash",
+"parenleft l",
+"bracketleft l",
+"parenleft H",
+"parenleft T",
+"equal equal",
+"z v",
+"f l",
+"t t",
+"E T",
+"A Z",
+"quotedbl W",
+"hyphen S",
+"g j",
+"T V",
+"O G",
+"v v",
+"f f",
+"lcaron l"
+);
+};
+}
+);
+glyphs = (
+{
+glyphname = A;
+kernLeft = KO_A;
+kernRight = KO_A;
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (336,0);
+},
+{
+name = ogonek;
+pos = (630,0);
+},
+{
+name = top;
+pos = (336,729);
+}
+);
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(72,0,l),
+(148,200,l),
+(530,200,l),
+(607,0,l),
+(647,0,l),
+(364,729,l),
+(314,729,l),
+(31,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(271,516,l),
+(338,690,l),
+(342,690,l),
+(408,516,l),
+(517,233,l),
+(161,233,l)
+);
+}
+);
+};
+layerId = m019;
+shapes = (
+{
+closed = 1;
+nodes = (
+(83,0,l),
+(300,605,l),
+(334,696,l),
+(340,696,l),
+(372,605,l),
+(588,0,l),
+(630,0,l),
+(363,729,l),
+(309,729,l),
+(43,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(513,234,l),
+(513,270,l),
+(154,270,l),
+(154,234,l)
+);
+}
+);
+userData = {
+com.schriftgestaltung.hints = (
+{
+horizontal = 1;
+options = 0;
+origin = (
+0,
+7
+);
+stem = -2;
+target = (
+u,
+p
+);
+type = BottomGhost;
+},
+{
+horizontal = 1;
+options = 0;
+origin = (
+1,
+3
+);
+stem = -2;
+target = (
+0,
+1
+);
+type = Stem;
+},
+{
+horizontal = 1;
+options = 0;
+origin = (
+0,
+6
+);
+stem = -2;
+target = (
+1,
+0
+);
+type = Stem;
+}
+);
+};
+width = 670;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (373,0);
+},
+{
+name = ogonek;
+pos = (740,0);
+},
+{
+name = top;
+pos = (373,729);
+}
+);
+background = {
+shapes = (
+{
+closed = 1;
+nodes = (
+(222,0,l),
+(348,431,l),
+(379,547,l),
+(386,547,l),
+(417,431,l),
+(543,0,l),
+(754,0,l),
+(527,729,l),
+(238,729,l),
+(11,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(521,130,l),
+(476,284,l),
+(289,284,l),
+(244,130,l)
+);
+}
+);
+};
+layerId = m020;
+shapes = (
+{
+closed = 1;
+nodes = (
+(219,0,l),
+(346,482,l),
+(367,577,l),
+(379,577,l),
+(400,482,l),
+(527,0,l),
+(740,0,l),
+(520,729,l),
+(230,729,l),
+(10,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(537,155,l),
+(491,314,l),
+(254,314,l),
+(210,155,l)
+);
+}
+);
+width = 750;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (289,0);
+},
+{
+name = ogonek;
+pos = (578,0);
+},
+{
+name = top;
+pos = (428,729);
+}
+);
+layerId = "095FE76F-1953-440B-9108-AA0678D151F9";
+shapes = (
+{
+closed = 1;
+nodes = (
+(19,0,l),
+(363,588,l),
+(420,690,l),
+(423,690,l),
+(442,583,l),
+(540,0,l),
+(578,0,l),
+(452,729,l),
+(404,729,l),
+(-23,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(515,200,l),
+(509,233,l),
+(145,233,l),
+(126,200,l)
+);
+}
+);
+width = 663;
+},
+{
+anchors = (
+{
+name = bottom;
+pos = (357,0);
+},
+{
+name = ogonek;
+pos = (736,0);
+},
+{
+name = top;
+pos = (492,729);
+}
+);
+layerId = "63AAE8D6-1DFF-4DD4-BD9A-49272FE52904";
+shapes = (
+{
+closed = 1;
+nodes = (
+(166,0,l),
+(412,470,l),
+(453,559,l),
+(466,559,l),
+(476,470,l),
+(534,0,l),
+(736,0,l),
+(628,729,l),
+(356,729,l),
+(-46,0,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(530,130,l),
+(516,284,l),
+(296,284,l),
+(222,130,l)
+);
+}
+);
+width = 802;
+}
+);
+unicode = 65;
+userData = {
+KernOnName = A;
+};
+}
+);
+instances = (
+{
+axesValues = (
+0,
+0
+);
+instanceInterpolations = {
+m019 = 1.28571;
+m020 = -0.28571;
+};
+name = Regular;
+},
+{
+axesValues = (
+0,
+1
+);
+instanceInterpolations = {
+"095FE76F-1953-440B-9108-AA0678D151F9" = 1.28571;
+"63AAE8D6-1DFF-4DD4-BD9A-49272FE52904" = -0.28571;
+};
+isItalic = 1;
+name = Italic;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = dflt;
+value = "Copyright 2022 The Mona Sans Project Authors (https://github.com/github/mona-sans), with Reserved Font Name \"Mona\"";
+}
+);
+},
+{
+key = designers;
+values = (
+{
+language = dflt;
+value = "Deni Anggara";
+}
+);
+},
+{
+key = designerURL;
+value = www.degarism.com;
+},
+{
+key = licenses;
+values = (
+{
+language = dflt;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://scripts.sil.org/OFL";
+}
+);
+},
+{
+key = licenseURL;
+value = "https://openfontlicense.org";
+},
+{
+key = manufacturers;
+values = (
+{
+language = dflt;
+value = GitHub;
+}
+);
+},
+{
+key = manufacturerURL;
+value = www.github.com;
+},
+{
+key = vendorID;
+value = GTHB;
+}
+);
+stems = (
+{
+horizontal = 1;
+name = H;
+},
+{
+horizontal = 1;
+name = o;
+},
+{
+name = n;
+},
+{
+name = o;
+}
+);
+unitsPerEm = 1000;
+userData = {
+GSDimensionPlugin.Dimensions = {
+"106FCE83-F343-403B-A314-646E4D059B3F" = {
+HV = "38";
+OH = "36";
+OV = "40";
+nV = "37";
+};
+"1EDCBF6C-9964-4A28-BC87-E86B534B8BE7" = {
+HH = "172";
+HV = "203";
+OH = "172";
+OV = "208";
+nV = "191";
+oH = "153";
+oV = "193";
+};
+"28A8A76A-23B4-40F5-83B9-DC51E48BF161" = {
+HH = "36";
+HV = "38";
+OH = "36";
+OV = "40";
+nV = "37";
+oH = "35";
+oV = "38";
+};
+"2D1A1AFE-39FB-4EBD-856C-88C6B057247F" = {
+HH = "178";
+HV = "229";
+OH = "179";
+OV = "235";
+nV = "221";
+};
+"377EF8AC-8B0D-46C2-96BB-3B5B69A8F571" = {
+HV = "227";
+};
+"5713303B-ED49-44A7-8230-B5CAE56DEB7E" = {
+HH = "30";
+HV = "31";
+OH = "29";
+OV = "33";
+nV = "29";
+oH = "27";
+oV = "29";
+};
+"5A048DDA-4734-4F8A-A53C-0BED34B57D1C" = {
+HV = "38";
+nV = "36";
+oV = "38";
+};
+"71D8B5AD-B400-4239-9672-E7BA455EF2D0" = {
+HV = "31";
+OH = "29";
+OV = "33";
+nV = "30";
+oH = "27";
+oV = "31";
+tH = "27";
+};
+"D2144554-01B8-4B9B-B16A-E0E5B5794DFC" = {
+HH = "178";
+HV = "229";
+OH = "179";
+OV = "230";
+nV = "221";
+oH = "166";
+oV = "220";
+};
+"DED42A87-C949-4722-A202-2B551272A3FB" = {
+HV = "203";
+OH = "172";
+OV = "210";
+nV = "191";
+oV = "193";
+};
+"E787E54A-EE3E-475A-BF02-8501A6DA5144" = {
+HH = "156";
+HV = "184";
+OH = "156";
+OV = "180";
+nV = "177";
+oH = "137";
+oV = "177";
+};
+"FFCA1F59-E305-4E0F-BBF9-E0C4511C19C1" = {
+HV = "186";
+OH = "156";
+OV = "188";
+nV = "177";
+tH = "143";
+};
+m019 = {
+HH = "36";
+HV = "37";
+OH = "36";
+OV = "39";
+nV = "37";
+oV = "38";
+};
+m020 = {
+HH = "172";
+HV = "201";
+OH = "175";
+OV = "206";
+nV = "191";
+oH = "153";
+oV = "195";
+tH = "153";
+};
+master01 = {
+HH = "36";
+HV = "38";
+OH = "36";
+OV = "40";
+nV = "36";
+oH = "35";
+oV = "38";
+};
+};
+KernOnKerningWeightLimit = 48000;
+KernOnRegenerateGroups = 1;
+KernOnVersion = "1.37";
+com.eweracs.HTLSManager.fontRules = {
+Letter = {
+312438f7decf4fc68bcbaca450e03a99 = {
+case = 2;
+filter = "";
+referenceGlyph = x;
+subcategory = Any;
+value = 1;
+};
+6a2d898c1367438986d3a6a56dff674b = {
+case = 1;
+filter = "";
+referenceGlyph = H;
+subcategory = Any;
+value = 1.1;
+};
+};
+Mark = {
+};
+Number = {
+2bd1e700934d48afa4ccdec6e58ec3e7 = {
+case = 4;
+filter = inferior;
+referenceGlyph = oneinferior;
+subcategory = Small;
+value = "1.0";
+};
+55f63e4331df4db2af4078f7d25e7c81 = {
+case = 0;
+filter = fraction;
+referenceGlyph = one.numr;
+subcategory = Fraction;
+value = "1.0";
+};
+83f21c7fa30c4bda82d83ce68797bf1e = {
+case = 4;
+filter = .dnom;
+referenceGlyph = one.dnom;
+subcategory = Fraction;
+value = "1.0";
+};
+ed5cb22a9b09400187c0feacae1f0f8f = {
+case = 0;
+filter = "";
+referenceGlyph = H;
+subcategory = "Decimal DigitalicItalic";
+value = 1.1;
+};
+};
+Punctuation = {
+167668d12cdd4c8893e2ea25c8b50ee7 = {
+case = 0;
+filter = "";
+referenceGlyph = "";
+subcategory = Quote;
+value = 0.8;
+};
+473a79e894d44c599a51e7e1ece63290 = {
+case = 0;
+filter = guil;
+referenceGlyph = "";
+subcategory = Quote;
+value = 1.2;
+};
+4ec998b892f749cda9789e6906484c17 = {
+case = 0;
+filter = comma;
+referenceGlyph = period;
+subcategory = Any;
+value = "0.7";
+};
+9184a8a098a84478838c6fc128ee0a80 = {
+case = 0;
+filter = "";
+referenceGlyph = bracketleft;
+subcategory = Parenthesis;
+value = 1.2;
+};
+9d511a8382cb45d792fdbfdfc50ffffd = {
+case = 1;
+filter = "";
+referenceGlyph = H;
+subcategory = Any;
+value = 1.2;
+};
+9ec58eaef538412db8c6e39bfab814c4 = {
+case = 0;
+filter = colon;
+referenceGlyph = idotless;
+subcategory = Any;
+value = 1.2;
+};
+9f4aa33eabc048148a0062f6007b15aa = {
+case = 1;
+filter = "";
+referenceGlyph = "";
+subcategory = Parenthesis;
+value = 1.2;
+};
+c63f0f2ed1a04e758a366249316b4adc = {
+case = 0;
+filter = "";
+referenceGlyph = "";
+subcategory = Any;
+value = 0.7;
+};
+d38ed0f19582418b87419664ccbaea66 = {
+case = 0;
+filter = numbersign;
+referenceGlyph = "";
+subcategory = Any;
+value = "1";
+};
+};
+Symbol = {
+0fc37ed242184cf0bb4187ff151ca40f = {
+case = 0;
+filter = florin;
+referenceGlyph = idotless;
+subcategory = Currency;
+value = 1;
+};
+29efbbb3c5a14419ae21c4df65fbd7be = {
+case = 0;
+filter = "";
+referenceGlyph = "";
+subcategory = Math;
+value = 1;
+};
+42048483ab514efc835267f63d632f9d = {
+case = 0;
+filter = "";
+referenceGlyph = "";
+subcategory = Any;
+value = 1.3;
+};
+d186e1aee4d04436b206cbedd9f1894d = {
+case = 0;
+filter = "";
+referenceGlyph = H;
+subcategory = Currency;
+value = 1.3;
+};
+};
+};
+};
+versionMajor = 2;
+versionMinor = 22;
+}

--- a/data/test/builder/split_italic/config.yaml
+++ b/data/test/builder/split_italic/config.yaml
@@ -1,0 +1,11 @@
+sources:
+  - TestFamily.glyphs
+familyName: Test Family
+buildVariable: true
+splitItalic: true
+buildWebfont: False
+buildOTF: False
+buildTTF: False
+axisOrder:
+  - wght
+  - ital

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -55,6 +55,14 @@ TEST_DIR = os.path.join(CWD, "..", "data", "test", "builder")
                 ),
             ],
         ),
+        # Testing VF split
+        (
+            os.path.join(TEST_DIR, "split_italic"),
+            [
+                os.path.join("variable", "TestFamily[wght].ttf"),
+                os.path.join("variable", "TestFamily-Italic[wght].ttf"),
+            ],
+        ),
     ],
 )
 def test_builder(fp, font_paths):


### PR DESCRIPTION
My work on adding the fontsetter, #1166 broke the Italic VF split. This PR restores the googlefonts recipe provider to the previous implementation in a4d25179f5d4d794f07e86653821bb8dd1294ed6.

Fixes #1172 