### PR TITLE
Fix gftools-qa

### DIFF
--- a/Lib/gftools/qa.py
+++ b/Lib/gftools/qa.py
@@ -3,13 +3,36 @@ import os
 from pathlib import Path
 import subprocess
 import traceback
-from typing import List, Sequence
+from typing import List, Optional, Sequence
 
 from gftools.gfgithub import GitHubClient
 from gftools.utils import mkdir
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+def has_interpolatable() -> bool:
+    """Check if the interpolatable tool is available."""
+    try:
+        subprocess.run(
+            ["interpolatable", "--version"], check=True, stdout=subprocess.PIPE
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def is_variable(font_path: str) -> bool:
+    """Check if the font is a variable font."""
+    try:
+        from fontTools.ttLib import TTFont
+
+        with TTFont(font_path) as font:
+            return "fvar" in font
+    except Exception as e:
+        logger.warning(f"Failed to check if {font_path} is a variable font: {e}")
+        return False
 
 
 def report_exceptions(meth):
@@ -26,7 +49,7 @@ def report_exceptions(meth):
     return safe_call
 
 
-def all_relevant_files(fonts: Sequence[DFont]) -> List[str]:
+def all_relevant_files(fonts: Sequence[str]) -> List[str]:
     """Returns a list of all relevant files for the given fonts."""
     files = []
     relevant_globs = [
@@ -38,7 +61,7 @@ def all_relevant_files(fonts: Sequence[DFont]) -> List[str]:
     ]
 
     for font in fonts:
-        path = Path(font.path)
+        path = Path(font)
         files.append(str(path))
         for glob in relevant_globs:
             for file in path.parent.glob(glob):
@@ -48,7 +71,15 @@ def all_relevant_files(fonts: Sequence[DFont]) -> List[str]:
 
 
 class FontQA:
-    def __init__(self, fonts, fonts_before=None, out="out", url=None):
+    def __init__(
+        self,
+        fonts: List[str],
+        fonts_before: Optional[List[str]] = None,
+        out="out",
+        url=None,
+    ):
+        if fonts_before is None:
+            fonts_before = []
         self.fonts = fonts
         self.fonts_before = fonts_before
         self.out = out
@@ -56,15 +87,15 @@ class FontQA:
         self.has_error = False
 
     @report_exceptions
-    def diffenator3(self, **kwargs):
+    def diffenator3(self):
         logger.info("Running Diffenator3")
         if not self.fonts_before:
             logger.warning("Cannot run Diffenator since there are no fonts before")
             return
         assert len(self.fonts) >= len(self.fonts_before)
         for f, f_before in zip(
-            sorted([f.path for f in self.fonts]),
-            sorted([f.path for f in self.fonts_before]),
+            sorted(self.fonts),
+            sorted(self.fonts_before),
         ):
             cmd = [
                 "diffenator3",
@@ -76,13 +107,13 @@ class FontQA:
                 f_before,
                 f,
             ]
-            process = subprocess.run(cmd)
+            process = subprocess.run(cmd, check=False)
             if process.returncode != 0:
                 self.has_error = True
                 return
 
     @report_exceptions
-    def diffbrowsers(self, imgs=False):
+    def diffbrowsers(self):
         logger.info("Running Diffbrowsers")
         if not self.fonts_before:
             logger.warning("Cannot run diffbrowsers since there are no fonts before")
@@ -91,8 +122,8 @@ class FontQA:
         mkdir(dst)
         assert len(self.fonts) >= len(self.fonts_before)
         for f, f_before in zip(
-            sorted([f.path for f in self.fonts]),
-            sorted([f.path for f in self.fonts_before]),
+            sorted(self.fonts),
+            sorted(self.fonts_before),
         ):
             cmd = [
                 "diff3proof",
@@ -101,7 +132,7 @@ class FontQA:
                 f_before,
                 f,
             ]
-            process = subprocess.run(cmd)
+            process = subprocess.run(cmd, check=False)
             if process.returncode != 0:
                 self.has_error = True
             os.rename(
@@ -111,7 +142,7 @@ class FontQA:
         return
 
     @report_exceptions
-    def proof(self, imgs=False):
+    def proof(self):
         logger.info("Running proofing tools")
         dst = os.path.join(self.out, "Proof")
         mkdir(dst)
@@ -120,12 +151,12 @@ class FontQA:
                 "diff3proof",
                 "--output",
                 dst,
-                font.path,
+                font,
             ]
-            process = subprocess.run(cmd)
+            process = subprocess.run(cmd, check=False)
             os.rename(
                 os.path.join(dst, "diff3proof.html"),
-                os.path.join(dst, f"diff3proof-{Path(font.path).stem}.html"),
+                os.path.join(dst, f"diff3proof-{Path(font).stem}.html"),
             )
 
             if process.returncode != 0:
@@ -135,20 +166,20 @@ class FontQA:
     @report_exceptions
     def interpolations(self):
         dst = os.path.join(self.out, "Interpolations")
-        if not any(f.is_variable() for f in self.fonts):
+        if not any(is_variable(f) for f in self.fonts):
             return
         mkdir(dst)
         for font in self.fonts:
-            font_dst = os.path.join(dst, f"{os.path.basename(font.path[:-4])}.pdf")
-            if not font.is_variable():
+            font_dst = os.path.join(dst, f"{os.path.basename(font[:-4])}.pdf")
+            if not is_variable(font):
                 continue
-            if rust:
-                cmd = ["interpolatable", font.path, "--pdf", font_dst]
+            if has_interpolatable():
+                cmd = ["interpolatable", font, "--pdf", font_dst]
             else:
                 cmd = [
                     "fonttools",
                     "varLib.interpolatable",
-                    font.path,
+                    self.fonts,
                     "--pdf",
                     font_dst,
                 ]
@@ -161,7 +192,7 @@ class FontQA:
         mkdir(out)
         cmd = (
             ["fontbakery", "check-" + profile, "-l", "INFO", "--succinct"]
-            + [f.path for f in self.fonts]
+            + [f for f in self.fonts]
             + ["-C"]
             + ["--ghmarkdown", os.path.join(out, "report.md")]
             + ["-e", "FATAL"]
@@ -170,7 +201,7 @@ class FontQA:
             cmd.extend(["--html", os.path.join(out, "report.html")])
         if extra_args:
             cmd.extend(extra_args)
-        process = subprocess.run(cmd)
+        process = subprocess.run(cmd, check=False)
 
         fontbakery_report = os.path.join(self.out, "Fontbakery", "report.md")
         if not os.path.isfile(fontbakery_report):
@@ -178,7 +209,7 @@ class FontQA:
                 "Cannot Post Github message because no Fontbakery report exists"
             )
             return
-        with open(fontbakery_report) as doc:
+        with open(fontbakery_report, encoding="utf8") as doc:
             msg = doc.read()
             self.post_to_github(msg)
 
@@ -208,7 +239,7 @@ class FontQA:
             cmd.extend(["--html", os.path.join(out, "report.html")])
         if extra_args:
             cmd.extend(extra_args)
-        process = subprocess.run(cmd)
+        process = subprocess.run(cmd, check=False)
 
         fontspector_report = os.path.join(self.out, "Fontspector", "report.md")
         if not os.path.isfile(fontspector_report):
@@ -216,30 +247,30 @@ class FontQA:
                 "Cannot Post Github message because no Fontspector report exists"
             )
             return
