### PR TITLE
builder: recognise .ufoz (zipped UFO) sources

### DIFF
--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -38,9 +38,7 @@ class File:
     @property
     def is_ufo(self):
         # ".ufoz" is a zipped UFO; ufoLib2 (via open_ufo) reads it like a UFO.
-        return (
-            self.extension in ("ufo", "ufoz") or ".ufo.json" in self.path
-        )
+        return self.extension in ("ufo", "ufoz") or ".ufo.json" in self.path
 
     @property
     def is_designspace(self):

--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -37,7 +37,10 @@ class File:
 
     @property
     def is_ufo(self):
-        return self.extension == "ufo" or ".ufo.json" in self.path
+        # ".ufoz" is a zipped UFO; ufoLib2 (via open_ufo) reads it like a UFO.
+        return (
+            self.extension in ("ufo", "ufoz") or ".ufo.json" in self.path
+        )
 
     @property
     def is_designspace(self):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -133,3 +133,23 @@ def test_bad_configs():
     config = {"Sources": ["foo.glyphs"]}
     with pytest.raises(ValueError):
         GFBuilder(config)
+
+
+def test_ufoz_is_a_ufo_source(tmp_path):
+    # A ".ufoz" (zipped UFO) must be recognised as a buildable UFO source; before
+    # this it was not is_font_source and File.family_name crashed.
+    import ufoLib2
+
+    from gftools.builder.file import File
+
+    ufoz = tmp_path / "MyFont.ufoz"
+    font = ufoLib2.Font()
+    font.info.familyName = "My Font"
+    font.newGlyph("a")
+    font.save(ufoz, structure="zip")
+
+    f = File(str(ufoz))
+    assert f.is_ufo
+    assert f.is_font_source
+    assert not f.is_variable  # a single zipped UFO is a static master
+    assert f.family_name == "My Font"


### PR DESCRIPTION
`File.is_ufo` only matched an exact `.ufo` extension, so a `.ufoz` (zipped UFO) source was not is_font_source and `File.family_name` crashed with **AttributeError (designspace is None)**. Accept the "ufoz" extension too; `open_ufo()` and fontmake already read `.ufoz`, and the recipe providers / fontc operation pass the source path through unchanged. Behaviour is unchanged for every other extension.

Verified: new unit test (a generated `.ufoz` is a UFO source and resolves a family name) and `gftools builder --generate` on a real `.ufoz` config now emits a correct recipe instead of crashing.