### PR TITLE
`gftools-gen-stat`: allow a builder config file as STAT source

### DIFF
--- a/Lib/gftools/builder/schema.py
+++ b/Lib/gftools/builder/schema.py
@@ -7,6 +7,7 @@ from strictyaml import (
     MapPattern,
     Str,
     Int,
+    HexInt,
     Float,
     Seq,
     Optional,
@@ -45,7 +46,7 @@ stat_schema = Seq(
                         Optional("linkedValue"): Int() | Float(),
                         Optional("rangeMinValue"): Int() | Float(),
                         Optional("rangeMaxValue"): Int() | Float(),
-                        Optional("flags"): Int(),
+                        Optional("flags"): Int() | HexInt(),
                     }
                 )
             ),

--- a/Lib/gftools/scripts/gen_stat.py
+++ b/Lib/gftools/scripts/gen_stat.py
@@ -63,7 +63,6 @@ def main(args=None):
     )
     args = parser.parse_args(args)
 
-    print(args.fonts)
     fonts = [TTFont(f) for f in args.fonts]
 
     if args.src:

--- a/Lib/gftools/scripts/gen_stat.py
+++ b/Lib/gftools/scripts/gen_stat.py
@@ -68,6 +68,9 @@ def main(args=None):
 
     if args.src:
         config = yaml.load(open(args.src), Loader=yaml.SafeLoader)
+        # If there's a top-level item called stat in the config (which there may
+        # be if we're injesting a full builder config.yaml), use that
+        config = config.get("stat", config)
         gen_stat_tables_from_config(config, fonts)
     else:
         gen_stat_tables(fonts)


### PR DESCRIPTION
As I discovered the other day, if you aren't using the default Google Fonts recipe provider, your in-line STAT definition within your `config.yaml` isn't respected by the `buildStat` operation; it'll always auto-generate.

How the in-line STAT works with the Google Fonts recipe provider is a bit hacky and not simple to replicate without a full-blown custom recipe provider. So this PR takes a path with less resistance: by having `gftools-gen-stat` check for a "stat" key in the source YAML, and if found it uses its value instead of the full document. So now the following works:

```yml
# This is my sources/config.yaml
recipe:
  ../fonts/variable/MyFont[wght].ttf:
    - source: MyFont.glyphspackage
    - operation: buildVariable
    - operation: fix
    # Must be done as a post-processing step if stat is defined per-font,
    # because otherwise the file names won't match
    - postprocess: buildStat
      args: --src config.yaml  # 👈 specifying itself as the STAT source

stat:
  - name: Weight
    tag: wght
    values:
      - flags: 0
        name: Hairline
        value: 1.0
      # you know how this story goes...
```

Could I have just put the STAT definition in a separate file? Yes, and by all means reject this PR on that basis. But to me needing a separate `stat.yaml` doesn't feel very intuitive when you're transitioning from the default recipe builder.

I could look into having `buildStat` support a `$src` key if that's preferred over raw `args`. It's just more work then to integrate this with the existing Google Fonts recipe provider (which requires zero modifications with this PR as-is).

---

I also snuck in two unrelated changes: allowing STAT flags to be hex ints (I can remove this change if you want), and I also removed a debug print lying around in `gftools-gen-stat`.