### PR TITLE
[gen-push-lists] Add Tags and Axis registry/Lang sections

### DIFF
--- a/Lib/gftools/scripts/gen_push_lists.py
+++ b/Lib/gftools/scripts/gen_push_lists.py
@@ -24,7 +24,6 @@ from gftools.push.utils import branch_matches_google_fonts_main
 from pathlib import Path
 from gftools.utils import is_google_fonts_repo
 from contextlib import contextmanager
-import pygit2
 
 
 @contextmanager
@@ -35,6 +34,29 @@ def in_google_fonts_repo(gf_path):
         yield True
     finally:
         os.chdir(cwd)
+
+
+STATIC_FOOTER = (
+    "\n# Tags\n"
+    "tags/all/families.csv\n"
+    "\n"
+    "# Axis registry / Lang\n"
+    "# To complete if there is a new release\n"
+    "# axisregistry/contrast.textproto # No PR / Process automated\n"
+)
+
+
+def _append_static_footer(fp):
+    with open(fp, "r", encoding="utf-8") as doc:
+        content = doc.read()
+    # Drop a previously-appended footer first, so re-running the script
+    # doesn't keep piling up duplicate sections.
+    marker = "\n# Tags\n"
+    if marker in content:
+        content = content.split(marker)[0]
+    content = content.rstrip("\n") + "\n" + STATIC_FOOTER
+    with open(fp, "w", encoding="utf-8") as doc:
+        doc.write(content)
 
 
 def main(args=None):
@@ -70,13 +92,8 @@ def main(args=None):
         to_sandbox.to_server_file(to_sandbox_fp)
         to_production.to_server_file(to_production_fp)
 
-    repo = pygit2.Repository(str(gf_path))
-    if any("tags/all/families.csv" in d.delta.new_file.path for d in repo.diff()):
-        with open(to_sandbox_fp, "r", encoding="utf-8") as doc:
-            string = doc.read()
-        string += "\n# Tags\ntags/all/families.csv\n"
-        with open(to_sandbox_fp, "w", encoding="utf-8") as doc:
-            doc.write(string)
+        _append_static_footer(to_sandbox_fp)
+        _append_static_footer(to_production_fp)
 
 
 if __name__ == "__main__":

--- a/Lib/gftools/scripts/gen_push_lists.py
+++ b/Lib/gftools/scripts/gen_push_lists.py
@@ -37,14 +37,6 @@ def in_google_fonts_repo(gf_path):
     finally:
         os.chdir(cwd)
 
-
-# "tags/all/families.csv" and the axisregistry/lang directories are not
-# PushCategory members (see gftools.push.trafficjam.PushItems.to_server_file),
-# and axisregistry/lang releases usually land without a Traffic Jam PR at
-# all, so they never show up in PushItems.from_traffic_jam() either. Instead
-# of a static reminder on every run, we look at what actually changed in git
-# between the last time these two files were generated (and committed) and
-# now, and only surface a section when there's something to report.
 TAGS_PATH = "tags/all/families.csv"
 AXIS_LANG_DIRS = ("lang", "axisregistry")
 SERVER_FILENAMES = ("to_sandbox.txt", "to_production.txt")