-        with open(fontspector_report) as doc:
+        with open(fontspector_report, encoding="utf8") as doc:
             msg = doc.read()
             self.post_to_github(msg)
 
         if process.returncode != 0:
             self.has_error = True
 
-    def googlefonts_upgrade(self, imgs=False):
+    def googlefonts_upgrade(self):
         self.fontspector()
         self.diffenator3()
-        self.diffbrowsers(imgs)
+        self.diffbrowsers()
         self.interpolations()
 
-    def googlefonts_new(self, imgs=False):
+    def googlefonts_new(self):
         self.fontspector()
         self.diffenator3()
-        self.proof(imgs)
+        self.proof()
         self.interpolations()
 
-    def render(self, imgs=False):
+    def render(self):
         if self.fonts_before:
-            self.diffbrowsers(imgs)
+            self.diffbrowsers()
         else:
-            self.proof(imgs)
+            self.proof()
 
     def post_to_github(self, text):
         """Post text as a new issue or as a comment to an open
@@ -260,7 +291,7 @@ class FontQA:
             else:
                 client.create_issue("Google Font QA report", text)
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 "Cannot post QA report!\n"
                 "Most likely, the repository may lack a GH_TOKEN secret, or "
                 "the pull request has come from a forked repo which "

--- a/Lib/gftools/scripts/qa.py
+++ b/Lib/gftools/scripts/qa.py
@@ -17,7 +17,7 @@ Compare a github folder of fonts against the same family hosted on Google
 Fonts:
 `gftools qa -gh www.github.com/user/repo/tree/fonts/ttf -gfb -a -o qa`
 """
-from fontTools.ttLib import TTFont
+
 import argparse
 import os
 import sys
@@ -33,19 +33,27 @@ from gftools.utils import (
 )
 import re
 from gftools.qa import FontQA
-from diffenator2.font import DFont
-
 
 __version__ = "3.1.0"
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def family_name_from_fonts(fonts):
-    results = set(f.family_name for f in fonts)
-    if len(results) > 1:
-        raise Exception("Multiple family names found: [{}]".format(", ".join(results)))
-    return list(results)[0]
+def family_name_from_fonts(fonts: list[str]) -> str:
+    family_names = set()
+    for f in fonts:
+        try:
+            from fontTools.ttLib import TTFont
+
+            with TTFont(f) as font:
+                family_names.add(font["name"].getName(1, 3, 1).toUnicode())
+        except Exception as e:
+            logger.warning(f"Failed to read family name from {f}: {e}")
+    if len(family_names) > 1:
+        raise ValueError(
+            "Multiple family names found: [{}]".format(", ".join(family_names))
+        )
+    return list(family_names)[0]
 
 
 def main(args=None):
@@ -154,7 +162,7 @@ def main(args=None):
     parser.add_argument("--version", action="version", version=__version__)
     args = parser.parse_args(args)
     if args.out_github and not any([args.pull_request, args.github_dir]):
-        raise Exception(
+        raise ValueError(
             "Cannot upload results to a github issue or pr. "
             "Font input must either a github dir or a pull request"
         )
@@ -169,7 +177,7 @@ def main(args=None):
             args.interpolations,
         ]
     ):
-        raise Exception(
+        raise ValueError(
             "Terminating. No checks selected. Run gftools qa "
             "--help to see all possible commands."
         )
@@ -179,7 +187,8 @@ def main(args=None):
     fonts_dir = os.path.join(args.out, "fonts")
     mkdir(fonts_dir)
     if args.fonts:
-        [shutil.copy(f, fonts_dir) for f in args.fonts]
+        for f in args.fonts:
+            shutil.copy(f, fonts_dir)
         fonts = args.fonts
     elif args.pull_request:
         fonts = download_files_in_github_pr(
@@ -199,19 +208,20 @@ def main(args=None):
         fonts = download_files_from_archive(args.archive, fonts_dir)
     elif args.googlefonts:
         fonts = download_family_from_Google_Fonts(args.googlefonts, fonts_dir)
+    else:
+        raise ValueError("No fonts found. Please provide a font input method")
 
     if args.filter_fonts:
         re_filter = re.compile(args.filter_fonts)
         fonts = [f for f in fonts if re_filter.search(f)]
 
-    dfonts = [
-        DFont(f) for f in fonts if f.endswith((".ttf", ".otf")) and "static" not in f
-    ]
+    dfonts = [f for f in fonts if f.endswith((".ttf", ".otf")) and "static" not in f]
     family_name = family_name_from_fonts(dfonts)
     family_on_gf = Google_Fonts_has_family(family_name)
 
     # Retrieve fonts_before and store in out dir
-    fonts_before = None
+    fonts_before: list[str] = []
+    fonts_before_dir = os.path.join(args.out, "fonts_before")
     if any(
         [
             args.fonts_before,
@@ -220,10 +230,10 @@ def main(args=None):
             args.archive_before,
         ]
     ) or (args.googlefonts_before and family_on_gf):
-        fonts_before_dir = os.path.join(args.out, "fonts_before")
         mkdir(fonts_before_dir, overwrite=False)
     if args.fonts_before:
-        [shutil.copy(f, fonts_before_dir) for f in args.fonts_before]
+        for f in args.fonts_before:
+            shutil.copy(f, fonts_before_dir)
         fonts_before = args.fonts_before
     elif args.pull_request_before:
         fonts_before = download_files_in_github_pr(
@@ -239,6 +249,8 @@ def main(args=None):
         )
     elif args.googlefonts_before and family_on_gf:
         fonts_before = download_family_from_Google_Fonts(family_name, fonts_before_dir)
+    else:
+        fonts_before = []
 
     url = None
     if args.out_url:
@@ -250,7 +262,7 @@ def main(args=None):
 
     if fonts_before:
         dfonts_before = [
-            DFont(f)
+            f
             for f in fonts_before
             if f.endswith((".ttf", ".otf")) and "static" not in f
         ]
@@ -259,27 +271,21 @@ def main(args=None):
         qa = FontQA(dfonts, out=args.out, url=url)
 
     if args.auto_qa and family_on_gf:
-        qa.googlefonts_upgrade(args.imgs, args.rust)
+        qa.googlefonts_upgrade(args.imgs)
     elif args.auto_qa and not family_on_gf:
-        qa.googlefonts_new(args.imgs, args.rust)
+        qa.googlefonts_new(args.imgs)
     if args.render:
-        qa.render(args.imgs, args.rust)
+        qa.render(args.imgs)
     if args.fontbakery:
-        if args.rust:
-            qa.fontspector(extra_args=args.extra_fontspector_args)
-        else:
-            qa.fontbakery(extra_args=args.extra_fontbakery_args)
+        qa.fontbakery(extra_args=args.extra_fontbakery_args)
     if args.diffenator:
-        if args.rust:
-            qa.diffenator3()
-        else:
-            qa.diffenator()
+        qa.diffenator3()
     if args.diffbrowsers:
-        qa.diffbrowsers(args.imgs, rust=args.rust)
+        qa.diffbrowsers(args.imgs)
     if args.proof:
-        qa.proof(rust=args.rust)
+        qa.proof()
     if args.interpolations:
-        qa.interpolations(rust=args.rust)
+        qa.interpolations()
 
     if qa.has_error:
         logger.fatal("QA tools have raised a fatal error. Please fix!")

--- a/Lib/gftools/scripts/qa.py
+++ b/Lib/gftools/scripts/qa.py
@@ -271,9 +271,9 @@ def main(args=None):
         qa = FontQA(dfonts, out=args.out, url=url)
 
     if args.auto_qa and family_on_gf:
-        qa.googlefonts_upgrade(args.imgs)
+        qa.googlefonts_upgrade()
     elif args.auto_qa and not family_on_gf:
-        qa.googlefonts_new(args.imgs)
+        qa.googlefonts_new()
     if args.render:
         qa.render(args.imgs)
     if args.fontbakery:

--- a/Lib/gftools/utils.py
+++ b/Lib/gftools/utils.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from __future__ import annotations
-from typing import Union
+from typing import Optional, Union
 import requests
 from urllib.parse import urljoin
 from io import BytesIO
@@ -31,7 +31,6 @@ from github import Github
 import importlib.resources
 from gfmetadata import text_format
 import json
-from PIL import Image
 import re
 import shlex
 import subprocess
@@ -55,8 +54,8 @@ PROD_FAMILY_DOWNLOAD = "https://fonts.google.com/download?family={}"
 
 
 def download_family_from_Google_Fonts(
-    family, dst=None, dl_url=PROD_FAMILY_DOWNLOAD, ignore_static=True, auth=None
-):
+    family: str, dst=None, dl_url=PROD_FAMILY_DOWNLOAD, ignore_static=True, auth=None
+) -> list[str]:
     """Download a font family from Google Fonts"""
     # TODO (M Foley) update all dl_urls in .ini files.
     dl_url = dl_url.replace("download?family=", "download/list?family=")
@@ -79,7 +78,7 @@ def download_family_from_Google_Fonts(
     return res
 
 
-def Google_Fonts_has_family(name):
+def Google_Fonts_has_family(name: str) -> bool:
     """Check if Google Fonts has the specified font family"""
     # This endpoint is private and may change at some point
     # TODO (MF) if another function needs this data, refactor it into a
@@ -119,12 +118,12 @@ def parse_github_dir_url(url):
 
 
 def download_files_in_github_pr(
-    url,
-    dst,
+    url: str,
+    dst: str,
     filter_files=[],
     ignore_static_dir=True,
     overwrite=True,
-):
+) -> list[str]:
     """Download files in a github pr e.g
     https://github.com/google/fonts/pull/2072
 
@@ -143,11 +142,11 @@ def download_files_in_github_pr(
     list of paths to downloaded files
     """
     gh = Github(os.environ["GH_TOKEN"])
-    url = parse_github_pr_url(url)
-    repo_slug = "{}/{}".format(url.user, url.repo)
+    parsed_url = parse_github_pr_url(url)
+    repo_slug = "{}/{}".format(parsed_url.user, parsed_url.repo)
     repo = gh.get_repo(repo_slug)
-    pull = repo.get_pull(url.pull)
-    files = [f for f in pull.get_files()]
+    pull = repo.get_pull(parsed_url.pull)
+    files = list(pull.get_files())
 
     mkdir(dst, overwrite=overwrite)
     # if the pr is from google/fonts or a fork of it, download all the
@@ -226,13 +225,15 @@ def download_files_in_github_dir(orig_url, dst, filter_files=[], overwrite=True)
     return results
 
 
-def download_files_from_archive(url, dst):
+def download_files_from_archive(url: str, dst: str) -> list[str]:
     zip_io = download_file(url)
     with ZipFile(zip_io) as zip_file:
         return fonts_from_zip(zip_file, dst)
 
 
-def download_file(url, dst_path=None, auth=None):
+def download_file(
+    url: str, dst_path: Optional[str] = None, auth=None
+) -> BytesIO | None:
     """Download a file from a url. If no dst_path is specified, store the file
     as a BytesIO object"""
     if os.environ.get("GH_TOKEN") and re.match(r"^https://(\w+\.)?github.com", url):


### PR DESCRIPTION
`gftools-qa` was left in a slightly half-baked state after we committed to Rust tools. The old `--rust` arg was still around in some places, the old `diffenator2.DFont` object was still around in others. This removes both and does some light clean-up to get `gftools-qa` working again.