### PR TITLE
Manage-traffic-jam crashes on closed-but-not-merged PRs ('NoneType' object is not subscriptable)

### DIFF
--- a/Lib/gftools/push/trafficjam.py
+++ b/Lib/gftools/push/trafficjam.py
@@ -532,6 +532,11 @@ class PushItems(list):
 
             # get files for prs which have more than 100 changed files
             for item in board_items:
+                # Closed-but-not-merged PRs are skipped further down anyway, and
+                # GitHub returns ``files: null`` for them, which makes the
+                # ``totalCount`` lookup below raise. Skip them here as well.
+                if item["content"]["closed"] and not item["content"]["merged"]:
+                    continue
                 changed_files = item["content"]["files"]["totalCount"]
                 if changed_files <= 100:
                     continue


### PR DESCRIPTION
### Problem
When the Traffic Jam board contains a pull request that is closed but not merged, `PushItems.from_traffic_jam` crashes with:
```
File ".../gftools/push/trafficjam.py", line 535, in from_traffic_jam
    changed_files = item["content"]["files"]["totalCount"]
TypeError: 'NoneType' object is not subscriptable
```
For such PRs, the GitHub GraphQL API returns `content.files == null`, so indexing `["totalCount"]` on it fails. The crash is reported as a bare CRITICAL 'NoneType' object is not subscriptable unless --show-tracebacks is used, which makes it hard to diagnose.
The board already intends to ignore these PRs: the later result-building loop skips them with if item["content"]["closed"] and not item["content"]["merged"]: continue. The problem is only that the changed_files loop runs before that check and processes every item, including the closed-unmerged ones.

### Example
PR [google/fonts#10574](https://github.com/google/fonts/pull/10574) was closed without being merged but its card was still on the board. It doesn't show up under "PR Merged", so it's easy to miss, and it returned files: null, taking the whole run down.

### Fix
Apply the same closed and not merged guard at the top of the changed_files loop, so these PRs are skipped consistently and never reach the files lookup.