### PR TITLE
`subsetmerger.py`: use `filelock` to prevent race condition while downloading

### DIFF
--- a/Lib/gftools/subsetmerger.py
+++ b/Lib/gftools/subsetmerger.py
@@ -12,6 +12,7 @@ from zipfile import ZipFile
 
 import ufoLib2
 import yaml
+from filelock import FileLock
 from fontmake.font_project import FontProject
 from fontTools.designspaceLib import (
     DesignSpaceDocument,
@@ -394,6 +395,11 @@ class SubsetMerger:
                 font_name = os.path.basename(upstream)
             else:
                 raise ValueError("Unknown subsetting font %s" % upstream)
+            lockfile_path = os.path.join(
+                upstream,
+                os.path.pardir,
+                f".gftools_subsetmerger_{upstream.replace('/', '_')}.lock",
+            )
         else:
             if isinstance(upstream, str):
                 repo, path = SUBSET_SOURCES[upstream]
@@ -416,11 +422,16 @@ class SubsetMerger:
                 path = upstream["path"]
                 font_name = f"{repo}/{ref}/{path}"
             path = os.path.join(self.cache_dir, repo, ref, path)
+            lockfile_path = os.path.join(
+                self.cache_dir,
+                f".gftools_subsetmerger_{repo.replace('/', '_')}_{ref.replace('/', '_')}.lock",
+            )
 
-        if os.path.exists(path):
-            logger.info("Subset files present on disk, skipping download")
-        else:
-            self.download_for_subsetting(repo, ref)
+        with FileLock(lockfile_path):
+            if os.path.exists(path):
+                logger.info("Subset files present on disk, skipping download")
+            else:
+                self.download_for_subsetting(repo, ref)
 
         # We're doing a UFO-UFO merge, so Glyphs files will need to be converted
         if path.endswith((".glyphs", ".glyphspackage")):

--- a/Lib/gftools/subsetmerger.py
+++ b/Lib/gftools/subsetmerger.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Literal, NamedTuple, Union
 from zipfile import ZipFile
+from filelock import FileLock
 
 import ufoLib2
 import yaml
-from filelock import FileLock
 from fontmake.font_project import FontProject
 from fontTools.designspaceLib import (
     DesignSpaceDocument,
@@ -395,11 +395,6 @@ class SubsetMerger:
                 font_name = os.path.basename(upstream)
             else:
                 raise ValueError("Unknown subsetting font %s" % upstream)
-            lockfile_path = os.path.join(
-                upstream,
-                os.path.pardir,
-                f".gftools_subsetmerger_{upstream.replace('/', '_')}.lock",
-            )
         else:
             if isinstance(upstream, str):
                 repo, path = SUBSET_SOURCES[upstream]
@@ -422,16 +417,16 @@ class SubsetMerger:
                 path = upstream["path"]
                 font_name = f"{repo}/{ref}/{path}"
             path = os.path.join(self.cache_dir, repo, ref, path)
+            
             lockfile_path = os.path.join(
                 self.cache_dir,
                 f".gftools_subsetmerger_{repo.replace('/', '_')}_{ref.replace('/', '_')}.lock",
             )
-
-        with FileLock(lockfile_path):
-            if os.path.exists(path):
-                logger.info("Subset files present on disk, skipping download")
-            else:
-                self.download_for_subsetting(repo, ref)
+            with FileLock(lockfile_path):
+                if os.path.exists(path):
+                    logger.info("Subset files present on disk, skipping download")
+                else:
+                    self.download_for_subsetting(repo, ref)
 
         # We're doing a UFO-UFO merge, so Glyphs files will need to be converted
         if path.endswith((".glyphs", ".glyphspackage")):

--- a/Lib/gftools/subsetmerger.py
+++ b/Lib/gftools/subsetmerger.py
@@ -417,7 +417,7 @@ class SubsetMerger:
                 path = upstream["path"]
                 font_name = f"{repo}/{ref}/{path}"
             path = os.path.join(self.cache_dir, repo, ref, path)
-            
+
             lockfile_path = os.path.join(
                 self.cache_dir,
                 f".gftools_subsetmerger_{repo.replace('/', '_')}_{ref.replace('/', '_')}.lock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dependencies = [
   # We are migrating to tomllib from configparser. For pre-3.11 Python versions,
   # we need to install tomli.
   'tomli; python_version < "3.11"',
+  "filelock>=3.20.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #1181 

`filelock` is already a transitive dependency, so this isn't adding a new dependency.

I moved the download code path under the original conditional as in the `isinstance(upstream, str) and upstream not in SUBSET_SOURCES` branch, the file's existence has already been checked and the download is never needed, and so we don't need a lockfile. This also fixes "potentially unbound variable" lints for `repo` & `ref`.