### PR TITLE
Ensure `File.glyphs_format` is always an int

### DIFF
--- a/Lib/gftools/builder/file.py
+++ b/Lib/gftools/builder/file.py
@@ -61,9 +61,9 @@ class File:
     @property
     def glyphs_format(self) -> int:
         if self.is_glyphs_file:
-            return self.glyphs_plist.get(".formatVersion", 2)
+            return int(self.glyphs_plist.get(".formatVersion", 2))
         elif self.is_glyphspackage:
-            return self.glyphspackage_fontinfo.get(".formatVersion", 2)
+            return int(self.glyphspackage_fontinfo.get(".formatVersion", 2))
         else:
             raise ValueError(
                 "File.glyphs_format should not be accessed on non-Glyphs sources"


### PR DESCRIPTION
I think this should fix the test failures after merging #1198. I guess `openstep_plist` is sometimes loading the value as a string? Since strings can be unquoted I guess that's plausible, so I've chucked an `int` cast around reading `.formatVersion`.

It's a shame tests can't run on PRs - I hadn't realised.