--- a/Lib/gftools/scripts/gen_push_lists.py
+++ b/Lib/gftools/scripts/gen_push_lists.py
@@ -15,6 +15,7 @@ gftools gen-push-lists /path/to/google/fonts
 """
 import sys
 import os
+import subprocess
 from gftools.push.trafficjam import (
     PushItems,
     PushStatus,
@@ -24,6 +25,7 @@ from gftools.push.utils import branch_matches_google_fonts_main
 from pathlib import Path
 from gftools.utils import is_google_fonts_repo
 from contextlib import contextmanager
+import pygit2
 
 
 @contextmanager
@@ -36,25 +38,88 @@ def in_google_fonts_repo(gf_path):
         os.chdir(cwd)
 
 
-STATIC_FOOTER = (
-    "\n# Tags\n"
-    "tags/all/families.csv\n"
-    "\n"
-    "# Axis registry / Lang\n"
-    "# To complete if there is a new release\n"
-    "# axisregistry/contrast.textproto # No PR / Process automated\n"
-)
+# "tags/all/families.csv" and the axisregistry/lang directories are not
+# PushCategory members (see gftools.push.trafficjam.PushItems.to_server_file),
+# and axisregistry/lang releases usually land without a Traffic Jam PR at
+# all, so they never show up in PushItems.from_traffic_jam() either. Instead
+# of a static reminder on every run, we look at what actually changed in git
+# between the last time these two files were generated (and committed) and
+# now, and only surface a section when there's something to report.
+TAGS_PATH = "tags/all/families.csv"
+AXIS_LANG_DIRS = ("lang", "axisregistry")
+SERVER_FILENAMES = ("to_sandbox.txt", "to_production.txt")
 
 
-def _append_static_footer(fp):
+def _last_generated_commit(gf_path):
+    """Hash of the last commit that touched to_sandbox.txt or
+    to_production.txt, i.e. the last time this script's output was
+    committed. None if neither file has ever been committed (fresh repo)."""
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%H", "--", *SERVER_FILENAMES],
+        cwd=str(gf_path),
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() or None
+
+
+def _changed_paths_since(repo, since_commit_hash, prefixes):
+    """Paths that changed between since_commit_hash and HEAD, restricted to
+    the given top-level prefixes (e.g. "lang", "axisregistry")."""
+    try:
+        old_commit = repo.revparse_single(since_commit_hash)
+    except KeyError:
+        # since_commit_hash isn't reachable anymore (rebase/squash, etc.)
+        return set()
+    new_commit = repo.head.peel()
+    diff = repo.diff(old_commit, new_commit)
+    changed = set()
+    for delta in diff.deltas:
+        path = delta.new_file.path or delta.old_file.path
+        if any(path == p or path.startswith(f"{p}/") for p in prefixes):
+            changed.add(path)
+    return changed
+
+
+def _build_dynamic_footer(gf_path):
+    since = _last_generated_commit(gf_path)
+    if since is None:
+        # Nothing to compare against yet (e.g. first ever run) -- we can't
+        # tell what's "new", so don't guess.
+        return ""
+
+    repo = pygit2.Repository(str(gf_path))
+    tags_changed = _changed_paths_since(repo, since, [TAGS_PATH])
+    axis_lang_changed = _changed_paths_since(repo, since, list(AXIS_LANG_DIRS))
+
+    lines = []
+    if tags_changed:
+        lines += ["", "# Tags", TAGS_PATH]
+
+    if axis_lang_changed:
+        lines += ["", "# Axis registry / Lang", "# To complete if there is a new release"]
+        for path in sorted(axis_lang_changed):
+            lines.append(f"# {path} # No PR / Process automated")
+
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
+
+
+def _apply_dynamic_footer(fp, footer):
     with open(fp, "r", encoding="utf-8") as doc:
         content = doc.read()
-    # Drop a previously-appended footer first, so re-running the script
-    # doesn't keep piling up duplicate sections.
-    marker = "\n# Tags\n"
-    if marker in content:
-        content = content.split(marker)[0]
-    content = content.rstrip("\n") + "\n" + STATIC_FOOTER
+    # Strip a previously-appended footer first, so re-running the script
+    # doesn't keep piling up duplicate/stale sections.
+    cut_points = [
+        i
+        for i in (content.find("\n# Tags\n"), content.find("\n# Axis registry / Lang\n"))
+        if i != -1
+    ]
+    if cut_points:
+        content = content[: min(cut_points)]
+    if footer:
+        content = content.rstrip("\n") + "\n" + footer
     with open(fp, "w", encoding="utf-8") as doc:
         doc.write(content)
 
@@ -92,8 +157,9 @@ def main(args=None):
         to_sandbox.to_server_file(to_sandbox_fp)
         to_production.to_server_file(to_production_fp)
 
-        _append_static_footer(to_sandbox_fp)
-        _append_static_footer(to_production_fp)
+        footer = _build_dynamic_footer(gf_path)
+        _apply_dynamic_footer(to_sandbox_fp, footer)
+        _apply_dynamic_footer(to_production_fp, footer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`PushItems.to_server_file()` only writes out categories that exist in the `PushCategory` enum. `tags/all/families.csv` isn't a `PushCategory` member, so it silently fell out of the generated file. The previous workaround (git-diff a check via `pygit2`) only patched this for `to_sandbox.txt`, and only when a diff happened to touch that specific path — `to_production.txt` never got the section at all, and the check was fragile (depended on repo diff state at the time the script ran).

There was also no equivalent reminder for axis registry / lang releases, which are handled manually and easy to forget.

## Change

- Removed the `pygit2`-based conditional check.
- Added `_append_static_footer()`, called unconditionally on **both**
  `to_sandbox.txt` and `to_production.txt` after they're generated. It
  appends: