### PR TITLE
Avoid loading Glyphspackage sources with glyphslib where possible

### DIFF
--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
+from typing import Any
 
 import openstep_plist
 from fontTools.designspaceLib import InstanceDescriptor
@@ -68,11 +69,9 @@ class File:
             # accessing self.gsfont, instead just reach into the fontinfo.plist
             # directly.
             # Conditions match the ordinary Glyphs ones below.
-            fontinfo_path = Path(self.path) / "fontinfo.plist"
-            fontinfo = openstep_plist.load(fontinfo_path.open(encoding="utf-8"))
-            return len(fontinfo["fontMaster"]) > 1 or any(
+            return len(self.glyphspackage_fontinfo["fontMaster"]) > 1 or any(
                 custom_parameter["name"] == "Virtual Master"
-                for custom_parameter in fontinfo["customParameters"]
+                for custom_parameter in self.glyphspackage_fontinfo["customParameters"]
             )
         # Glyphs may have a "virtual master"
         masters = len(self.gsfont.masters)
@@ -87,6 +86,17 @@ class File:
 
             return glyphsLib.load(self.path)
         return None
+
+    @cached_property
+    def glyphspackage_fontinfo(self) -> dict[str, Any]:
+        """Grants raw dictly-typed access to a Glyphspackage's fontinfo.plist to
+        avoid loading the full font through glyphsLib"""
+
+        assert self.is_glyphspackage, (
+            "File.glyphspackage_fontinfo should not be accessed on non-glyphspackage sources"
+        )
+        fontinfo_path = Path(self.path) / "fontinfo.plist"
+        return openstep_plist.load(fontinfo_path.open(encoding="utf-8"))
 
     @cached_property
     def designspace(self):

--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -121,8 +121,12 @@ class File:
     @cached_property
     def family_name(self):
         # Figure out target name
-        if self.is_glyphs:
+        if self.is_glyphs_file:
             name = self.gsfont.familyName
+        elif self.is_glyphspackage:
+            # Optimisation: pull this directly from the fontinfo.plist instead
+            # of potentially loading the whole font with glyphsLib
+            name = self.glyphspackage_fontinfo["familyName"]
         elif self.is_ufo:
             ufo = open_ufo(self.path)
             name = ufo.info.familyName

--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -64,20 +64,18 @@ class File:
             return len(self.designspace.sources) > 1
         if self.is_ufo:
             return False
-        if self.is_glyphspackage:
-            # Optimisation opportunity: avoid loading the full GSFont by
-            # accessing self.gsfont, instead just reach into the fontinfo.plist
-            # directly.
-            # Conditions match the ordinary Glyphs ones below.
-            return len(self.glyphspackage_fontinfo["fontMaster"]) > 1 or any(
-                custom_parameter["name"] == "Virtual Master"
-                for custom_parameter in self.glyphspackage_fontinfo["customParameters"]
-            )
-        # Glyphs may have a "virtual master"
-        masters = len(self.gsfont.masters)
-        if any("Virtual Master" == c.name for c in self.gsfont.customParameters):
-            masters += 1
-        return masters > 1
+        # Deal with Glyphs sources in their raw plist form to save parsing with
+        # glyphsLib, which is far slower
+        if self.is_glyphs_file:
+            glyphs_fontinfo = self.glyphs_plist
+        elif self.is_glyphspackage:
+            glyphs_fontinfo = self.glyphspackage_fontinfo
+        else:
+            raise ValueError(f"unsure how to determine if {self.path} is variable")
+        return len(glyphs_fontinfo["fontMaster"]) > 1 or any(
+            custom_parameter["name"] == "Virtual Master"
+            for custom_parameter in glyphs_fontinfo["customParameters"]
+        )
 
     @cached_property
     def gsfont(self):
@@ -88,9 +86,19 @@ class File:
         return None
 
     @cached_property
+    def glyphs_plist(self) -> dict[str, Any]:
+        """Grants raw dictly-typed access to a Glyphs to avoid parsing the full
+        font with glyphsLib"""
+
+        assert self.is_glyphs_file, (
+            "File.glyphs_plist should not be accessed on non-glyphs single file sources"
+        )
+        return openstep_plist.load(open(self.path, encoding="utf-8"))
+
+    @cached_property
     def glyphspackage_fontinfo(self) -> dict[str, Any]:
         """Grants raw dictly-typed access to a Glyphspackage's fontinfo.plist to
-        avoid loading the full font through glyphsLib"""
+        avoid parsing the full font with glyphsLib"""
 
         assert self.is_glyphspackage, (
             "File.glyphspackage_fontinfo should not be accessed on non-glyphspackage sources"
@@ -122,10 +130,12 @@ class File:
     def family_name(self):
         # Figure out target name
         if self.is_glyphs_file:
-            name = self.gsfont.familyName
+            # Optimisation: pull directly from source instead of parsing with
+            # glyphsLib
+            name = self.glyphs_plist["familyName"]
         elif self.is_glyphspackage:
             # Optimisation: pull this directly from the fontinfo.plist instead
-            # of potentially loading the whole font with glyphsLib
+            # of parsing with glyphsLib
             name = self.glyphspackage_fontinfo["familyName"]
         elif self.is_ufo:
             ufo = open_ufo(self.path)

--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -58,6 +58,15 @@ class File:
     def is_glyphspackage(self):
         return self.extension == "glyphspackage"
 
+    @property
+    def glyphs_format(self) -> int:
+        if self.is_glyphs_file:
+            return self.glyphs_plist.get(".formatVersion", 2)
+        elif self.is_glyphspackage:
+            return self.glyphspackage_fontinfo.get(".formatVersion", 2)
+        else:
+            raise ValueError("File.glyphs_format should not be accessed on non-Glyphs sources")
+
     @cached_property
     def is_variable(self) -> bool:
         if self.is_designspace:
@@ -72,6 +81,7 @@ class File:
             glyphs_fontinfo = self.glyphspackage_fontinfo
         else:
             raise ValueError(f"unsure how to determine if {self.path} is variable")
+        # Fine for Glyphs v2 & v3
         return len(glyphs_fontinfo["fontMaster"]) > 1 or any(
             custom_parameter["name"] == "Virtual Master"
             for custom_parameter in glyphs_fontinfo["customParameters"]
@@ -88,7 +98,9 @@ class File:
     @cached_property
     def glyphs_plist(self) -> dict[str, Any]:
         """Grants raw dictly-typed access to a Glyphs to avoid parsing the full
-        font with glyphsLib"""
+        font with glyphsLib.
+        
+        Note that this could be either Glyphs format v2 or v3."""
 
         assert self.is_glyphs_file, (
             "File.glyphs_plist should not be accessed on non-glyphs single file sources"
@@ -132,6 +144,7 @@ class File:
         if self.is_glyphs_file:
             # Optimisation: pull directly from source instead of parsing with
             # glyphsLib
+            # Fine for Glyphs v2 & v3
             name = self.glyphs_plist["familyName"]
         elif self.is_glyphspackage:
             # Optimisation: pull this directly from the fontinfo.plist instead

--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -1,8 +1,9 @@
 import os
 from dataclasses import dataclass
 from functools import cached_property
+from pathlib import Path
 
-import ufoLib2
+import openstep_plist
 from fontTools.designspaceLib import InstanceDescriptor
 from glyphsLib.builder import UFOBuilder
 
@@ -33,7 +34,7 @@ class File:
 
     @property
     def is_glyphs(self):
-        return self.extension == "glyphs" or self.extension == "glyphspackage"
+        return self.is_glyphs_file or self.is_glyphspackage
 
     @property
     def is_ufo(self):
@@ -48,12 +49,31 @@ class File:
     def is_font_source(self):
         return self.is_glyphs or self.is_ufo or self.is_designspace
 
+    @property
+    def is_glyphs_file(self):
+        return self.extension == "glyphs"
+
+    @property
+    def is_glyphspackage(self):
+        return self.extension == "glyphspackage"
+
     @cached_property
     def is_variable(self) -> bool:
         if self.is_designspace:
             return len(self.designspace.sources) > 1
         if self.is_ufo:
             return False
+        if self.is_glyphspackage:
+            # Optimisation opportunity: avoid loading the full GSFont by
+            # accessing self.gsfont, instead just reach into the fontinfo.plist
+            # directly.
+            # Conditions match the ordinary Glyphs ones below.
+            fontinfo_path = Path(self.path) / "fontinfo.plist"
+            fontinfo = openstep_plist.load(fontinfo_path.open(encoding="utf-8"))
+            return len(fontinfo["fontMaster"]) > 1 or any(
+                custom_parameter["name"] == "Virtual Master"
+                for custom_parameter in fontinfo["customParameters"]
+            )
         # Glyphs may have a "virtual master"
         masters = len(self.gsfont.masters)
         if any("Virtual Master" == c.name for c in self.gsfont.customParameters):

--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -163,7 +163,15 @@ class GFBuilder(RecipeProviderBase):
         sourcebase = os.path.splitext(source.basename)[0]
         if source.is_glyphs_file:
             # Optimisation: avoid parsing the full GSFont here
-            tags = [ax["tag"] for ax in source.glyphs_plist["axes"]]
+            if source.glyphs_format >= 3:
+                tags = [ax["tag"] for ax in source.glyphs_plist["axes"]]
+            else:
+                axes = next(
+                    param["value"]
+                    for param in source.glyphs_plist["customParameters"]
+                    if param["name"] == "Axes"
+                )
+                tags = [axis["Tag"] for axis in axes]
         elif source.is_glyphspackage:
             # Optimisation: avoid parsing the full GSFont here when what we need
             # is within the fontinfo.plist

--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -162,7 +162,8 @@ class GFBuilder(RecipeProviderBase):
         """Determine the file name for a variable font."""
         sourcebase = os.path.splitext(source.basename)[0]
         if source.is_glyphs_file:
-            tags = [ax.axisTag for ax in source.gsfont.axes]
+            # Optimisation: avoid parsing the full GSFont here
+            tags = [ax["tag"] for ax in source.glyphs_plist["axes"]]
         elif source.is_glyphspackage:
             # Optimisation: avoid parsing the full GSFont here when what we need
             # is within the fontinfo.plist

--- a/Lib/gftools/builder/recipeproviders/googlefonts.py
+++ b/Lib/gftools/builder/recipeproviders/googlefonts.py
@@ -161,8 +161,12 @@ class GFBuilder(RecipeProviderBase):
     ):
         """Determine the file name for a variable font."""
         sourcebase = os.path.splitext(source.basename)[0]
-        if source.is_glyphs:
+        if source.is_glyphs_file:
             tags = [ax.axisTag for ax in source.gsfont.axes]
+        elif source.is_glyphspackage:
+            # Optimisation: avoid parsing the full GSFont here when what we need
+            # is within the fontinfo.plist
+            tags = [ax["tag"] for ax in source.glyphspackage_fontinfo["axes"]]
         elif source.is_designspace:
             tags = [ax.tag for ax in source.designspace.axes]
         else:


### PR DESCRIPTION
For large projects using the fontc compiler, having to load the font with glyphsLib to check if the font is variable and get the axis tags was a significant proportion of total build time. By just reaching into the fontinfo.plist directly with `openstep_plist`, I reduced a 4 minute build down to a 50 seconds. Admittedly, this font is monstrous, and I'm currently working on a laptop instead of my usual desktop, so the difference is likely to be a lot less prominent for other users. My hope would be that for smaller fonts or projects that do end up needing glyphsLib anyway - thus meaning my approach will have actually added overhead - that this slowdown is negligible.

I understand that most/all of this code is likely to get overwritten by builder 3, but I just wrote it to keep myself entertained while watching CI jobs spin; I don't mind if it's relatively short-lived.

In summary, this PR avoids using glyphsLib to check if a font is variable and read its axis tags, because doing so allows a font compiled with fontc to never need to load the font with glyphsLib, saving time.