### PR TITLE
deps: drop unused packages and bump diffenator2 to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dependencies = [
   'fontmake[json]>=3.3.0',
   'PyYAML',
   'ttfautohint-py',
+  # Not imported directly, but fontTools loads it lazily for woff2 compression
+  # (invoked by gftools-builder via `fonttools ttLib.woff2 compress`).
+  'brotli',
   'jinja2',
   'fontFeatures',
   'vharfbuzz',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,19 +51,12 @@ dependencies = [
   'pygit2>=1.16.0',
   'strictyaml',
   'fontmake[json]>=3.3.0',
-  'skia-pathops',
-  'statmake',
   'PyYAML',
-  'babelfont',
   'ttfautohint-py',
-  'brotli',
   'jinja2',
   'fontFeatures',
   'vharfbuzz',
-  'bumpfontversion',
   'nanoemoji>=0.15.0',
-  'font-v',
-  'afdko',
   'beautifulsoup4',
   'rich',
   'packaging',
@@ -83,7 +76,7 @@ dependencies = [
 [project.optional-dependencies]
 qa = [
   "fontbakery[googlefonts]",
-  "diffenator2>=0.2.0",
+  "diffenator2>=0.5.0", # earlier versions cap unicodedata2<16 and import pkg_resources
   "pycairo", # needed for fontTools varLib.interpolatable --pdf
 ]
 test = [


### PR DESCRIPTION
Drops 7 deps not imported anywhere or used as subprocesses: skia-pathops, statmake, babelfont, brotli, bumpfontversion, font-v, afdko. Bumps diffenator2>=0.5.0 in [qa] (older versions cap unicodedata2<16 and import pkg_resources, which setuptools 81+ removed).