### PR TITLE
builder: add cross-target implicit deps for postprocess steps

### DIFF
--- a/Lib/gftools/builder/__init__.py
+++ b/Lib/gftools/builder/__init__.py
@@ -276,6 +276,18 @@ class GFBuilder:
                         parents = list(self.graph.predecessors(current))
                         previous_edge = self.graph[parents[0]][current]
                         step.implicit = [current]
+                        # Check if postprocess args reference other recipe
+                        # targets (cross-target dependencies). E.g. gen-stat
+                        # may need both the upright and italic variants built.
+                        args_str = step.original.get("args", "")
+                        for recipe_target in self.recipe:
+                            if (
+                                recipe_target in args_str
+                                and recipe_target != target.path
+                            ):
+                                dep_file = self.named_files.get(recipe_target)
+                                if dep_file and dep_file not in step.implicit:
+                                    step.implicit.append(dep_file)
                         self.graph.add_edge(current, binary, operation=step)
                     else:
                         step.set_source(previous)

--- a/Lib/gftools/builder/operations/instantiateUfo.py
+++ b/Lib/gftools/builder/operations/instantiateUfo.py
@@ -65,7 +65,7 @@ class InstantiateUFO(FontmakeOperationBase):
             vars["args"] += f"--instance-dir {escape_path(str(self.instance_dir))}"
         else:
             vars["args"] += f"--output-dir {escape_path(str(self.instance_dir))}"
-        vars["instance_name"] = escape(self.original['instance_name'])
+        vars["instance_name"] = escape(self.original["instance_name"])
         if self.original.get("glyphData") is not None:
             for glyphData in self.original["glyphData"]:
                 vars["args"] += f" --glyph-data {escape_path(glyphData)}"

--- a/Lib/gftools/builder/operations/instantiateUfo.py
+++ b/Lib/gftools/builder/operations/instantiateUfo.py
@@ -7,7 +7,7 @@ import os
 import gftools.builder
 from functools import cached_property
 from glyphsLib.builder import UFOBuilder
-from ninja.ninja_syntax import Writer, escape_path
+from ninja.ninja_syntax import Writer, escape_path, escape
 from fontTools.designspaceLib import InstanceDescriptor
 
 
@@ -65,7 +65,7 @@ class InstantiateUFO(FontmakeOperationBase):
             vars["args"] += f"--instance-dir {escape_path(str(self.instance_dir))}"
         else:
             vars["args"] += f"--output-dir {escape_path(str(self.instance_dir))}"
-        vars["instance_name"] = self.original["instance_name"]
+        vars["instance_name"] = escape(self.original['instance_name'])
         if self.original.get("glyphData") is not None:
             for glyphData in self.original["glyphData"]:
                 vars["args"] += f" --glyph-data {escape_path(glyphData)}"


### PR DESCRIPTION
Zalando Sans has custom recipe targets that call `gftools gen-stat`, https://github.com/zalando/sans/blob/main/sources/config.yaml#L79-L81. Currently, it crashes because `gen-stat` attempts to use fonts that haven't been generated yet.