### PR TITLE
fix-font: add flag to skip rewriting fvar instances

### DIFF
--- a/Lib/gftools/fix.py
+++ b/Lib/gftools/fix.py
@@ -878,11 +878,12 @@ def fix_no_varpsname(ttFont: TTFont) -> FixResult:
 
 
 def fix_font(
-    font,
-    include_source_fixes=False,
-    new_family_name=None,
-    fvar_instance_axis_dflts=None,
-):
+    font: TTFont,
+    include_source_fixes: bool = False,
+    new_family_name: str | None = None,
+    fvar_instance_axis_dflts: dict[str, float] | None = None,
+    overwrite_fvar_instances: bool = True,
+) -> TTFont:
     fixed_font = deepcopy(font)
     if new_family_name:
         rename_font(fixed_font, new_family_name)
@@ -919,7 +920,8 @@ def fix_font(
         if messages:
             log.info("\n".join(messages))
 
-    fix_fvar_instances(fixed_font, fvar_instance_axis_dflts)
+    if overwrite_fvar_instances:
+        fix_fvar_instances(fixed_font, fvar_instance_axis_dflts)
     return fixed_font
 
 

--- a/Lib/gftools/scripts/fix_font.py
+++ b/Lib/gftools/scripts/fix_font.py
@@ -39,6 +39,12 @@ def main(args=None):
             "wdth=100 opsz=36"
         ),
     )
+    parser.add_argument(
+        "--skip-fvar-instances",
+        dest="overwrite_fvar_instances",
+        action="store_false",
+        help="don't re-write fvar instances",
+    )
     args = parser.parse_args(args)
 
     font = TTFont(args.font)
@@ -47,7 +53,13 @@ def main(args=None):
         axis_dflts = parse_axis_dflts(args.fvar_instance_axis_dflts)
     else:
         axis_dflts = None
-    font = fix_font(font, args.include_source_fixes, args.rename_family, axis_dflts)
+    font = fix_font(
+        font,
+        args.include_source_fixes,
+        args.rename_family,
+        axis_dflts,
+        args.overwrite_fvar_instances,
+    )
 
     if args.out:
         font.save(args.out)

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -581,7 +581,7 @@ def read_proto(fp, schema):
     return data
 
 
-def parse_axis_dflts(string):
+def parse_axis_dflts(string: str) -> dict[str, float]:
     axes = string.split()
     res = {}
     for axis in axes:


### PR DESCRIPTION
The family I'm migrating to gftools doesn't want to change its instances, but the `fix` operation has other useful goodies so I thought I'd just make this one bit configurable so it would suit our use case.

The ninja template already passes through `$args` so no changes are required in builder land, it just works!

The type hint fairy also came and sprinkled in some goodness ✨

(P.S.: if this could get a release if merged, that would be awesome, thanks!)